### PR TITLE
Properly handle `--raw` in `beegfs client stats`

### DIFF
--- a/ctl/internal/cmd/benchmark/benchmark.go
+++ b/ctl/internal/cmd/benchmark/benchmark.go
@@ -91,8 +91,8 @@ Note benchmark files will not be deleted automatically. Use the "cleanup" mode t
 		},
 	}
 	cmd.Flags().AddFlagSet(parentFlags)
-	util.I64BytesVar(cmd.Flags(), &backendCfg.FileSize, "size", "s", "1GiB", "The total amount of data to read/write per thread to each benchmark file, specified with an IEC or SI suffix (e.g, 1GiB). Omit the suffix for bytes.")
-	util.I64BytesVar(cmd.Flags(), &backendCfg.BlockSize, "block-size", "b", "128k", "I/O request size used by the benchmark with an IEC or SI suffix (e.g, 1MiB). Omit the suffix for bytes.")
+	util.I64BytesVar(cmd.Flags(), &backendCfg.FileSize, "size", "s", "1GiB", "The total amount of data to read/write per thread to each benchmark file, specified with an IEC or SI unit (e.g, 1GiB). Omit the unit for bytes.")
+	util.I64BytesVar(cmd.Flags(), &backendCfg.BlockSize, "block-size", "b", "128k", "I/O request size used by the benchmark with an IEC or SI unit (e.g, 1MiB). Omit the unit for bytes.")
 	cmd.Flags().Int32VarP(&backendCfg.Threads, "num-tasks", "n", 1, "The number of client streams to simulate per target for the benchmark. Each task will read or write from a separate benchmark file.")
 	cmd.Flags().BoolVarP(&backendCfg.ODirect, "odirect", "D", false, "Use direct I/O (O_DIRECT) on the storage nodes.")
 	cmd.Flags().BoolVarP(&readBench, "read", "r", false, "By default a write benchmark is performed. Set to perform a read benchmark instead. \n\tNote: Requires first running a write benchmark with at least as many tasks and the same/larger file size as the read benchmark.")

--- a/ctl/internal/cmd/stats/client.go
+++ b/ctl/internal/cmd/stats/client.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/dsnet/golib/unitconv"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/thinkparq/beegfs-go/common/beegfs"
 	"github.com/thinkparq/beegfs-go/ctl/internal/cmdfmt"
+	"github.com/thinkparq/beegfs-go/ctl/pkg/config"
 	"github.com/thinkparq/beegfs-go/ctl/pkg/ctl/stats"
 )
 
@@ -258,7 +260,7 @@ func clientIPToString(ip uint64, name bool) string {
 }
 
 // Prints one client Ip/username, number of operations and operation name
-func printOpsRow(tbl *cmdfmt.Printomatic, name string, ops []uint64, nt beegfs.NodeType, raw bool) {
+func printOpsRow(tbl *cmdfmt.Printomatic, name string, ops []uint64, nt beegfs.NodeType, all bool) {
 	var opNames []string
 	if nt == beegfs.Meta {
 		opNames = stats.MetaOpNamesLower
@@ -268,8 +270,8 @@ func printOpsRow(tbl *cmdfmt.Printomatic, name string, ops []uint64, nt beegfs.N
 
 	rowColumns := append(make([]any, 0, len(opNames)), name)
 	for i, v := range ops {
-		if v != 0 || raw {
-			if opNames[i] == "rd" || opNames[i] == "wr" {
+		if v != 0 || all {
+			if !viper.GetBool(config.RawKey) && (opNames[i] == "rd" || opNames[i] == "wr") {
 				rowColumns = append(rowColumns, unitconv.FormatPrefix(float64(v), unitconv.IEC, 0))
 			} else {
 				rowColumns = append(rowColumns, fmt.Sprintf("%d", v))
@@ -286,7 +288,7 @@ func printOpsRow(tbl *cmdfmt.Printomatic, name string, ops []uint64, nt beegfs.N
 
 // Prints one client Ip/username, number of operations and operation name in the old-style CTL
 // "retro" format.
-func printOpsRetro(name string, ops []uint64, nt beegfs.NodeType, raw bool) {
+func printOpsRetro(name string, ops []uint64, nt beegfs.NodeType, all bool) {
 	var opNames []string
 	if nt == beegfs.Meta {
 		opNames = stats.MetaOpNames
@@ -297,8 +299,8 @@ func printOpsRetro(name string, ops []uint64, nt beegfs.NodeType, raw bool) {
 	fmt.Printf("%s: ", name)
 
 	for i, v := range ops {
-		if v != 0 || raw {
-			if opNames[i] == "rd" || opNames[i] == "wr" {
+		if v != 0 || all {
+			if !viper.GetBool(config.RawKey) && (opNames[i] == "rd" || opNames[i] == "wr") {
 				fmt.Printf("%s [%s] ", unitconv.FormatPrefix(float64(v), unitconv.IEC, 0), opNames[i])
 			} else {
 				fmt.Printf("%d [%s] ", v, opNames[i])

--- a/ctl/internal/config/config.go
+++ b/ctl/internal/config/config.go
@@ -21,7 +21,7 @@ import (
 func InitGlobalFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool(config.DebugKey, false, "Print additional details that are normally hidden.")
 
-	cmd.PersistentFlags().Bool(config.RawKey, false, "Print raw values without SI or IEC prefixes (except durations).")
+	cmd.PersistentFlags().Bool(config.RawKey, false, "Print raw values without SI or IEC prefixed units (except durations).")
 
 	cmd.PersistentFlags().String(config.ManagementAddrKey, config.BeeGFSMgmtdAddrAuto, `The network address and gRPC port of the management node.
 	By default determined automatically when BeeGFS is mounted and all mount points are for the same file system.`)


### PR DESCRIPTION
### What does this PR do / why do we need it?

Gets the correct configuration value to determine if numbers should be printed raw or with units.

### Checklist before merging:
*Required for all PRs.*

When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [x] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [x] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [x] Git Hygiene: 
  - [x] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [x] Is the commit history squashed down reasonably?

For more details refer to the [Go coding standards](https://github.com/ThinkParQ/beegfs-go/wiki/Getting-Started-with-Go#coding-standards) and the [pull request process](https://github.com/ThinkParQ/beegfs-go/wiki/Pull-Requests).
