### PR TITLE
Only trigger release workflow for BeeGFS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,10 @@ name: goreleaser
 
 on:
   push:
-    # run only against tags
+    # Releases including packages and other artifacts should only be built for BeeGFS releases.
+    # Tagging a release of the Go module should not trigger the release workflow.
     tags:
-      - "*"
+      - "v8.*"
 
 permissions:
   # Required to publish releases.


### PR DESCRIPTION
Releases including packages and other artifacts should only be built for BeeGFS releases. Tagging a release of the Go module should not trigger the release workflow. When we release a new major version this will need to be updated.