### PR TITLE
Clarify split versioning scheme for Go module and binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,18 @@ jobs:
         # Make sure the runner has access to the internal repos repo using an access token
         # This must be after the step to setup Go which also installs git.
         run: git config --global url."https://${{ secrets.CI_PROTOBUF_ACCESS }}@github.com/thinkparq".insteadOf https://github.com/thinkparq
+        # The way GoReleaser gets the previous changelog tag does not work consistently if we are
+        # pushing different tags to version the Go module API versus the built BeeGFS binaries. This
+        # approach ensures the tag that triggered the workflow is used as the current version, and
+        # sets the previous tag based on the most recent semantic version before the current tag.
+        # Ref: https://goreleaser.com/cookbooks/set-a-custom-git-tag/
+      - name: Get current and previous tags
+        id: tags
+        run: |
+          git fetch --tags
+          echo "GORELEASER_CURRENT_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+          previous_tag=$(git tag -l --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$' | grep -v "${{ github.ref_name }}" | head -n 1)
+          echo "GORELEASER_PREVIOUS_TAG=${previous_tag}" >> $GITHUB_ENV
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/README.md
+++ b/README.md
@@ -27,12 +27,91 @@ familiar with Go, check out the ThinkParQ [Getting Started with
 Go](https://github.com/ThinkParQ/developer-handbook/tree/main/getting_started/go) section of the
 developer handbook.
 
-## Using Shared Packages
+
+## Versioning
+
+BeeGFS OS packages/binaries built from this repository and the `beegfs-go` module that provides
+reusable Go packages currently follow slightly different versioning schemes:
+
+* OS packages/binaries built from this repository follow the same versioning scheme as the other BeeGFS
+  components and start at version `v8.x.y`. 
+  * For example if you want to build the version of the `beegfs` tool compatible with BeeGFS 8.0.0
+    you would check out the `v8.0.0` tag.
+* The Go module and reusable packages it provides will remain at `v0` indicating the Go module's API
+  is not necessarily guaranteed to be stable and each `v8.x.y` BeeGFS release, the module's API will
+  be versioned as `v0.x.y`.
+  * For example, to import Go packages from the `beegfs-go` module that work with BeeGFS
+    `v8.0.0-beta.0` you would run `go get github.com/thinkparq/beegfs-go@v0.0.0-beta.0`.
+  * If you make changes to `beegfs-go` that need to be imported elsewhere before a new "official"
+    version is tagged, you would use a [pseudo-version](https://go.dev/ref/mod#pseudo-versions) by
+    running `go get github.com/thinkparq/beegfs-go@<LONG-COMMIT-HASH>` to import a specific commit.
+
+### FAQs:
+
+#### Why not just use the same version for the Go module and binaries it provides?
+
+There are a few reasons for this:
+
+First, Go has specific rules around [module version
+numbering](https://go.dev/doc/modules/version-numbers). Once we move past `v0` or `v1`, the module
+path must be updated to include the version (i.e., `github.com/thinkparq/beegfs-go/v8`). However, it
+would be ideal to provide a single Go module that maintains compatibility across different BeeGFS
+versions. This approach simplifies development for maintainers of `beegfs-go` (as there is no need
+to backport fixes to multiple branches) and makes it easier for external users. Since we cannot yet
+determine if future major BeeGFS versions will require breaking changes to the Go module, there is
+no immediate need to synchronize the versions.
+
+Second, moving past `v0` signals that the module's external API is stable and guaranteed not to
+change. While we believe the external API is largely stable, we think it is still prudent to wait
+before making this guarantee to users.
+
+In short, moving past v0 is a one way trip. Until there is a compelling reason to do so, sticking at
+`v0` leaves more options available for how to handle module versioning in the future.
+
+#### Is there precedence for this?
+
+Yes, Kubernetes releases are versioned as `v1.31.0`, but the [`kubernetes/client-go`
+module](https://github.com/kubernetes/client-go?tab=readme-ov-file#versioning) is versioned as
+`v0.31.0`, signaling no API stability is guaranteed (and they do break their API from time to time).
+
+#### Aren't we worried eventually the version namespaces will collide? 
+
+If/when we bump from `v0` we would likely either bump to `v1` if we think we can provide one module
+that works across multiple major BeeGFS versions, or bump directly to sync with the BeeGFS major
+version if backward compatibility cannot be ensured.
+
+#### Why not just use different tags for the module and binaries?
+
+We use GoReleaser to build binaries and OS packages. It expects to work with a tag that follows
+semantic versioning rules, and currently does not appear to provide a way to extract a semver from a
+non-semver tag. However we only run GoReleaser on tags prefixed with `v8.` and the actions workflow
+is configured to only run on the pushed tag and determine the previous tag based on the most recent
+semantic version before the current tag.
+
+## Working with Executables
+
+Besides providing shared Go packages, this project hosts a number of components that are meant to be
+built into binaries. These components generally adhere to the unofficial [Standard Go Project
+Layout](https://github.com/golang-standards/project-layout). Once you have [installed
+Go](https://go.dev/doc/install) there are a few options to run these components:
+
+* Directly build and run (best for debugging): `go run ctl/cmd/beegfs/main.go`
+
+* Install to your `$GOBIN` (best if you just want to run the applications): `go install ./ctl/cmd/beegfs/`
+  * For convenience, you can also use `make install` / `make uninstall` which manages installs at `$HOME/go/bin`. 
+
+* Build and install using OS packages: `make package-all` 
+  * Install the resulting packages using `dpkg -i <package>` or similar.
+
+Refer to the documentation included with each component for more details.
+
+## Importing functionality into other Go projects
 
 If you just want to use some common functionality in your project, first run `go get
-github.com/thinkparq/beegfs-go` then import/use the shared package(s) as needed throughout your
-project. The beegfs-go project is meant to be used as a Go module meaning you can (and should) pin
-your `go.mod` file to a particular stable version of beegfs-go.
+github.com/thinkparq/beegfs-go@latest` then import/use the shared package(s) as needed throughout
+your project. The `beegfs-go` project is meant to be used as a Go module meaning you can (and
+should) pin your `go.mod` file to a particular stable version of beegfs-go. See the versioning
+section above to ensure you use the correct version.
 
 Individual modules can then be imported, for example to use the logging package:
 
@@ -54,23 +133,6 @@ documented using Go doc comments, which can be read directly from the source fil
 command line `go doc` (e.g., `go doc logging`). An interactive doc site can also be started using
 the godoc tool (`go get golang.org/x/tools/cmd/godoc`) with `godoc -http=:8080`. Some packages may
 also provide additional documentation in markdown format.
-
-## Working with Executables
-
-Besides common packages, this project hosts a number of components that are meant to be built into
-binaries. These components generally adhere to the unofficial [Standard Go Project
-Layout](https://github.com/golang-standards/project-layout). Once you have [installed
-Go](https://go.dev/doc/install) there are a few options to run these components:
-
-* Directly build and run (best for debugging): `go run ctl/cmd/beegfs/main.go`
-
-* Install to your `$GOBIN` (best if you just want to run the applications): `go install ./ctl/cmd/beegfs/`
-  * For convenience, you can also use `make install` / `make uninstall` which manages installs at `$HOME/go/bin`. 
-
-* Build and install using OS packages: `make package-all` 
-  * Install the resulting packages using `dpkg -i <package>` or similar.
-
-Refer to the documentation included with each component for more details.
 
 # Contributing to beegfs-go
 


### PR DESCRIPTION
Tagging @ThinkParQ/devops for review as this largely affects the CI workflow. The overall final decision around versioning I'll bring up Monday for discussion with the team.

Also updated the developer handbook to reflect these changes with https://github.com/ThinkParQ/developer-handbook/pull/29.