### PR TITLE
(Quick) chore: upgrade to Go 1.23.5

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,7 +6,7 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.23.1
+      image: golang:1.23.5
       options: --user 1001
     steps:
       - name: Checkout

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thinkparq/beegfs-go
 
-go 1.23.1
+go 1.23.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.25.2


### PR DESCRIPTION
There are two vulnerabilities fixed in Go 1.23.5:

```
$ govulncheck ./...
=== Symbol Results ===

Vulnerability #1: GO-2025-3420
    Sensitive headers incorrectly sent after cross-domain redirect in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-3420
  Standard library
    Found in: net/http@go1.23.2
    Fixed in: net/http@go1.23.5
    Example traces found:
      #1: common/rst/s3.go:218:49: rst.S3Client.CreateUpload calls s3.Client.CreateMultipartUpload, which eventually calls http.Client.Do

Vulnerability #2: GO-2025-3373
    Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-3373
  Standard library
    Found in: crypto/x509@go1.23.2
    Fixed in: crypto/x509@go1.23.5
    Example traces found:
      #1: common/beegfs/beegrpc/grpc.go:94:35: beegrpc.NewClientConn calls x509.CertPool.AppendCertsFromPEM
      #2: common/filesystem/fs.go:305:24: filesystem.BeeGFS.CopyContentsToFile calls io.CopyBuffer, which eventually calls x509.Certificate.Verify
      #3: common/filesystem/fs.go:305:24: filesystem.BeeGFS.CopyContentsToFile calls io.CopyBuffer, which eventually calls x509.Certificate.VerifyHostname
      #4: common/types/errors.go:16:32: types.MultiError.Error calls x509.HostnameError.Error
      #5: common/rst/s3.go:341:2: rst.S3Client.Download calls http.http2requestBody.Close, which eventually calls x509.ParseCertificate
      #6: common/beegfs/beegrpc/grpc.go:88:39: beegrpc.NewClientConn calls x509.SystemCertPool

Your code is affected by 2 vulnerabilities from the Go standard library.
This scan found no other vulnerabilities in packages you import or modules you
require.
Use '-show verbose' for more details.
```