### PR TITLE
feat(rst): Add bee-remote performance benchmarking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/thinkparq/protobuf v0.0.0-rc.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/sync v0.10.0
 	golang.org/x/sys v0.29.0
 	golang.org/x/term v0.28.0
 	google.golang.org/grpc v1.69.4

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/rst/remote/internal/config/config.go
+++ b/rst/remote/internal/config/config.go
@@ -31,8 +31,12 @@ type AppConfig struct {
 	Workers              []worker.Config             `mapstructure:"worker"`
 	RemoteStorageTargets []*flex.RemoteStorageTarget `mapstructure:"remote-storage-target"`
 	Developer            struct {
-		PerfProfilingPort int  `mapstructure:"perf-profiling-port"`
-		DumpConfig        bool `mapstructure:"dump-config"`
+		PerfProfilingPort         int    `mapstructure:"perf-profiling-port"`
+		DumpConfig                bool   `mapstructure:"dump-config"`
+		BenchmarkTarget           uint32 `mapstructure:"benchmark-target"`
+		BenchmarkCount            int    `mapstructure:"benchmark-count"`
+		BenchmarkMockWorkRequests int    `mapstructure:"benchmark-mock-work-requests"`
+		BenchmarkMockBeeGFS       int    `mapstructure:"benchmark-mock-beegfs"`
 	}
 }
 

--- a/rst/remote/internal/worker/mock.go
+++ b/rst/remote/internal/worker/mock.go
@@ -42,7 +42,7 @@ func (n *MockNode) heartbeat(request *flex.HeartbeatRequest) (*flex.HeartbeatRes
 
 func (n *MockNode) disconnect() error {
 	args := n.Called()
-	return args.Error(1)
+	return args.Error(0)
 }
 
 func (n *MockNode) SubmitWork(request *flex.WorkRequest) (*flex.Work, error) {


### PR DESCRIPTION
**Support for [(https://github.com/ThinkParQ/bee-remote/issues/31)](https://github.com/ThinkParQ/bee-remote/issues/31): Add Benchmarking Support for Remote Targets**

This change introduces developer-facing benchmarking support to assist with evaluating performance during development.

Key updates:
- Introduces hidden `--developer.benchmark-*` arguments for simulating job workloads and uploading results to remote storage targets.
- Adds a **mock remote storage target** implementation to enable testing without requiring a real storage backend.
- Fixes an issue in `MockNode.disconnect()` where the `Error` argument index was incorrect.

These changes help facilitate performance validation and enable development workflows without depending on live infrastructure. Here's an example output and artifacts produced.

```bash
$ go run rst/remote/cmd/beegfs-remote/main.go \
      --cfg-file /etc/beegfs/beegfs-remote.toml \
      --mount-point /mnt/beegfs \
      --developer.benchmark-count 100000 \
      --developer.benchmark-target 0 \
      --developer.benchmark-mock-work-requests 1 \
      --developer.benchmark-mock-beegfs
Mocking BeeGFS mount point
Create temporary files...
Temporary files created. Path: performance-testing.tmp
Run performance benchmark against mocked target...
Performance benchmark complete.
Benchmark Complete.

Files transferred: 100000
Duration: 6.07 sec
Average: 16466.71 jobs/s
Average Without Outliers: 16533.14 jobs/s
Maximum: 17791.62 jobs/s
Minimum: 15124.06 jobs/s
```

```bash
$ tree benchmark-1743605081/
benchmark-1743605081/
├── pprof-debug-vars.ndjson
├── results.csv
└── summary.log
```
[results.csv](https://github.com/user-attachments/files/19570247/results.csv)
[summary.log](https://github.com/user-attachments/files/19570249/summary.log)
[pprof-debug-vars.ndjson](https://github.com/user-attachments/files/19570260/pprof-debug-vars.ndjson.txt)
