### PR TITLE
(Quick) Switch to using v0.0.0 protobuf version tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/thinkparq/protobuf v0.0.19
+	github.com/thinkparq/protobuf v0.0.0-beta.3
 	go.uber.org/zap v1.27.0
 	golang.org/x/sys v0.25.0
 	golang.org/x/term v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/thinkparq/protobuf v0.0.19 h1:ChCKjhXVKHTj0Igqt3DxyFoSxoNU3RpUgEKKT2ALPeg=
-github.com/thinkparq/protobuf v0.0.19/go.mod h1:ECPwmpoEIFcGYMXQTkXF+ZfvcygtsL4QKQfagRXftPk=
+github.com/thinkparq/protobuf v0.0.0-beta.3 h1:r7tKlIqjgTScVxQdG+N2tARyf8tJcmmk+6qapCWCAK4=
+github.com/thinkparq/protobuf v0.0.0-beta.3/go.mod h1:ECPwmpoEIFcGYMXQTkXF+ZfvcygtsL4QKQfagRXftPk=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=


### PR DESCRIPTION
This is required to switch protobuf to following the same [versioning scheme as beegfs-go](https://github.com/ThinkParQ/beegfs-go?tab=readme-ov-file#versioning).

Note if you get an error like `invalid version: git tag v0.0.0-beta.3 2af0dd5059822d33146cefdcb0e8096a3c56e936` it may be required to clear your cache with `go clean -modcache`.