### PR TITLE
(Quick) Fix goreleaser configuration after beegfs-ctl reorganization

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,23 +5,23 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X github.com/thinkparq/beegfs-go/beegfs-ctl/cmd/beegfs-ctl/cmd.Version={{ .Version }}
-      - -X github.com/thinkparq/beegfs-go/beegfs-ctl/cmd/beegfs-ctl/cmd.BinaryName=beegfs
-      - -X github.com/thinkparq/beegfs-go/beegfs-ctl/cmd/beegfs-ctl/cmd.Commit={{ .Commit }}
-      - -X github.com/thinkparq/beegfs-go/beegfs-ctl/cmd/beegfs-ctl/cmd.BuildTime={{ .Date }}
+      - -X github.com/thinkparq/beegfs-go/ctl/internal/cmd.Version={{ .Version }}
+      - -X github.com/thinkparq/beegfs-go/ctl/internal/cmd.BinaryName=beegfs
+      - -X github.com/thinkparq/beegfs-go/ctl/internal/cmd.Commit={{ .Commit }}
+      - -X github.com/thinkparq/beegfs-go/ctl/internal/cmd.BuildTime={{ .Date }}
     binary: beegfs
     goos:
       - linux
     goarch:
       - amd64
       - arm64
-    main: beegfs-ctl/cmd/beegfs-ctl/main.go
+    main: ctl/cmd/beegfs/main.go
     hooks:
       post:
         # Note post hooks run for each binary so we actually generate the script twice and just
         # overwrite it in place. It should always be the same for arm64 and amd64 so this is fine.
         # However when adding future post hooks ensure this is what you want.
-        - sh -c "go run beegfs-ctl/cmd/beegfs-ctl/main.go completion bash > ./dist/beegfs_bashcomp"
+        - sh -c "go run ctl/cmd/beegfs/main.go completion bash > ./dist/beegfs_bashcomp"
 
 nfpms:
   - id: beegfs_tools
@@ -49,7 +49,7 @@ nfpms:
         dst: /usr/sbin/beegfs
         type: "symlink"
       - src: ./dist/beegfs_bashcomp
-        dst: /etc/bash_completion.d/beegfs-ctl
+        dst: /etc/bash_completion.d/beegfs
       - src: NOTICE.md
         dst: /usr/share/doc/beegfs-tools/NOTICE.md
       - src: LICENSE.md

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ package-all:
 		exit 1; \
 	}
 	@goreleaser --clean --snapshot --skip sign
-	@echo "INFO: OS packages and other artifacts are available under dist/ and can be installed with `dpkg -i <PATH>`"
+	@echo "INFO: OS packages and other artifacts are available under dist/ and can be installed with: dpkg -i <PATH>"
 
 # Generate NOTICE file.
 .PHONY: generate-notices


### PR DESCRIPTION
I just realized I forgot to take the goreleaser configuration into consideration for https://github.com/ThinkParQ/beegfs-go/pull/37.