### PR TITLE
Minor improvements in the help page and update location for copy packages.

### DIFF
--- a/ctl/internal/cmd/copy/copy.go
+++ b/ctl/internal/cmd/copy/copy.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	beegfsCopyPath = "/opt/beegfs/sbin/beegfs-copy/bin/beegfs-copy"
+	beegfsCopyPath = "/opt/beegfs/sbin/beegfs-copy"
 	featureString  = "io.beegfs.copy"
 )
 


### PR DESCRIPTION
Minor improvements in the help page and update location for copy packages.

Two suggestions:
- as briefly mentioned yesterday, I think it is better to make the number of threads/workers per node a mandatory parameter,
- would it be possible to split the flags into two groups? Something like **Mandatory** (machine-file and threads-per-node) and **Optional** for the others, to improve readability and for simplicity in understanding how it works. I say this because the main negative feedback we got from the pre-release tester was related to the documentation and the help-page.
- 