### PR TITLE
Add Username/Groupname column to quota commands.

### DIFF
--- a/ctl/internal/cmd/buddygroup/resync/restart.go
+++ b/ctl/internal/cmd/buddygroup/resync/restart.go
@@ -30,7 +30,7 @@ This mode is not supported with metadata targets because metadata targets must a
 	cmd.Flags().Int64Var(&cfg.timestampSec, "timestamp", -1,
 		"Override last buddy communication timestamp with a specific Unix timestamp (storage targets only).")
 	cmd.Flags().DurationVar(&cfg.timespan, "timespan", -1*time.Second,
-		"Resync entries modified in the given timespan, for example 1d for the last day or 1h for the last hour (storage targets only).")
+		"Resync entries modified in the given timespan, for example 24h for the last day or 1h for the last hour (storage targets only).")
 
 	cmd.MarkFlagsMutuallyExclusive("timestamp", "timespan")
 	cmd.MarkFlagsOneRequired("timestamp", "timespan")

--- a/ctl/internal/cmd/buddygroup/resync/start.go
+++ b/ctl/internal/cmd/buddygroup/resync/start.go
@@ -37,7 +37,7 @@ func newStartResyncCmd() *cobra.Command {
 	cmd.Flags().Int64Var(&cfg.timestampSec, "timestamp", -1,
 		"Override last buddy communication timestamp with a specific Unix timestamp (storage targets only).")
 	cmd.Flags().DurationVar(&cfg.timespan, "timespan", -1*time.Second,
-		"Resync entries modified in the given timespan, for example 1d for the last day or 1h for the last hour (storage targets only).")
+		"Resync entries modified in the given timespan, for example 24h for the last day or 1h for the last hour (storage targets only).")
 	cmd.MarkFlagsMutuallyExclusive("timestamp", "timespan")
 
 	return cmd

--- a/ctl/internal/cmd/buddygroup/resync/stats.go
+++ b/ctl/internal/cmd/buddygroup/resync/stats.go
@@ -65,7 +65,7 @@ func printMetaResults(result msg.GetMetaResyncStatsResp) {
 	fmt.Println("\nDiscovery Results")
 	fmt.Println("-----------------")
 	fmt.Printf("Directories Discovered: %d\n", result.DiscoveredDirs)
-	fmt.Printf("Files Discovered: %d\n", result.GatherErrors)
+	fmt.Printf("Discovery Errors: %d\n", result.GatherErrors)
 
 	fmt.Println("\nSync Results")
 	fmt.Println("------------")


### PR DESCRIPTION
1. Add user and group names in quota commands.
```
#  beegfs --tls-disable --auth-disable  quota list-usage;
NAME  ID  TYPE   POOL                  SPACE       INODE    
root   0  user   storage_pool_default  56.00KiB/∞  26.00/∞  
root   0  group  storage_pool_default  56.00KiB/∞  26.00/∞  

Warning: Quota usage information is fetched every 60s from the server nodes, thus the displayed values might be slightly out of date.
```
2. Fix help text and output field names in resync commands. 