### PR TITLE
Enabling signing of RPM packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.PUBLICREPO_GPGPACKAGEKEY }}
           passphrase: ${{ secrets.PUBLICREPO_GPGPACKAGEPASSPHRASE }}
+      - name: Write private key to a file for package signing with GoReleaser
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.PUBLICREPO_GPGPACKAGEKEY }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" > /tmp/private-key.asc
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -54,6 +59,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_KEY_PATH: /tmp/private-key.asc
+          NFPM_PASSPHRASE: ${{ secrets.PUBLICREPO_GPGPACKAGEPASSPHRASE }}
           GOPRIVATE: github.com/thinkparq/*
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,6 +54,9 @@ nfpms:
         dst: /usr/share/doc/beegfs-tools/NOTICE.md
       - src: LICENSE.md
         dst: /usr/share/doc/beegfs-tools/LICENSE.md
+    rpm:
+      signature:
+        key_file: "{{ .Env.GPG_KEY_PATH }}"
 
 changelog:
   sort: asc

--- a/Makefile
+++ b/Makefile
@@ -16,15 +16,17 @@ uninstall:
 	rm -f $(INSTALL_DIR)/$(BINARY_NAME)
 	@echo "Uninstallation complete!"
 
-# Trigger a "local-only" release using goreleaser to generate OS packages that can be used locally
-# (Ref: https://goreleaser.com/quick-start/ and https://goreleaser.com/customization/snapshots/):
+# Trigger a "local-only" release using GoReleaser to generate OS packages that can be used locally
+# (Ref: https://goreleaser.com/quick-start/ and https://goreleaser.com/customization/snapshots/).
+# Note signing is skipped for building local packages, but GPG_KEY_PATH must still be set or
+# GoReleaser will complain about the missing environment variable.
 .PHONY: package-all
 package-all:
 	@command -v goreleaser >/dev/null 2>&1 || { \
 		echo >&2 "ERROR: goreleaser is not installed, it can be installed with 'go install github.com/goreleaser/goreleaser/v2@latest' (see https://goreleaser.com/install/#install for additional options)."; \
 		exit 1; \
 	}
-	@goreleaser --clean --snapshot --skip sign
+	@GPG_KEY_PATH="" goreleaser --clean --snapshot --skip sign
 	@echo "INFO: OS packages and other artifacts are available under dist/ and can be installed with: dpkg -i <PATH>"
 
 # Generate NOTICE file.


### PR DESCRIPTION
Sign individual RPM packages as is done for the other core packages (and is common practice in the RPM ecosystem).

Note Debian packages are not individually signed and instead rely on the repository to be signed.

```
$ rpm -qpi beegfs-tools-8.0.0-alpha.3-linux.amd64.rpm
warning: beegfs-tools-8.0.0-alpha.3-linux.amd64.rpm: Header V4 RSA/SHA256 Signature, key ID 5acaf8ef: NOKEY
Name        : beegfs-tools
Version     : 8.0.0~alpha.3
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : (none)
Size        : 14535512
License     : BeeGFS EULA
Signature   : RSA/SHA256, Thu 10 Oct 2024 05:51:52 PM UTC, Key ID 29f83e2d5acaf8ef
Source RPM  : beegfs-tools-8.0.0~alpha.3-1.src.rpm
Build Date  : Thu 10 Oct 2024 05:51:51 PM UTC
Build Host  : fv-az1077-601
Packager    : BeeGFS Maintainers <packages@beegfs.com>
Vendor      : ThinkparQ GmbH
URL         : https://www.beegfs.io
Summary     : A collection of tools for managing BeeGFS.
Description :
A collection of tools for managing BeeGFS.
```
