### PR TITLE
Unset "Provides" field in RPM packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,8 +31,6 @@ nfpms:
     homepage: https://www.beegfs.io
     maintainer: BeeGFS Maintainers <packages@beegfs.com>
     description: A collection of tools for managing BeeGFS.
-    provides:
-      - beegfs
     license: BeeGFS EULA
     formats:
       - rpm


### PR DESCRIPTION
This commit makes sure we set the provided version that goreleaser configures implicitly (`VER-RELEASE`). Setting "Provides" to the package name without any version effectively disables version dependency checking.

See ThinkParQ/beegfs-core#4136.