### PR TITLE
Added max-memory & num-workers to tree summary during rescan

### DIFF
--- a/ctl/internal/cmd/index/rescan.go
+++ b/ctl/internal/cmd/index/rescan.go
@@ -103,6 +103,13 @@ func runPythonRescanIndex(paths []string, bflagSet *bflag.FlagSet, recurse bool)
 		}
 	}
 	treeArgs := []string{createCmd, "-S"}
+	requiredFlags := map[string]bool{"-X": true, "-n": true}
+	for i := 0; i < len(wrappedArgs); i++ {
+		if requiredFlags[wrappedArgs[i]] && i+1 < len(wrappedArgs) {
+			treeArgs = append(treeArgs, wrappedArgs[i], wrappedArgs[i+1])
+			i++
+		}
+	}
 	log.Debug("Running BeeGFS Hive Index Tree-Summary command",
 		zap.Any("Args", treeArgs),
 	)


### PR DESCRIPTION
The max-memory and num-workers arguments from the `wrappedArgs` used in rescanning, should also be included in `treeArgs` which is used in the Tree Summary Command.