### PR TITLE
Add resync state column to target list

### DIFF
--- a/common/beemsg/msg/resync.go
+++ b/common/beemsg/msg/resync.go
@@ -136,7 +136,7 @@ const (
 func (n BuddyResyncJobState) String() string {
 	switch n {
 	case NotStarted:
-		return "Not_Started"
+		return "Not-started"
 	case Running:
 		return "Running"
 	case Success:

--- a/ctl/internal/cmd/health/check.go
+++ b/ctl/internal/cmd/health/check.go
@@ -194,7 +194,7 @@ func runHealthCheckCmd(ctx context.Context, filterByMounts []string, frontendCfg
 		if unhealthyTargets {
 			failedCheck = true
 		}
-		printDF(targets, tgtFrontend.PrintConfig{Capacity: true, State: true})
+		printDF(ctx, targets, tgtFrontend.PrintConfig{Capacity: true, State: true})
 	}
 
 	fmt.Print(hint("HINT: This mode does not check file system consistency. To check for file system inconsistencies,\n      you can run 'beegfs-fsck --checkfs --readOnly' and consult with ThinkParQ support.\n"))

--- a/ctl/internal/cmd/health/df.go
+++ b/ctl/internal/cmd/health/df.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"context"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -20,7 +21,7 @@ func newDFCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			printDF(targets, tgtFrontend.PrintConfig{Capacity: true})
+			printDF(cmd.Context(), targets, tgtFrontend.PrintConfig{Capacity: true})
 			return nil
 		},
 	}
@@ -29,7 +30,7 @@ func newDFCmd() *cobra.Command {
 
 // printDF() is a wrapper for PrintTargetList() that prints metadata and storage targets as separate
 // lists sorted by target ID.
-func printDF(targets []tgtBackend.GetTargets_Result, printConfig tgtFrontend.PrintConfig) {
+func printDF(ctx context.Context, targets []tgtBackend.GetTargets_Result, printConfig tgtFrontend.PrintConfig) {
 	metaTargets := []tgtBackend.GetTargets_Result{}
 	storageTargets := []tgtBackend.GetTargets_Result{}
 	for _, tgt := range targets {
@@ -47,8 +48,8 @@ func printDF(targets []tgtBackend.GetTargets_Result, printConfig tgtFrontend.Pri
 	})
 
 	printHeader("Metadata Targets", "-")
-	tgtFrontend.PrintTargetList(printConfig, metaTargets)
+	tgtFrontend.PrintTargetList(ctx, printConfig, metaTargets)
 
 	printHeader("Storage Targets", "-")
-	tgtFrontend.PrintTargetList(printConfig, storageTargets)
+	tgtFrontend.PrintTargetList(ctx, printConfig, storageTargets)
 }

--- a/ctl/pkg/ctl/buddygroup/list.go
+++ b/ctl/pkg/ctl/buddygroup/list.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/thinkparq/beegfs-go/common/beegfs"
 	"github.com/thinkparq/beegfs-go/ctl/pkg/config"
+	"github.com/thinkparq/beegfs-go/ctl/pkg/ctl/target"
 	pb "github.com/thinkparq/protobuf/go/beegfs"
 	pm "github.com/thinkparq/protobuf/go/management"
 )
@@ -50,21 +51,21 @@ func GetBuddyGroups(ctx context.Context) ([]GetBuddyGroups_Result, error) {
 		primary_cs := ""
 		switch t.PrimaryConsistencyState {
 		case pb.ConsistencyState_GOOD:
-			primary_cs = "Good"
+			primary_cs = target.ConsistencyGood
 		case pb.ConsistencyState_NEEDS_RESYNC:
-			primary_cs = "Needs resync"
+			primary_cs = target.ConsistencyNeedsResync
 		case pb.ConsistencyState_BAD:
-			primary_cs = "Bad"
+			primary_cs = target.ConsistencyBad
 		}
 
 		secondary_cs := ""
 		switch t.SecondaryConsistencyState {
 		case pb.ConsistencyState_GOOD:
-			secondary_cs = "Good"
+			secondary_cs = target.ConsistencyGood
 		case pb.ConsistencyState_NEEDS_RESYNC:
-			secondary_cs = "Needs resync"
+			secondary_cs = target.ConsistencyNeedsResync
 		case pb.ConsistencyState_BAD:
-			secondary_cs = "Bad"
+			secondary_cs = target.ConsistencyBad
 		}
 
 		res = append(res, GetBuddyGroups_Result{

--- a/ctl/pkg/ctl/target/list.go
+++ b/ctl/pkg/ctl/target/list.go
@@ -27,11 +27,11 @@ type GetTargets_Result struct {
 // Defined as constants for reuse elsewhere, notably the health checks.
 const (
 	ReachabilityOnline          = "Online"
-	ReachabilityProbablyOffline = "Probably offline"
+	ReachabilityProbablyOffline = "Probably-offline"
 	ReachabilityOffline         = "Offline"
 
 	ConsistencyGood        = "Good"
-	ConsistencyNeedsResync = "Needs resync"
+	ConsistencyNeedsResync = "Needs-resync"
 	ConsistencyBad         = "Bad"
 
 	CapacityNormal    = "Normal"


### PR DESCRIPTION
We talked about this in our 1x1. I originally went down the path of trying to do this on the backend, but ultimately decided it was better to selectively call it from the frontend (which is aligned with the first approach you suggested). I decided to add this as a dedicated column and also replace spaces with hyphens in various constants to everything more machine readable (using either table or JSON output).

In most cases we don't actually retrieve the sync state and it is simply listed as "Healthy". I thought this made sense both for non-buddy mirror systems that don't sync anything (which is why I didn't put "Synced") and buddy mirror systems. If a node is offline or we're otherwise unable to get the sync state it is just listed as "Unknown".