### PR TITLE
ctl: cancel the command context on interrupt signal or exit

### DIFF
--- a/ctl/internal/cmd/stats/client.go
+++ b/ctl/internal/cmd/stats/client.go
@@ -171,8 +171,13 @@ func runClientStatsCmd(cmd *cobra.Command, cfg *clientStats_Config) error {
 			break
 		}
 
-		time.Sleep(cfg.interval)
-		t += int(cfg.interval.Abs().Seconds())
+		select {
+		case <-time.After(cfg.interval):
+			t += int(cfg.interval.Abs().Seconds())
+			continue
+		case <-cmd.Context().Done():
+			return nil
+		}
 	}
 
 	return nil

--- a/ctl/internal/cmd/stats/server.go
+++ b/ctl/internal/cmd/stats/server.go
@@ -120,7 +120,12 @@ func runServerstatsCmd(cmd *cobra.Command, cfg *serverStats_Config) error {
 			break
 		}
 
-		time.Sleep(cfg.Interval)
+		select {
+		case <-time.After(cfg.Interval):
+			continue
+		case <-cmd.Context().Done():
+			return nil
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
I was looking into when the Cobra `command.Context()` is cancelled for a command I'm working on (I thought Cobra might do it automatically on exit) and realized it wasn't ever being cancelled by default, even on an interrupt signal. If you don't configure a default signal handler the Go runtime will just immediately terminate everything and not give Goroutines a chance to cleanup or log out any messages that may be helpful (for example if someone used ctrl+c because a command was hung). 

This PR wires the command context to the interrupt signal so a `Ctrl+C` will no longer immediately terminate everything and instead wait for the running command to return. For this to work correctly it requires any blocking calls to respect the context. Because we already used the `command.Context()` throughout CTL this largely worked already, and generally a `Ctrl+C` will now return something like `Error: TCP request to node_meta_1[meta:1, uid:3] failed: error reading BeeMsg: context canceled`.

While spot checking commands that are known to be long running I realized `stats server` never gets a `context cancelled` error and `stats client` won't exit immediately but has to wait for a sleep to finish. I rewired these so they now use a select statement to control the refresh interval that will respect the context and exit immediately if requested.

Tagging @prtpq since this is a change to the root command configuration which I believe he setup initially and @pranavpadmasali to make sure I didn't miss anything with the updates to the `stats` commands.