### PR TITLE
feat(chunkbalance): initial implementation of chunkbalance for BeeGFS-go

### DIFF
--- a/common/beemsg/msg/chunkbalance.go
+++ b/common/beemsg/msg/chunkbalance.go
@@ -1,0 +1,51 @@
+package msg
+
+import (
+	"github.com/thinkparq/beegfs-go/common/beemsg/beeserde"
+)
+
+// StartChunkBalanceMsg represents a message for chunk balancing
+type StartChunkBalanceMsg struct {
+	TargetID      uint16
+	DestinationID uint16
+	EntryInfo     *EntryInfo
+	RelativePaths  *[]string
+}
+
+// Serialization of StartChunkBalanceMsg
+func (m *StartChunkBalanceMsg) Serialize(s *beeserde.Serializer) {
+	beeserde.SerializeInt(s, m.TargetID)
+	beeserde.SerializeInt(s, m.DestinationID)
+	m.EntryInfo.Serialize(s)
+	if m.RelativePaths != nil {
+		byteSlices := make([][]byte, len(*m.RelativePaths))
+		for i, str := range *m.RelativePaths {
+			byteSlices[i] = []byte(str)
+		}
+		beeserde.SerializeStringSeq(s, byteSlices)
+	}
+}
+
+// MsgId returns the message ID for StartChunkBalanceMsg
+func (m *StartChunkBalanceMsg) MsgId() uint16 {
+	return 2127
+}
+
+func (m *StartChunkBalanceRespMsg) Deserialize(d *beeserde.Deserializer) {
+	beeserde.DeserializeInt(d, &m.Result)
+}
+
+// StartChunkBalanceRespMsg represents a response message for starting chunk balance
+type StartChunkBalanceRespMsg struct {
+	Result int32
+}
+
+// Serialization of StartChunkBalanceRespMsg
+func (m *StartChunkBalanceRespMsg) Serialize(s *beeserde.Serializer) {
+	beeserde.SerializeInt(s, m.Result)
+}
+
+// MsgId returns the message ID for StartChunkBalanceRespMsg
+func (m *StartChunkBalanceRespMsg) MsgId() uint16 {
+	return 2128
+}

--- a/ctl/internal/cmd/chunkbalance/chunkbalance.go
+++ b/ctl/internal/cmd/chunkbalance/chunkbalance.go
@@ -1,0 +1,189 @@
+package chunkbalance
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/thinkparq/beegfs-go/common/beegfs"
+	"github.com/thinkparq/beegfs-go/common/types"
+	"github.com/thinkparq/beegfs-go/ctl/pkg/ctl/chunkbalance"
+	"github.com/thinkparq/beegfs-go/ctl/pkg/ctl/buddygroup"
+	"github.com/thinkparq/beegfs-go/ctl/pkg/ctl/entry"
+	"github.com/thinkparq/beegfs-go/ctl/pkg/util"
+	tgtBackend "github.com/thinkparq/beegfs-go/ctl/pkg/ctl/target"
+)
+
+type chunkBalanceCfg struct {
+	SourceID       uint16
+	DestinationID  uint16
+	Verbose        bool
+	NullDelim      bool
+	Mirrored       bool
+	ReadFromStdin  bool
+	UseMountedPath bool
+	stdinDelimiter string
+}
+
+func NewCmd() *cobra.Command {
+	chunkBalanceCfg := chunkBalanceCfg{}
+	cmd := &cobra.Command{
+		Use: "chunkbalance --sourceid=<sourceID> --destinationid=<destinationID> <path>",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("missing <path> argument. Usage: %s", cmd.Use)
+			}
+			return nil
+		},
+		Short:       "Balance chunks between storage targets",
+		Annotations: map[string]string{"authorization.AllowAllUsers": ""},
+		Long: `Balance chunks between storage targets.
+SPECIFYING PATHS:
+The <path> is required and can be a file or directory.
+You can specify the --sourceid and --destinationid to indicate the storage targets.
+The command can read multiple paths from stdin by using '-' as the <path> (e.g., 'cat path_list.txt | beegfs chunkbalance --sourceid=3 --destinationid=5 -').
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runChunkBalanceCmd(cmd, args, chunkBalanceCfg)
+		},
+	}
+
+	cmd.Flags().Uint16Var(&chunkBalanceCfg.SourceID, "sourceid", 0, "Balance chunks from the given source ID.")
+	cmd.Flags().Uint16Var(&chunkBalanceCfg.DestinationID, "destinationid", 0, "Balance chunks to the given destination ID.")
+	cmd.Flags().BoolVar(&chunkBalanceCfg.Verbose, "verbose", false, "Print verbose messages information.")
+	cmd.Flags().BoolVar(&chunkBalanceCfg.NullDelim, "null", false, "Assume that paths on stdin are delimited by a null character instead of newline.")
+	cmd.Flags().BoolVar(&chunkBalanceCfg.Mirrored, "mirrored", false, "Option to specify if the targetIDs are mirror buddy group IDs.")
+	cmd.Flags().BoolVar(&chunkBalanceCfg.UseMountedPath, "unmounted", false, "Specify relative paths to the root directory of a possibly unmounted BeeGFS.")
+	cmd.Flags().StringVar(&chunkBalanceCfg.stdinDelimiter, "stdin-delimiter", "\n", "Change the string delimiter used to determine individual paths when read from stdin (e.g., --stdin-delimiter=\"\\x00\" for NULL).")
+
+	return cmd
+}
+
+func runChunkBalanceCmd(cmd *cobra.Command, args []string, chunkBalanceCfg chunkBalanceCfg) error {
+
+	method, err := util.DeterminePathInputMethod(args, false, chunkBalanceCfg.stdinDelimiter)
+
+	if err != nil {
+		return err
+	}
+
+	getEntriesCfg := entry.GetEntriesCfg{}
+
+	// both these parameters need to be true to get the full info about the chunk path
+	getEntriesCfg.IncludeOrigMsg = true
+	getEntriesCfg.Verbose = true
+
+	entriesChan, errChan, err := entry.GetEntries(cmd.Context(), method, getEntriesCfg)
+	if err != nil {
+		return err
+	}
+
+	var multiErr types.MultiError
+
+run:
+	// Iterate over the entries received from entriesChan
+	for {
+		select {
+		case entryInfo, ok := <-entriesChan:
+			if !ok {
+				break run
+			}
+			entryVar := entryInfo
+
+			if chunkBalanceCfg.Mirrored {
+				groups, err := buddygroup.GetBuddyGroups(cmd.Context())
+				if err != nil {
+					return err
+				}
+				if len(groups) == 0 {
+					return fmt.Errorf("no mirrors configured")
+				}
+				foundSrc := false
+				foundDst := false
+
+				for _, group := range groups {
+					if group.NodeType == beegfs.Storage {
+						if strings.Contains(group.BuddyGroup.String(), fmt.Sprintf("%d", chunkBalanceCfg.SourceID)) {
+							foundSrc = true
+						}
+						if strings.Contains(group.BuddyGroup.String(), fmt.Sprintf("%d", chunkBalanceCfg.DestinationID)) {
+							foundDst = true
+						}
+					}
+				}
+
+				if !foundSrc {
+					return fmt.Errorf("mirrored option used but sourceID is not a valid mirrorGroupID")
+				}
+
+				if !foundDst {
+					return fmt.Errorf("mirrored option used but destinationID is not a valid mirrorGroupID")
+				}
+			} else {
+				// Validation logic for source and destination IDs
+				sourceIDValid, err := isValidTargetID(cmd.Context(), chunkBalanceCfg.SourceID)
+				if err != nil {
+					return fmt.Errorf("error validating sourceID (%d): %w", chunkBalanceCfg.SourceID, err)
+				}
+				if !sourceIDValid {
+					return fmt.Errorf("sourceID (%d) is NOT a target in the file system", chunkBalanceCfg.SourceID)
+				}
+
+				destinationIDValid, err := isValidTargetID(cmd.Context(), chunkBalanceCfg.DestinationID)
+				if err != nil {
+					return fmt.Errorf("error validating destinationID (%d): %w", chunkBalanceCfg.DestinationID, err)
+				}
+				if !destinationIDValid {
+					return fmt.Errorf("destinationID (%d) is NOT a target in the file system", chunkBalanceCfg.DestinationID)
+				}
+
+				// Check if source and destination IDs are in the pattern of the file
+				sourceIDInPattern := isIDInPattern(entryVar.Entry.Pattern.TargetIDs, chunkBalanceCfg.SourceID)
+				if !sourceIDInPattern {
+					return fmt.Errorf("sourceID (%d) is NOT a target for the required path", chunkBalanceCfg.SourceID)
+				}
+
+				destinationIDInPattern := isIDInPattern(entryVar.Entry.Pattern.TargetIDs, chunkBalanceCfg.DestinationID)
+				if destinationIDInPattern {
+					return fmt.Errorf("destinationID (%d) is already a target for the required path", chunkBalanceCfg.DestinationID)
+				}
+			}
+
+			err_chunkbalance := chunkbalance.ExecuteChunkBalance(cmd.Context(), entryVar, chunkBalanceCfg.SourceID, chunkBalanceCfg.DestinationID)
+			if err_chunkbalance != nil {
+				fmt.Println("Chunk balance failed:", err)
+			}
+
+		case err, ok := <-errChan:
+			if ok {
+
+				multiErr.Errors = append(multiErr.Errors, err)
+			}
+		}
+	}
+	return nil
+}
+
+func isIDInPattern(targetIDs []uint16, userSpecifiedID uint16) bool {
+	for _, v := range targetIDs {
+		if v == userSpecifiedID {
+			return true
+		}
+	}
+	return false
+}
+
+func isValidTargetID(ctx context.Context, targetID uint16) (bool, error) {
+	storageTargets, err := tgtBackend.GetTargets(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	for _, tgt := range storageTargets {
+		if uint16(tgt.Target.LegacyId.NumId) == targetID {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/ctl/internal/cmd/root.go
+++ b/ctl/internal/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/benchmark"
 	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/buddygroup"
+	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/chunkbalance"
 	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/copy"
 	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/debug"
 	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/entry"
@@ -105,6 +106,7 @@ Thank you for using BeeGFS and supporting its ongoing development! 🐝
 	cmd.AddCommand(index.NewCmd())
 	cmd.AddCommand(copy.NewCopyCmd())
 	cmd.AddCommand(debug.NewCmd())
+	cmd.AddCommand(chunkbalance.NewCmd())
 
 	// This must run AFTER all commands are added.
 	wrapAllCommands(cmd)

--- a/ctl/pkg/ctl/chunkbalance/chunkbalance.go
+++ b/ctl/pkg/ctl/chunkbalance/chunkbalance.go
@@ -1,0 +1,47 @@
+package chunkbalance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/thinkparq/beegfs-go/common/beemsg/msg"
+	"github.com/thinkparq/beegfs-go/ctl/pkg/config"
+	"github.com/thinkparq/beegfs-go/ctl/pkg/ctl/entry"
+)
+
+func ExecuteChunkBalance(ctx context.Context, entryVar *entry.GetEntryCombinedInfo, SourceID uint16, DestinationID uint16) error {
+
+	store, err := config.NodeStore(ctx)
+	if err != nil {
+		return fmt.Errorf("error accessing the node store: %w", err)
+	}
+
+	metaRoot := store.GetMetaRootNode()
+	if metaRoot == nil {
+		return fmt.Errorf("unable to proceed without a working root metadata server")
+	}
+
+	currentNode := *metaRoot
+
+	chunkPathList := []string{entryVar.Entry.Verbose.ChunkPath}
+	fmt.Println(chunkPathList)
+
+	// Create the ChunkBalanceMsg
+	chunkBalanceMsgPrep := &msg.StartChunkBalanceMsg{
+		TargetID:      SourceID,
+		DestinationID: DestinationID,
+		EntryInfo:     entryVar.Entry.OrigEntryInfoMsg,
+		RelativePaths: &chunkPathList,
+	}
+	var resp = &msg.StartChunkBalanceRespMsg{}
+
+	err = store.RequestTCP(ctx, currentNode.Uid, chunkBalanceMsgPrep, resp)
+	if err != nil {
+		return fmt.Errorf("error sending chunk balance msg: %w", err)
+	}
+
+	if resp.Result != 0 {
+		return fmt.Errorf("failed to start chunk balance, result: %d", resp.Result)
+	}
+	return nil
+}

--- a/ctl/pkg/ctl/entry/create.go
+++ b/ctl/pkg/ctl/entry/create.go
@@ -89,7 +89,7 @@ func generateAndVerifyMakeFileReq(userCfg *CreateEntryCfg, parent *GetEntryCombi
 		// get a vague internal error).
 		Mode:       (*userCfg.Permissions & 07777) | syscall.S_IFREG,
 		Umask:      0000,
-		ParentInfo: *parent.Entry.origEntryInfoMsg,
+		ParentInfo: *parent.Entry.OrigEntryInfoMsg,
 		// Start with the parent pattern and RST config.
 		Pattern: parent.Entry.Pattern.StripePattern,
 		RST:     parent.Entry.Remote.RemoteStorageTarget,
@@ -271,7 +271,7 @@ func generateAndVerifyMkDirRequest(userCfg *CreateEntryCfg, parent *GetEntryComb
 		// get a vague internal error).
 		Mode:           (*userCfg.Permissions & 07777) | syscall.S_IFDIR,
 		Umask:          0000,
-		ParentInfo:     *parent.Entry.origEntryInfoMsg,
+		ParentInfo:     *parent.Entry.OrigEntryInfoMsg,
 		NoMirror:       userCfg.DirCfg.NoMirror,
 		PreferredNodes: make([]uint16, 0, len(userCfg.DirCfg.Nodes)),
 	}

--- a/ctl/pkg/ctl/entry/entry.go
+++ b/ctl/pkg/ctl/entry/entry.go
@@ -67,7 +67,7 @@ type Entry struct {
 	// Only populated if getEntries() is called with includeOrigMsg. This is mostly useful for other
 	// modes like set pattern that need to include the EntryInfo message so they don't need to recreate
 	// the message from scratch.
-	origEntryInfoMsg *msg.EntryInfo
+	OrigEntryInfoMsg *msg.EntryInfo
 }
 
 // patternConfig embeds the BeeMsg defined stripe pattern alongside fields that map various
@@ -236,7 +236,7 @@ func GetEntry(ctx context.Context, mappings *util.Mappings, cfg GetEntriesCfg, p
 	}
 	entryWithParent.Entry = newEntry(mappings, entry, ownerNode, *resp)
 	if cfg.IncludeOrigMsg {
-		entryWithParent.Entry.origEntryInfoMsg = &entry
+		entryWithParent.Entry.OrigEntryInfoMsg = &entry
 	}
 
 	if cfg.Verbose {
@@ -256,7 +256,7 @@ func GetEntry(ctx context.Context, mappings *util.Mappings, cfg GetEntriesCfg, p
 				entryWithParent.Parent = newEntry(mappings, parentEntry, parentOwner, msg.GetEntryInfoResponse{})
 				entryWithParent.Entry.Verbose = newVerbose(resp.Path, entryWithParent.Entry, entryWithParent.Parent)
 				if cfg.IncludeOrigMsg {
-					entryWithParent.Parent.origEntryInfoMsg = &parentEntry
+					entryWithParent.Parent.OrigEntryInfoMsg = &parentEntry
 				}
 			}
 		} else {

--- a/ctl/pkg/ctl/entry/migrate.go
+++ b/ctl/pkg/ctl/entry/migrate.go
@@ -406,7 +406,7 @@ func migrate(ctx context.Context, client filesystem.Provider, originalStat os.Fi
 		// if a mask was set (after the ownership was reset on the new file). But in general this is
 		// the safest approach.
 		Umask:       0000,
-		ParentInfo:  *entry.Parent.origEntryInfoMsg,
+		ParentInfo:  *entry.Parent.OrigEntryInfoMsg,
 		NewFileName: []byte(tempFileBase),
 		Pattern:     newPattern,
 		RST:         entry.Entry.Remote.RemoteStorageTarget,

--- a/ctl/pkg/ctl/entry/set.go
+++ b/ctl/pkg/ctl/entry/set.go
@@ -142,7 +142,7 @@ func setEntry(ctx context.Context, mappings *util.Mappings, cfg SetEntryCfg, pat
 func handleDirectory(ctx context.Context, mappings *util.Mappings, store *beemsg.NodeStore, entry *GetEntryCombinedInfo, cfg SetEntryCfg, path string) (SetEntryResult, error) {
 	// Start with the current settings for this entry:
 	request := &msg.SetDirPatternRequest{
-		EntryInfo: *entry.Entry.origEntryInfoMsg,
+		EntryInfo: *entry.Entry.OrigEntryInfoMsg,
 		Pattern:   entry.Entry.Pattern.StripePattern,
 		RST:       entry.Entry.Remote.RemoteStorageTarget,
 	}
@@ -224,7 +224,7 @@ func handleFile(ctx context.Context, store *beemsg.NodeStore, entry *GetEntryCom
 
 	// Start with the current settings for this entry
 	request := &msg.SetFilePatternRequest{
-		EntryInfo: *entry.Entry.origEntryInfoMsg,
+		EntryInfo: *entry.Entry.OrigEntryInfoMsg,
 		RST:       entry.Entry.Remote.RemoteStorageTarget,
 	}
 


### PR DESCRIPTION
This is the preliminary implementation of chunk balance mode for go, to be able to test the module in BeeGFS-core.

It includes (incomplete list):
- de- and serialization of msg for BeeGFS-core,
- buddy mirroring option,
- possibility to accept multiple paths,
- flag to specify delimiter for multiple inputs,
- using default function to handle absolute/relative paths.

Caveat: I modified the property of origEntryInfoMsg from entryInfo, to make it exportable. Maybe the code needs to be modified in order to revert this change.