### PR TITLE
feat(entry): set the buddy mirror flag when getting root entry info

### DIFF
--- a/common/beegfs/entity.go
+++ b/common/beegfs/entity.go
@@ -161,6 +161,14 @@ type EntityIdSet struct {
 	LegacyId LegacyId `json:"id"`
 }
 
+func (s *EntityIdSet) Clone() EntityIdSet {
+	return EntityIdSet{
+		Uid:      s.Uid,
+		Alias:    s.Alias,
+		LegacyId: s.LegacyId,
+	}
+}
+
 func EntityIdSetFromProto(input *pb.EntityIdSet) (EntityIdSet, error) {
 	if input == nil || input.LegacyId == nil {
 		return EntityIdSet{}, fmt.Errorf("proto EntityIdSet is invalid")

--- a/common/beemsg/nodestore.go
+++ b/common/beemsg/nodestore.go
@@ -128,17 +128,15 @@ func (store *NodeStore) GetMetaRootNode() *beegfs.Node {
 // SetMetaRootMirror sets the buddy-mirror node for the root metadata.
 // It resolves the given EntityId to a node UID, verifies it’s a meta node,
 // and stores it in the store.metaRootMirror field.
-func (store *NodeStore) SetMetaRootBuddyGroup(rootMirror beegfs.EntityIdSet) error {
+func (store *NodeStore) SetMetaRootBuddyGroup(rootMirror beegfs.EntityIdSet) {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
 
 	if rootMirror.Uid == 0 {
 		store.metaRootBuddyGroup = nil
-		return nil
 	}
 
 	store.metaRootBuddyGroup = &rootMirror
-	return nil
 }
 
 // GetMetaRootMirror returns a deep-copy of the buddy-mirror node for the root metadata.

--- a/common/beemsg/nodestore.go
+++ b/common/beemsg/nodestore.go
@@ -24,7 +24,7 @@ type NodeStore struct {
 	// The meta node which has the root inode
 	metaRootNode *beegfs.Node
 	// buddy‐mirror group for the root metadata
-	metaRootMirror *beegfs.EntityIdSet
+	metaRootBuddyGroup *beegfs.EntityIdSet
 
 	// The pointers to the connection stores
 	connsByUid map[beegfs.Uid]*util.NodeConns
@@ -128,36 +128,36 @@ func (store *NodeStore) GetMetaRootNode() *beegfs.Node {
 // SetMetaRootMirror sets the buddy-mirror node for the root metadata.
 // It resolves the given EntityId to a node UID, verifies it’s a meta node,
 // and stores it in the store.metaRootMirror field.
-func (store *NodeStore) SetMetaRootMirror(rootMirror beegfs.EntityIdSet) error {
+func (store *NodeStore) SetMetaRootBuddyGroup(rootMirror beegfs.EntityIdSet) error {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
 
 	if rootMirror.Uid == 0 {
-		store.metaRootMirror = nil
+		store.metaRootBuddyGroup = nil
 		return nil
 	}
 
-	store.metaRootMirror = &rootMirror
+	store.metaRootBuddyGroup = &rootMirror
 	return nil
 }
 
 // GetMetaRootMirror returns a deep-copy of the buddy-mirror node for the root metadata.
 // If no mirror has been set, it returns nil.
-func (store *NodeStore) GetMetaRootMirror() *beegfs.EntityIdSet {
+func (store *NodeStore) GetMetaRootBuddyGroup() *beegfs.EntityIdSet {
 	store.mutex.RLock()
 	defer store.mutex.RUnlock()
-	if store.metaRootMirror == nil {
+	if store.metaRootBuddyGroup == nil {
 		return nil
 	}
-	mirrorCopy := store.metaRootMirror.Clone()
+	mirrorCopy := store.metaRootBuddyGroup.Clone()
 	return &mirrorCopy
 }
 
 // HasMetaRootMirror returns true if a buddy-mirror node for the root metadata is set.
-func (store *NodeStore) HasMetaRootMirror() bool {
+func (store *NodeStore) HasMetaRootBuddyGroup() bool {
 	store.mutex.RLock()
 	defer store.mutex.RUnlock()
-	return store.metaRootMirror != nil
+	return store.metaRootBuddyGroup != nil
 }
 
 // Returns a single node from the store if the given EntityId exists. The returned Node is a deep

--- a/common/beemsg/nodestore.go
+++ b/common/beemsg/nodestore.go
@@ -23,6 +23,8 @@ type NodeStore struct {
 
 	// The meta node which has the root inode
 	metaRootNode *beegfs.Node
+	// buddy‐mirror group for the root metadata
+	metaRootMirror *beegfs.EntityIdSet
 
 	// The pointers to the connection stores
 	connsByUid map[beegfs.Uid]*util.NodeConns
@@ -121,6 +123,41 @@ func (store *NodeStore) GetMetaRootNode() *beegfs.Node {
 	}
 	rootMeta := store.metaRootNode.Clone()
 	return &rootMeta
+}
+
+// SetMetaRootMirror sets the buddy-mirror node for the root metadata.
+// It resolves the given EntityId to a node UID, verifies it’s a meta node,
+// and stores it in the store.metaRootMirror field.
+func (store *NodeStore) SetMetaRootMirror(rootMirror beegfs.EntityIdSet) error {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+
+	if rootMirror.Uid == 0 {
+		store.metaRootMirror = nil
+		return nil
+	}
+
+	store.metaRootMirror = &rootMirror
+	return nil
+}
+
+// GetMetaRootMirror returns a deep-copy of the buddy-mirror node for the root metadata.
+// If no mirror has been set, it returns nil.
+func (store *NodeStore) GetMetaRootMirror() *beegfs.EntityIdSet {
+	store.mutex.RLock()
+	defer store.mutex.RUnlock()
+	if store.metaRootMirror == nil {
+		return nil
+	}
+	mirrorCopy := store.metaRootMirror.Clone()
+	return &mirrorCopy
+}
+
+// HasMetaRootMirror returns true if a buddy-mirror node for the root metadata is set.
+func (store *NodeStore) HasMetaRootMirror() bool {
+	store.mutex.RLock()
+	defer store.mutex.RUnlock()
+	return store.metaRootMirror != nil
 }
 
 // Returns a single node from the store if the given EntityId exists. The returned Node is a deep

--- a/ctl/pkg/config/config.go
+++ b/ctl/pkg/config/config.go
@@ -443,11 +443,13 @@ func NodeStore(ctx context.Context) (*beemsg.NodeStore, error) {
 			return nil, err
 		}
 
-		rootMirror, err := beegfs.EntityIdSetFromProto(nodes.GetMetaRootBuddyGroup())
-		if err != nil {
-			return nil, fmt.Errorf("error parsing meta root mirror: %w", err)
+		if rootBuddy := nodes.GetMetaRootBuddyGroup(); rootBuddy != nil {
+			rootMirror, err := beegfs.EntityIdSetFromProto(rootBuddy)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing meta root mirror: %w", err)
+			}
+			nodeStore.SetMetaRootBuddyGroup(rootMirror)
 		}
-		nodeStore.SetMetaRootBuddyGroup(rootMirror)
 	}
 	return nodeStore, nil
 }

--- a/ctl/pkg/config/config.go
+++ b/ctl/pkg/config/config.go
@@ -443,11 +443,11 @@ func NodeStore(ctx context.Context) (*beemsg.NodeStore, error) {
 			return nil, err
 		}
 
-		rootMirror, err := beegfs.EntityIdSetFromProto(nodes.GetMetaRootMirror())
+		rootMirror, err := beegfs.EntityIdSetFromProto(nodes.GetMetaRootBuddyGroup())
 		if err != nil {
 			return nil, fmt.Errorf("error parsing meta root mirror: %w", err)
 		}
-		nodeStore.SetMetaRootMirror(rootMirror)
+		nodeStore.SetMetaRootBuddyGroup(rootMirror)
 	}
 	return nodeStore, nil
 }

--- a/ctl/pkg/config/config.go
+++ b/ctl/pkg/config/config.go
@@ -442,8 +442,13 @@ func NodeStore(ctx context.Context) (*beemsg.NodeStore, error) {
 		if err != nil {
 			return nil, err
 		}
-	}
 
+		rootMirror, err := beegfs.EntityIdSetFromProto(nodes.GetMetaRootMirror())
+		if err != nil {
+			return nil, fmt.Errorf("error parsing meta root mirror: %w", err)
+		}
+		nodeStore.SetMetaRootMirror(rootMirror)
+	}
 	return nodeStore, nil
 }
 

--- a/ctl/pkg/ctl/entry/entry.go
+++ b/ctl/pkg/ctl/entry/entry.go
@@ -319,7 +319,7 @@ func getEntryAndOwnerFromPathViaRPC(ctx context.Context, mappings *util.Mappings
 			EntryType:     1,
 			FeatureFlags: func() beegfs.EntryFeatureFlags {
 				var ff beegfs.EntryFeatureFlags
-				if store.HasMetaRootMirror() {
+				if store.HasMetaRootBuddyGroup() {
 					ff.SetBuddyMirrored()
 				}
 				return ff

--- a/ctl/pkg/ctl/entry/entry.go
+++ b/ctl/pkg/ctl/entry/entry.go
@@ -317,10 +317,13 @@ func getEntryAndOwnerFromPathViaRPC(ctx context.Context, mappings *util.Mappings
 			EntryID:       []byte("root"),
 			FileName:      []byte(filepath.Base(searchPath)),
 			EntryType:     1,
-			// TODO: https://github.com/thinkparq/ctl/issues/55
-			// Correctly set the FeatureFlags if the root metadata node is mirrored. Technically
-			// this doesn't matter, but may in the future if things change.
-			FeatureFlags: 0,
+			FeatureFlags: func() beegfs.EntryFeatureFlags {
+				var ff beegfs.EntryFeatureFlags
+				if store.HasMetaRootMirror() {
+					ff.SetBuddyMirrored()
+				}
+				return ff
+			}(),
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
-	github.com/thinkparq/protobuf v0.8.1
+	github.com/thinkparq/protobuf v0.8.2-0.20250709071028-24f942a79ffa
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.15.0
 	golang.org/x/sys v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/thinkparq/protobuf v0.8.1 h1:squ7j3zwvNBmy+gt2re1BE7RNKrYofq/KUSobN/adnI=
-github.com/thinkparq/protobuf v0.8.1/go.mod h1:AaUUy9mWaja/EggLSfzbKydAe+We+440z/6FdmPz5yI=
+github.com/thinkparq/protobuf v0.8.2-0.20250709071028-24f942a79ffa h1:KpyyeX04DSaqupPIOU/UgEAXwItdnHipj+IlrwgsZQQ=
+github.com/thinkparq/protobuf v0.8.2-0.20250709071028-24f942a79ffa/go.mod h1:AaUUy9mWaja/EggLSfzbKydAe+We+440z/6FdmPz5yI=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.36.0 h1:UumtzIklRBY6cI/lllNZlALOF5nNIzJVb16APdvgTXg=


### PR DESCRIPTION

### What does this PR do / why do we need it?
When running `--getentryinfo` the old CTL already knew when initially calling `findOwner()` if the root was buddy mirrored. Testing and [code analysis](https://github.com/ThinkParQ/beegfs-core/blob/2707eb514860d185724d3a6607b38d9a5a2fd60d/meta/source/net/message/storage/lookup/FindOwnerMsgEx.cpp#L25) shows for only the root meta node this flag is ignored, and the FindOwnerResponse will correctly set the feature flags in the response regardless if we specify zero here. Because it is possible this may change in the future we should add a flag to the node store to indicate when the root meta node is buddy mirrored.
### Related Issue(s)
https://github.com/ThinkParQ/beegfs-go/issues/27
### Where should the reviewer(s) start reviewing this? 
I'd suggest starting from the [nodestore.go](https://github.com/ThinkParQ/beegfs-go/pull/214/files#diff-39a21c510c7dac5900bbe416543d41eb2eae2a8e725b2ea7c9cdb92488b2fd55) changes first and then see the implementation inside the `entry.go`

### Are there any specific topics we should discuss before merging?
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Are there potential tradeoffs in the implementation?
-->

### What are the next steps after this PR? 
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Is further work planned in this area after this PR is merged? 
  * If so, what issue(s) and/or PRs is it tracked in? 
-->

### Checklist before merging:
*Required for all PRs.*

When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [ ] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [ ] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?

For more details refer to the [Go coding standards](https://github.com/ThinkParQ/beegfs-go/wiki/Getting-Started-with-Go#coding-standards) and the [pull request process](https://github.com/ThinkParQ/beegfs-go/wiki/Pull-Requests).
