### PR TITLE
feat(sync): add job request prioritization and rescheduling support

### DIFF
--- a/common/rst/builder.go
+++ b/common/rst/builder.go
@@ -37,6 +37,7 @@ func (c *JobBuilderClient) GetJobRequest(cfg *flex.JobRequestCfg) *beeremote.Job
 		Path:                cfg.Path,
 		RemoteStorageTarget: 0,
 		StubLocal:           cfg.StubLocal,
+		Priority:            cfg.GetPriority(),
 		Force:               cfg.Force,
 		Type: &beeremote.JobRequest_Builder{
 			Builder: &flex.BuilderJob{
@@ -90,6 +91,10 @@ func (c *JobBuilderClient) ExecuteJobBuilderRequest(ctx context.Context, workReq
 	}
 
 	return c.executeJobBuilderRequest(ctx, workRequest, walkChan, jobSubmissionChan, cfg)
+}
+
+func (r *JobBuilderClient) IsWorkRequestReady(ctx context.Context, request *flex.WorkRequest) (bool, time.Duration, error) {
+	return true, 0, nil
 }
 
 // ExecuteWorkRequestPart is not implemented and should never be called.

--- a/common/rst/jobrequest.go
+++ b/common/rst/jobrequest.go
@@ -128,6 +128,14 @@ func prepareJobRequests(ctx context.Context, remote beeremote.BeeRemoteClient, c
 		jobBuilder = true
 	}
 
+	if cfg.Priority == nil {
+		var priority int32 = 3
+		if jobBuilder {
+			priority = 4
+		}
+		cfg.Priority = &priority
+	}
+
 	if jobBuilder {
 		client := NewJobBuilderClient(ctx, nil, nil)
 		request := client.GetJobRequest(cfg)

--- a/common/rst/mock.go
+++ b/common/rst/mock.go
@@ -126,3 +126,8 @@ func (r *MockClient) GetRemotePathInfo(ctx context.Context, cfg *flex.JobRequest
 func (r *MockClient) GenerateExternalId(ctx context.Context, cfg *flex.JobRequestCfg) (string, error) {
 	return "", ErrUnsupportedOpForRST
 }
+
+func (r *MockClient) IsWorkRequestReady(ctx context.Context, request *flex.WorkRequest) (bool, time.Duration, error) {
+	args := r.Called(request)
+	return args.Bool(0), args.Get(1).(time.Duration), args.Error(2)
+}

--- a/common/rst/s3.go
+++ b/common/rst/s3.go
@@ -92,6 +92,7 @@ func (r *S3Client) GetJobRequest(cfg *flex.JobRequestCfg) *beeremote.JobRequest 
 		Path:                cfg.Path,
 		RemoteStorageTarget: cfg.RemoteStorageTarget,
 		StubLocal:           cfg.StubLocal,
+		Priority:            cfg.GetPriority(),
 		Force:               cfg.Force,
 		Type: &beeremote.JobRequest_Sync{
 			Sync: &flex.SyncJob{
@@ -118,6 +119,7 @@ func (r *S3Client) getJobRequestCfg(request *beeremote.JobRequest) *flex.JobRequ
 		StubLocal:           request.StubLocal,
 		Overwrite:           sync.Overwrite,
 		Flatten:             sync.Flatten,
+		Priority:            &request.Priority,
 		Force:               request.Force,
 		LockedInfo:          sync.LockedInfo,
 		Update:              request.Update,
@@ -177,6 +179,10 @@ func (r *S3Client) GenerateWorkRequests(ctx context.Context, lastJob *beeremote.
 // ExecuteJobBuilderRequest is not implemented and should never be called.
 func (r *S3Client) ExecuteJobBuilderRequest(ctx context.Context, workRequest *flex.WorkRequest, jobSubmissionChan chan<- *beeremote.JobRequest) error {
 	return ErrUnsupportedOpForRST
+}
+
+func (r *S3Client) IsWorkRequestReady(ctx context.Context, request *flex.WorkRequest) (bool, time.Duration, error) {
+	return true, 0, nil
 }
 
 func (r *S3Client) ExecuteWorkRequestPart(ctx context.Context, request *flex.WorkRequest, part *flex.Work_Part) error {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
-	github.com/thinkparq/protobuf v0.8.2-0.20250915082136-5706c6e57695
+	github.com/thinkparq/protobuf v0.8.3-0.20251028161233-2ca5278bb410
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.15.0
 	golang.org/x/sys v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/thinkparq/protobuf v0.8.2-0.20250915082136-5706c6e57695 h1:CKHOEylBPspjRjfLxobpbj6C1XYlD1mT5cIsR0L+AFs=
-github.com/thinkparq/protobuf v0.8.2-0.20250915082136-5706c6e57695/go.mod h1:AaUUy9mWaja/EggLSfzbKydAe+We+440z/6FdmPz5yI=
+github.com/thinkparq/protobuf v0.8.3-0.20251028161233-2ca5278bb410 h1:uf7rm+X4rEI72+5/5GcQxbH53H6nSeJn9T8DMiLbAR0=
+github.com/thinkparq/protobuf v0.8.3-0.20251028161233-2ca5278bb410/go.mod h1:AaUUy9mWaja/EggLSfzbKydAe+We+440z/6FdmPz5yI=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.36.0 h1:UumtzIklRBY6cI/lllNZlALOF5nNIzJVb16APdvgTXg=

--- a/rst/sync/build/beegfs-sync.toml
+++ b/rst/sync/build/beegfs-sync.toml
@@ -102,8 +102,8 @@ tls-disable = false
 # Manager configuration must be specified under [manager]. These settings affect how work requests
 # are tracked and stored internally by the Sync node.
 
-# journal-db: The path where a journal of all work requests assigned to this node will be kept. This
-# is used to resume outstanding work requests after the Sync node restarts or crashes.
+# journal-db: The path where a journal of scheduled work requests assigned to this node will be
+# kept. This is used to resume outstanding work requests after the Sync node restarts or crashes.
 
 # job-db: The path where a database of all jobs with active work requests on this node is stored.
 

--- a/rst/sync/internal/workmgr/scheduler.go
+++ b/rst/sync/internal/workmgr/scheduler.go
@@ -1,0 +1,467 @@
+package workmgr
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const priorityLevels = 5
+
+const tolerance = 1e-6
+
+type schedulerConfig struct {
+	// targetMultiple determines the multiplier used to calculate how many tokens are needed to maintain
+	// steady back-pressure on the activeWorkQueue. The nextTokens() function uses this factor to
+	// estimate the number of tokens required to sustain targetMultiple * averageComplete work. A smaller
+	// targetMultiple can cause worker starvation during sudden increases in completed work, while a
+	// larger targetMultiple may delay the execution of higher-priority requests.
+	targetMultiple float64
+	// alpha controls the weighting of previous values in the exponentially weighted moving averages
+	// (averageDeltaTimeMs and averageCompletePerMs). The halfLifeSec parameter determines how quickly the
+	// previous average decays. A larger halfLifeSec produces smoother but slower responses
+	// to changes in workload, while a smaller halfLifeSec reacts more quickly but with greater volatility.
+	halfLifeSec float64
+	// maximumAllowedTokenGrowth limits the growth of the allowed tokens in a given cycle. Larger values
+	// response faster to spikes in completed work whereas smaller values will be slow and more
+	// controlled. Extremely large values can cause oscillations in growth.
+	maximumAllowedTokenGrowth float64
+	// minimumAllowedTokens is the minimum allowed tokens that can be distributed among the
+	// priority queues per cycle. This value will be multipled by the targetMultiple to define a
+	// starting number of tokens to grow from. This should at least be the number of workers.
+	minimumAllowedTokens int
+	// pullInWorkTicker defines the periodic release of work tokens.
+	pullInWorkTicker time.Duration
+}
+
+type schedulerOpt func(*schedulerConfig)
+
+func WithMinimumAllowedTokens(tokens int) schedulerOpt {
+	return func(cfg *schedulerConfig) {
+		cfg.minimumAllowedTokens = tokens
+	}
+}
+
+type scheduler struct {
+	ctx context.Context
+	log *zap.Logger
+	// Weights are used to distribute tokens fairly between the priority queues as to avoid starving
+	// lower priorities while giving preference to higher priorities. These weights are dynamically
+	// adjust to exclude empty queues.
+	weights [priorityLevels]float64
+	// targetMultiple determines the multiplier used to calculate how many tokens are needed to maintain
+	// steady back-pressure on the activeWorkQueue. The nextTokens() function uses this factor to
+	// estimate the number of tokens required to sustain targetMultiple * averageComplete work. A smaller
+	// targetMultiple can cause worker starvation during sudden increases in completed work, while a
+	// larger targetMultiple may delay the execution of higher-priority requests.
+	targetMultiple float64
+	// capacity is the largest number of work requests the active work queue channel can have.
+	capacity int
+	// nextPriority returns the next priority level in a rotating sequence, cycling through all
+	// priorities once before returning false.
+	nextPriority func() (int, bool)
+	// workTokens maintains the number of alloted work workTokens for each priority. Work workTokens are
+	// used by the manager's work scheduler in order to maintain fairness between priority queues
+	// and back-pressure on the activeWorkQueue. The priority workTokens are used for both priority and
+	// wait queues.
+	workTokens [priorityLevels]atomic.Int32
+	// minimumAllowedTokens is the minimum allowed tokens that can be distributed among the
+	// priority queues per cycle.
+	minimumTokensToDistribute int
+	// maximumAllowedTokenGrowth limits the growth of the allowed tokens in a given cycle. Larger values
+	// response faster to spikes in completed work whereas smaller values will be slow and more
+	// controlled. Extremely large values can cause oscillations in growth.
+	maximumAllowedTokenGrowth float64
+	// alpha determines how much weight to give to past samples and is used in computing
+	// averageDurationMs and averageCompletedWorkPerMs. It must between 0 and 1. Smaller values will
+	// give more influence to past samples whereas larger values give the influence to the current.
+	alpha                float64
+	previousUsedCapacity int
+	// previousTokensDistributed tracks the total number of tokens distributed.
+	previousTokensDistributed int
+	previousTime              time.Time
+	averageDurationMs         float64
+	averageCompletedWorkPerMs float64
+	// lowWorkThreshold is the pending requests low threshold. If the active work queue requests
+	// falls below this value then the shortSendWorkTicker will send more work.
+	lowWorkThreshold int
+	// lowWorkThresholdPct is the percentage of average work throughput that defines the low
+	// threshold.
+	lowWorkThresholdPct float64
+	// allWorkTokens is a counter that maintains the total number of existing workTokens. This is
+	// used to release more tokens when the active work queue drops below a certain threshold.
+	allWorkTokens atomic.Int32
+	// tokensReleased is a buffered channel releases the priority tokens to the sync manager. This
+	// must be buffered to avoid deadlocking with manager. The channel must hold every sendWork that
+	// can occur before the manager loop reads m.scheduler.tokensReleased.
+	tokensReleased           chan [priorityLevels]int
+	shouldReportIdleStatus   bool
+	shouldReportActiveStatus bool
+}
+
+func NewScheduler(ctx context.Context, log *zap.Logger, queue chan workAssignment, fairness gemetricRatio, opts ...schedulerOpt) (s *scheduler, close func() error) {
+
+	cfg := &schedulerConfig{
+		targetMultiple:            2.5,
+		halfLifeSec:               10,
+		maximumAllowedTokenGrowth: 0.85,
+		minimumAllowedTokens:      32,
+		pullInWorkTicker:          1000 * time.Millisecond,
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	s = &scheduler{
+		ctx:                       ctx,
+		log:                       log,
+		weights:                   geometricFairnessWeights(fairness),
+		targetMultiple:            cfg.targetMultiple,
+		minimumTokensToDistribute: int(cfg.targetMultiple * float64(cfg.minimumAllowedTokens)),
+		maximumAllowedTokenGrowth: cfg.maximumAllowedTokenGrowth,
+		capacity:                  cap(queue),
+		nextPriority:              GetNextPriority(),
+		alpha:                     1 - math.Exp(-math.Ln2/cfg.halfLifeSec),
+		tokensReleased:            make(chan [priorityLevels]int, 1),
+		shouldReportIdleStatus:    false,
+		shouldReportActiveStatus:  true,
+	}
+	s.log.Info("worker node is idle")
+
+	pullInWorkTicker := time.NewTicker(cfg.pullInWorkTicker)
+	close = func() error {
+		pullInWorkTicker.Stop()
+		return nil
+	}
+
+	go func() {
+		s.previousTime = time.Now()
+		s.averageDurationMs = float64(cfg.pullInWorkTicker.Milliseconds())
+		for {
+			select {
+			case <-s.ctx.Done():
+				return
+			case currentTime := <-pullInWorkTicker.C:
+				usedCapacity := len(queue)
+
+				elapsedTimeMs := float64(currentTime.Sub(s.previousTime).Milliseconds())
+				s.averageDurationMs = s.alpha*elapsedTimeMs + (1-s.alpha)*s.averageDurationMs
+				s.previousTime = currentTime
+
+				completedWork := float64(s.previousUsedCapacity + s.previousTokensDistributed - usedCapacity)
+				completedWorkPerMs := completedWork / elapsedTimeMs
+				s.previousUsedCapacity = usedCapacity
+				s.sendWork(usedCapacity, completedWorkPerMs)
+			}
+		}
+	}()
+
+	return
+}
+
+// AddWorkToken(submissionID) tells the scheduler about a submission in the journal that is eligible
+// to be scheduled. It should be called whenever a WR is created, rediscovered on startup, or
+// rescheduled. The scheduler decodes the submission ID to determine the priority and increment that
+// bucket's token count. These counts are used to keep track of pending work at each priority to
+// ensure no priority queue is starved. Tokens represent work that is ready but not yet dispatched
+// to a worker.
+func (s *scheduler) AddWorkToken(submissionId string) {
+	priority := submissionIdPriority(submissionId)
+	s.workTokens[priority].Add(1)
+	s.allWorkTokens.Add(1)
+}
+
+// RemoveWorkToken(submissionID) is called once a work assignment has been added to the active work
+// queue (not when it actually completes). This tells the scheduler a request at the given priority
+// has been handed to a worker, allowing it to internally adjust how it assigns new work.
+func (s *scheduler) RemoveWorkToken(submissionId string) {
+	priority := submissionIdPriority(submissionId)
+	s.workTokens[priority].Add(-1)
+	s.allWorkTokens.Add(-1)
+}
+
+func (s *scheduler) sendWork(currentUsedCapacity int, completedWorkPerMs float64) {
+	tokensAllowed := s.getTokensAllowed(currentUsedCapacity, completedWorkPerMs)
+	tokens, isWork := s.distributeTokens(tokensAllowed)
+	if isWork {
+		s.tokensReleased <- tokens
+		if s.shouldReportActiveStatus {
+			s.log.Info("worker node is no longer idle")
+			s.shouldReportIdleStatus = true
+			s.shouldReportActiveStatus = false
+		}
+	} else if s.shouldReportIdleStatus && s.allWorkTokens.Load() == 0 {
+		s.log.Info("worker node is idle")
+		s.shouldReportIdleStatus = false
+		s.shouldReportActiveStatus = true
+	}
+}
+
+// Return the token allowed to be scheduled. The tokens determined by target multiple of
+// completed work, adjusted by the recent growth trend. This calculation attempts to:
+//   - Prevent worker starvation during short throughput bursts.
+//   - Avoid saturating the activeWorkQueue so it can drain quickly enough to minimize priority
+//     inversion (long delays for high-priority work caused by a backlog of lower-priority tasks).
+func (s *scheduler) getTokensAllowed(usedCapacity int, completedWorkPerMs float64) (tokensAllowed int) {
+	availableCapacity := s.capacity - usedCapacity
+
+	if s.averageCompletedWorkPerMs <= tolerance {
+		s.averageCompletedWorkPerMs = completedWorkPerMs
+		tokensAllowed = s.minimumTokensToDistribute
+		s.log.Debug("token scheduler warmup allowance",
+			zap.Int("usedCapacity", usedCapacity),
+			zap.Int("availableCapacity", availableCapacity),
+			zap.Int("tokensAllowed", tokensAllowed),
+		)
+	} else {
+
+		var growthFactor float64 = 0
+		growthDenominator := math.Abs(s.averageCompletedWorkPerMs)
+		if growthDenominator > tolerance {
+			growthFactor = (completedWorkPerMs - s.averageCompletedWorkPerMs) / growthDenominator
+			if growthFactor > s.maximumAllowedTokenGrowth {
+				growthFactor = s.maximumAllowedTokenGrowth
+			} else if growthFactor < -s.maximumAllowedTokenGrowth {
+				growthFactor = -s.maximumAllowedTokenGrowth
+			}
+		}
+
+		s.averageCompletedWorkPerMs = s.alpha*completedWorkPerMs + (1-s.alpha)*s.averageCompletedWorkPerMs
+		if s.averageCompletedWorkPerMs < 1.0/s.averageDurationMs {
+			s.averageCompletedWorkPerMs = 0
+		}
+		normalizedCompletedWork := s.averageCompletedWorkPerMs * s.averageDurationMs
+		s.lowWorkThreshold = int(math.Ceil(normalizedCompletedWork * s.lowWorkThresholdPct))
+
+		targetSlots := int(s.targetMultiple * (1 + growthFactor) * normalizedCompletedWork)
+		tokensAllowed = max(targetSlots, s.minimumTokensToDistribute) - usedCapacity
+		s.log.Debug("token scheduler computed allowance",
+			zap.Int("usedCapacity", usedCapacity),
+			zap.Int("availableCapacity", availableCapacity),
+			zap.Float64("normalizedCompletedWork", RoundToMillis(normalizedCompletedWork)),
+			zap.Float64("growth", RoundToMillis(growthFactor)),
+			zap.Int("tokensAllowed", tokensAllowed),
+		)
+	}
+
+	if tokensAllowed > availableCapacity {
+		tokensAllowed = availableCapacity
+	} else if tokensAllowed < 0 {
+		tokensAllowed = 0
+	}
+	return tokensAllowed
+}
+
+func (s *scheduler) distributeTokens(tokensAllowed int) (tokens [priorityLevels]int, isWork bool) {
+	if tokensAllowed <= 0 {
+		return
+	}
+
+	// Distribute tokens among the priority queues. The normalizer is used to handle empty
+	// priority queues by distributing their allocations to the queues with work. Any remainder
+	// that does not evenly distribute to each priority queue will be distributed to queues with
+	// the highest priorities first. Note that that alloted tokens (ie tokensLeft)
+	normalizer := 1.0
+	workTokens := [priorityLevels]int{}
+	for priority := range priorityLevels {
+		workTokens[priority] = int(s.workTokens[priority].Load())
+		if workTokens[priority] <= 0 {
+			normalizer -= s.weights[priority]
+		}
+	}
+	if normalizer < tolerance {
+		s.previousTokensDistributed = 0
+		s.log.Debug("all queues are empty")
+		return
+	}
+
+	isWork = true
+	tokensLeft := tokensAllowed
+	for priority, ok := s.nextPriority(); ok && tokensLeft > 0; priority, ok = s.nextPriority() {
+		if workTokens[priority] <= 0 {
+			continue
+		}
+		allowed := int(s.weights[priority] / normalizer * float64(tokensLeft))
+		tokens[priority] = min(allowed, workTokens[priority])
+		tokensLeft -= tokens[priority]
+		workTokens[priority] -= tokens[priority]
+	}
+
+	for priority := range priorityLevels {
+		if tokensLeft <= 0 || workTokens[priority] <= 0 {
+			continue
+		}
+		if workTokens[priority] >= tokensLeft {
+			tokens[priority] += tokensLeft
+			tokensLeft = 0
+		} else {
+			tokens[priority] += workTokens[priority]
+			tokensLeft -= workTokens[priority]
+		}
+	}
+
+	tokensUnused := tokensLeft
+	tokensDistributed := tokensAllowed - tokensLeft
+	s.log.Debug("token scheduler distribution",
+		zap.Int("tokensDistributed", tokensDistributed),
+		zap.Int("tokensUnused", tokensUnused),
+		zap.Any("tokensByPriority", tokens))
+	s.previousTokensDistributed = tokensDistributed
+	return
+}
+
+func RoundToMillis(x float64) float64 { return math.Round(x*1e3) / 1e3 }
+
+/*
+The highest base value for the submissionID is ^uint64(0) which is 3w5e11264sgsf in base-36. This
+can be fit multiple times within 13-character base-36 string so defined ranges are utilized to
+represent five priority ranges.
+
+In order to simplify parsing, 8-9 have been ignore and priority 2 begins at the 'a'. The following
+table shows the ranges. The lead-byte represents the first character in the submissionID string.
+
+| ASCII | Offset | Lead Byte | Priority |
+| ----- | ------ | --------- | -------- |
+|   48  |    0   |    `0`    |    0     |
+|   49  |    1   |    `1`    |    0     |
+|   50  |    2   |    `2`    |    0     |
+|   51  |    3   |    `3`    |    0     |
+|   52  |    4   |    `4`    |    1     |
+|   53  |    5   |    `5`    |    1     |
+|   54  |    6   |    `6`    |    1     |
+|   55  |    7   |    `7`    |    1     |
+|   56  |    8   |    `8`    | ignored  |
+|   57  |    9   |    `9`    | ignored  |
+|   97  |   49   |    `a`    |    2     |
+|   98  |   50   |    `b`    |    2     |
+|   99  |   51   |    `c`    |    2     |
+|  100  |   52   |    `d`    |    2     |
+|  101  |   53   |    `e`    |    3     |
+|  102  |   54   |    `f`    |    3     |
+|  103  |   55   |    `g`    |    3     |
+|  104  |   56   |    `h`    |    3     |
+|  105  |   57   |    `i`    |    4     |
+|  106  |   58   |    `j`    |    4     |
+|  107  |   59   |    `k`    |    4     |
+|  108  |   60   |    `l`    |    4     |
+*/
+const submissionIdPriorityTableStart = byte(48)
+
+// submissionIdPriorityOffsetTable defines the submissionId boundaries for each priority.
+// The offset range for a given priority spans from table[priority-1] to table[priority].
+var submissionIdPriorityOffsetTable = []byte{0, 4, 49, 53, 57, 61}
+var submissionIdPriorityStarts = []string{"0000000000000", "4000000000000", "a000000000000", "e000000000000", "i000000000000"}
+var submissionIdPriorityStops = []string{"4000000000000", "a000000000000", "e000000000000", "i000000000000", "m000000000000"}
+
+func SubmissionIdPriorityRange(priority int) (start, stop string) {
+	return submissionIdPriorityStarts[priority], submissionIdPriorityStops[priority]
+}
+
+func CreateSubmissionId(baseKey string, workRequestPriority int32) (string, int32) {
+	priority := workRequestPriority - 1
+	if priority < 0 || priority > priorityLevels-1 {
+		priority = 2
+	}
+	leadByte := baseKey[0] + submissionIdPriorityOffsetTable[priority]
+	return string(leadByte) + baseKey[1:], priority + 1
+}
+
+func DemoteSubmissionId(key string) (string, int32) {
+	baseKey := submissionBaseKey(key)
+	workRequestPriority := min(submissionIdPriority(key)+1, priorityLevels-1) + 1
+	return CreateSubmissionId(baseKey, workRequestPriority)
+}
+
+func PromoteSubmissionId(key string) (string, int32) {
+	baseKey := submissionBaseKey(key)
+	workRequestPriority := max(submissionIdPriority(key)-1, 0) + 1
+	return CreateSubmissionId(baseKey, workRequestPriority)
+}
+
+func submissionIdPriority(key string) int32 {
+	leadByte := key[0]
+	i := int32(priorityLevels - 1)
+	for ; i >= 0; i-- {
+		priorityStartByte := submissionIdPriorityTableStart + submissionIdPriorityOffsetTable[i]
+		if leadByte >= priorityStartByte {
+			break
+		}
+	}
+	return i
+}
+
+func submissionBaseKey(key string) string {
+	leadByte := key[0]
+	leadByte -= submissionIdPriorityOffsetTable[submissionIdPriority(key)]
+	return string(leadByte) + key[1:]
+}
+
+// nextPriority returns the next priority level in a rotating sequence, cycling through all
+// priorities once before returning false; after each full cycle, the starting priority shifts so
+// every level eventually gets a turn to go first.
+func GetNextPriority() func() (int, bool) {
+	counter := 0
+	id := 0
+	return func() (int, bool) {
+		id++
+		if id == priorityLevels {
+			id = 0
+		}
+
+		if counter == priorityLevels {
+			counter = 0
+			return -1, false
+		}
+		counter++
+		return id, true
+	}
+}
+
+type gemetricRatio float64
+
+const (
+	AGGRESSIVE gemetricRatio = 0.50  // [51.6 25.8 12.9 06.4 03.2]
+	STRONG     gemetricRatio = 0.667 // [38.3 25.5 17.0 11.3 07.5]
+	BALANCED   gemetricRatio = 0.75  // [32.7 24.5 18.4 13.8 10.3]
+	GENTLE     gemetricRatio = 0.85  // [26.9 22.9 19.4 16.5 14.0]
+	FAIR       gemetricRatio = 0.90  // [24.4 21.9 19.7 17.8 16.0]
+)
+
+func (r gemetricRatio) String() string {
+	switch r {
+	case AGGRESSIVE:
+		return "aggressive"
+	case STRONG:
+		return "strong"
+	case BALANCED:
+		return "balanced"
+	case GENTLE:
+		return "gentle"
+	case FAIR:
+		return "fair"
+	default:
+		return strconv.FormatFloat(float64(r), 'f', 3, 64)
+	}
+}
+
+// geometricFairnessWeights returns a normalized list of weights based on the geometricRatio.
+func geometricFairnessWeights(ratio gemetricRatio) (weights [priorityLevels]float64) {
+	normalizer := 0.0
+	current := 1.0
+	for range priorityLevels {
+		normalizer += current
+		current *= float64(ratio)
+	}
+
+	current = 1.0
+	for i := range priorityLevels {
+		weights[i] = current / normalizer
+		current *= float64(ratio)
+	}
+	return weights
+}

--- a/rst/sync/internal/workmgr/scheduler_test.go
+++ b/rst/sync/internal/workmgr/scheduler_test.go
@@ -1,0 +1,83 @@
+package workmgr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type submissionExpectation struct {
+	name                 string
+	priority             int32
+	baseKey              string
+	expectedSubmissionId string
+	expectedPriority     int32
+	expectedIncrement    string
+}
+
+func TestSubmissionIDFunctions(t *testing.T) {
+
+	tests := []submissionExpectation{
+		{
+			name:                 "test submissionId from previous release",
+			priority:             0,
+			baseKey:              "0000000000000",
+			expectedSubmissionId: "a000000000000",
+			expectedPriority:     3,
+			expectedIncrement:    "a000000000001",
+		},
+		{
+			name:                 "test lowest priority",
+			priority:             1,
+			baseKey:              "0000000000000",
+			expectedSubmissionId: "0000000000000",
+			expectedPriority:     1,
+			expectedIncrement:    "4000000000001",
+		},
+		{
+			name:                 "test highest priority",
+			priority:             5,
+			baseKey:              "0000000000000",
+			expectedSubmissionId: "i000000000000",
+			expectedPriority:     5,
+			expectedIncrement:    "i000000000001",
+		},
+		{
+			name:                 "test when submission id is the largest uint64 value and is incremented",
+			priority:             3,
+			baseKey:              "3w5e11264sgsf", // is the highest value uint64 can represent in base-36
+			expectedSubmissionId: "dw5e11264sgsf",
+			expectedPriority:     3,
+			expectedIncrement:    "a000000000000",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			submissionId, _ := CreateSubmissionId(test.baseKey, test.priority)
+			assert.Equal(t, test.expectedSubmissionId, submissionId, "createSubmissionID(%s, %d)", test.baseKey, test.priority)
+
+			workRequestPriority := submissionIdPriority(submissionId) + 1
+			assert.Equal(t, test.expectedPriority, workRequestPriority, "submissionIDPriority(%s)", submissionId)
+
+			base := submissionBaseKey(submissionId)
+			assert.Equal(t, test.baseKey, base, "submissionBaseKey(%s)", submissionId)
+
+			demoted, workRequestPriority := DemoteSubmissionId(submissionId)
+			wantDemotedPriority := test.expectedPriority
+			if wantDemotedPriority < priorityLevels {
+				wantDemotedPriority++
+			}
+			assert.Equal(t, wantDemotedPriority, workRequestPriority, "submissionIDPriority(demoteSubmissionId(%s))", submissionId)
+			assert.Equal(t, test.baseKey, submissionBaseKey(demoted), "submissionBaseKey(demoteSubmissionId(%s))", submissionId)
+
+			promoted, workRequestPriority := PromoteSubmissionId(submissionId)
+			wantPromotedPriority := test.expectedPriority
+			if wantPromotedPriority > 1 {
+				wantPromotedPriority--
+			}
+			assert.Equal(t, wantPromotedPriority, workRequestPriority, "submissionIDPriority(promoteSubmissionId(%s))", submissionId)
+			assert.Equal(t, test.baseKey, submissionBaseKey(promoted), "submissionBaseKey(promoteSubmissionId(%s))", submissionId)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do / why do we need it?
* Add priority with fairness
* Add wait queue which is required for archival support.
* Add priority option to ctl push/pull commands with five priority levels.
* Add IsWorkRequestReady() method to the rst.Provider interface to validate work is ready.
  * Before processing a work request, IsWorkRequestReady() is called to check if the client is prepared to handle it. Clients can use this hook to verify resource availability or other preconditions. If not ready, the request is deferred into the wait queue for the duration returned by IsWorkRequestReady().
* Unit tests have been added to verify the database scheme
* The following code was injected into the s3 provider to test the wait queue,
```
func (r *S3Client) IsWorkRequestReady(ctx context.Context, request *flex.WorkRequest) (bool, time.Time, error) {
	// Only for testing
	_, err := r.mountPoint.Stat(request.JobId)
	if err != nil && errors.Is(err, fs.ErrNotExist) {
		r.mountPoint.CreateWriteClose(request.JobId, []byte{}, 0600, false)
		retryTime := time.Now().Add(5 * time.Second)
		return false, retryTime, nil
	}
	return true, time.Time{}, nil
}
```

**Note**: In order to accommodate the addition of priorities the following protobuf branch is needed: [swartzn/add-priority-wait-queue
](https://github.com/ThinkParQ/protobuf/pull/60)

### Where should the reviewer(s) start reviewing this? 
There are two commits. 
1. Extends `mapStore` functionality to support getting entries across ranges and exposes `GenerateNextPK()` so consumers can utilize the counter.
2. Adds a second database for the wait queue and priority schema for the 13-character base-36 submission id key.
3. Follow the sync work manager polling with particular focus on the `pollForWorkTicker` case in the main loop.

The changes to mapStore are independent in the [first commit](https://github.com/ThinkParQ/beegfs-go/pull/210/commits/7cc4235f37d74ae353825d340229efbda665a149) and should be reviewed first . Afterwards, understand the scheme in [rst/sync/internal/workmgr/utils.go:L184](https://github.com/ThinkParQ/beegfs-go/pull/210/files#diff-eee9bb54e8cca8525c0f82919276a7be39b9c1184b9fbf942e972f9601000cff) before proceeding to the workmgr changes [rst/sync/internal/workmgr/manager.go](https://github.com/ThinkParQ/beegfs-go/pull/210/files#diff-c296cb8d5b15da228f0f2f51bff7e8d168450e0e9bcc5209b21734ac40c73b6a)

### Checklist before merging:
When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [ ] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [ ] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?

For more details refer to the [Go coding standards](https://github.com/ThinkParQ/beegfs-go/wiki/Getting-Started-with-Go#coding-standards) and the [pull request process](https://github.com/ThinkParQ/beegfs-go/wiki/Pull-Requests).
