### PR TITLE
set epoch version in packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,6 +54,8 @@ nfpms:
         dst: /usr/share/doc/beegfs-tools/NOTICE.md
       - src: LICENSE.md
         dst: /usr/share/doc/beegfs-tools/LICENSE.md
+    # In beegfs-core epoch 20 is set for release packages and epoch 19 for development packages
+    epoch: 20
 
 changelog:
   sort: asc


### PR DESCRIPTION
Add epoch in .goreleaser.yml
beegfs-core use epoch 20 for the release packages and 19 for the development packages.