### PR TITLE
Skip fetching tags a second time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Get current and previous tags
         id: tags
         run: |
-          git fetch --tags
           echo "GORELEASER_CURRENT_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
           previous_tag=$(git tag -l --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$' | grep -v "${{ github.ref_name }}" | head -n 1)
           echo "GORELEASER_PREVIOUS_TAG=${previous_tag}" >> $GITHUB_ENV


### PR DESCRIPTION
The checkout step with fetch-depth 0 already brings in all history. Trying to fetch tags again will fail with an error about clobbering an existing tag. This appears due to optimizations done by GH actions around fetching the history.