### PR TITLE
feat(ctl): add --verify-remote flag to remote status

### DIFF
--- a/common/rst/errors.go
+++ b/common/rst/errors.go
@@ -19,6 +19,7 @@ var (
 	ErrJobFailedPrecondition        = errors.New("job failed precondition")
 	ErrJobNotAllowed                = errors.New("submitting a new job is not allowed in this state")
 	ErrJobAlreadyExists             = errors.New("no changes to entry detected since the last job")
+	ErrEntryNotFound                = errors.New("entry was not found")
 	ErrFileHasNoRSTs                = errors.New("entry does not have any remote storage target IDs configured")
 	ErrFileHasAmbiguousRSTs         = errors.New("ambiguous remote source! There must only be one rst for downloads")
 	ErrFileOpenForWriting           = errors.New("entry is opened for writing on one or more clients")
@@ -27,6 +28,7 @@ var (
 	ErrFileTypeUnsupported          = errors.New("entry type is not supported")
 	ErrOffloadFileCreate            = errors.New("unable to create offload file")
 	ErrOffloadFileUrlMismatch       = errors.New("offload file url does not match")
+	ErrOffloadFileNotReadable       = errors.New("unable to read stub file")
 	ErrRSTUnavailable               = errors.New("remote target is unavailable")
 )
 

--- a/common/rst/rst.go
+++ b/common/rst/rst.go
@@ -854,3 +854,18 @@ func GetLastCompletedJobFromRst(ctx context.Context, inMountPath string, rstId u
 
 	return lastCompletedJob, nil
 }
+
+func GetRstMap(ctx context.Context, mountPoint filesystem.Provider, rstConfigMap map[uint32]*flex.RemoteStorageTarget) (map[uint32]Provider, error) {
+	rstMap := make(map[uint32]Provider)
+	for rstId, rstConfig := range rstConfigMap {
+		if !IsValidRstId(rstId) {
+			continue
+		}
+		rst, err := New(ctx, rstConfig, mountPoint)
+		if err != nil {
+			return nil, fmt.Errorf("encountered an error setting up remote storage target: %w", err)
+		}
+		rstMap[rstId] = rst
+	}
+	return rstMap, nil
+}

--- a/common/rst/s3.go
+++ b/common/rst/s3.go
@@ -443,7 +443,7 @@ func (r *S3Client) prepareJobRequest(ctx context.Context, cfg *flex.JobRequestCf
 	}
 
 	if !IsFileLocked(lockedInfo) {
-		if lockedInfo, writeLockSet, _, err = GetLockedInfo(ctx, r.mountPoint, cfg, cfg.Path); err != nil {
+		if lockedInfo, writeLockSet, _, err = GetLockedInfo(ctx, r.mountPoint, cfg, cfg.Path, false); err != nil {
 			err = fmt.Errorf("%w: %s", ErrJobFailedPrecondition, fmt.Sprintf("failed to acquire lock: %s", err.Error()))
 			return
 		}
@@ -489,9 +489,9 @@ func (r *S3Client) getObjectMetadata(ctx context.Context, key string, keyMustExi
 	resp, err := r.client.HeadObject(ctx, headObjectInput)
 	if err != nil {
 		var apiErr smithy.APIError
-		if !keyMustExist && errors.As(err, &apiErr) {
+		if errors.As(err, &apiErr) {
 			if apiErr.ErrorCode() == "NotFound" || apiErr.ErrorCode() == "NoSuchKey" {
-				return 0, time.Time{}, nil
+				return 0, time.Time{}, os.ErrNotExist
 			}
 		}
 		return 0, time.Time{}, err

--- a/ctl/pkg/ctl/entry/entry.go
+++ b/ctl/pkg/ctl/entry/entry.go
@@ -19,6 +19,7 @@ import (
 type GetEntriesCfg struct {
 	Verbose        bool
 	IncludeOrigMsg bool
+	FilterExpr     string
 }
 
 // GetEntryCombinedInfo returns all information needed to print details about an entry in BeeGFS.
@@ -221,7 +222,7 @@ func newVerbose(pathInfo msg.PathInfo, entry Entry, parent Entry) Verbose {
 // an error. The error channel returns any errors walking the directory or getting the entry info.
 // This approach allows callers to decide when there is an error if they should immediately
 // terminate, or continue writing out the remaining entries before handling the error.
-func GetEntries(ctx context.Context, pm util.PathInputMethod, cfg GetEntriesCfg) (<-chan *GetEntryCombinedInfo, <-chan error, error) {
+func GetEntries(ctx context.Context, pm util.PathInputMethod, cfg GetEntriesCfg) (<-chan *GetEntryCombinedInfo, func() error, error) {
 	log, _ := config.GetLogger()
 
 	mappings, err := util.GetMappings(ctx)
@@ -237,7 +238,7 @@ func GetEntries(ctx context.Context, pm util.PathInputMethod, cfg GetEntriesCfg)
 		return GetEntry(ctx, mappings, cfg, path)
 	}
 
-	return util.ProcessPaths(ctx, pm, true, processEntry)
+	return util.ProcessPaths(ctx, pm, true, processEntry, util.FilterExpr(cfg.FilterExpr))
 }
 
 // GetEntry retrieves GetEntryCombinedInfo based on the provided information. If mappings is nil

--- a/ctl/pkg/ctl/entry/migrate.go
+++ b/ctl/pkg/ctl/entry/migrate.go
@@ -129,7 +129,7 @@ type migration struct {
 // WARNING: For MigrateEntries to work correctly it sets the umask to zero because it needs to be
 // able to create files with any permissions. If needed, the caller should reset the umask once all
 // entries are migrated.
-func MigrateEntries(ctx context.Context, pm util.PathInputMethod, cfg MigrateCfg) (<-chan MigrateResult, <-chan error, error) {
+func MigrateEntries(ctx context.Context, pm util.PathInputMethod, cfg MigrateCfg) (<-chan MigrateResult, func() error, error) {
 	log, _ := config.GetLogger()
 
 	// Set the umask to 0 ensuring files can be created via ioctl with exact permissions. Without

--- a/ctl/pkg/ctl/entry/refresh.go
+++ b/ctl/pkg/ctl/entry/refresh.go
@@ -19,7 +19,7 @@ type RefreshEntryResult struct {
 	EntryID string
 }
 
-func RefreshEntriesInfo(ctx context.Context, paths util.PathInputMethod) (<-chan *RefreshEntryResult, <-chan error, error) {
+func RefreshEntriesInfo(ctx context.Context, paths util.PathInputMethod) (<-chan *RefreshEntryResult, func() error, error) {
 	log, _ := config.GetLogger()
 	store, err := config.NodeStore(ctx)
 	if err != nil {

--- a/ctl/pkg/ctl/entry/set.go
+++ b/ctl/pkg/ctl/entry/set.go
@@ -33,6 +33,8 @@ type SetEntryCfg struct {
 	RemoteCooldownSecs *uint16
 	AccessFlags        *beegfs.AccessFlags
 	DataState          *beegfs.DataState
+
+	FilterExpr string
 }
 
 // Validates the effective UID has permissions to make the requested updates.
@@ -80,7 +82,7 @@ type SetEntryResult struct {
 	Updates SetEntryCfg
 }
 
-func SetEntries(ctx context.Context, pm util.PathInputMethod, cfg SetEntryCfg) (<-chan SetEntryResult, <-chan error, error) {
+func SetEntries(ctx context.Context, pm util.PathInputMethod, cfg SetEntryCfg) (<-chan SetEntryResult, func() error, error) {
 	log, _ := config.GetLogger()
 
 	// Validate new configuration once:
@@ -101,7 +103,7 @@ func SetEntries(ctx context.Context, pm util.PathInputMethod, cfg SetEntryCfg) (
 		return setEntry(ctx, mappings, cfg, path)
 	}
 
-	return util.ProcessPaths(ctx, pm, false, processEntry)
+	return util.ProcessPaths(ctx, pm, false, processEntry, util.FilterExpr(cfg.FilterExpr))
 }
 
 // setEntry applies the SetEntryRequest to the specified searchPath. WARNING: This function is meant

--- a/ctl/pkg/ctl/rst/errors.go
+++ b/ctl/pkg/ctl/rst/errors.go
@@ -1,7 +1,0 @@
-package rst
-
-import "errors"
-
-var (
-	ErrEntryNotFound = errors.New("entry was not found")
-)

--- a/ctl/pkg/ctl/rst/getstubcontents.go
+++ b/ctl/pkg/ctl/rst/getstubcontents.go
@@ -1,0 +1,16 @@
+package rst
+
+import (
+	"context"
+
+	"github.com/thinkparq/beegfs-go/ctl/pkg/config"
+	"github.com/thinkparq/protobuf/go/beeremote"
+)
+
+func GetStubContents(ctx context.Context, path string) (*beeremote.GetStubContentsResponse, error) {
+	beeRemote, err := config.BeeRemoteClient()
+	if err != nil {
+		return nil, err
+	}
+	return beeRemote.GetStubContents(ctx, &beeremote.GetStubContentsRequest{Path: path})
+}

--- a/ctl/pkg/ctl/rst/status.go
+++ b/ctl/pkg/ctl/rst/status.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -11,18 +13,28 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/thinkparq/beegfs-go/common/filesystem"
+	"github.com/thinkparq/beegfs-go/common/rst"
 	"github.com/thinkparq/beegfs-go/ctl/pkg/config"
 	"github.com/thinkparq/beegfs-go/ctl/pkg/ctl/entry"
 	"github.com/thinkparq/beegfs-go/ctl/pkg/util"
 	"github.com/thinkparq/protobuf/go/beeremote"
+	"github.com/thinkparq/protobuf/go/flex"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type GetStatusCfg struct {
+	// By default the sync status is based on job entry database. However, if VerifyRemote==true
+	// then sync status will be verified with the remote storage targets.
+	VerifyRemote bool
 	// By default the sync status for each path is determined by the remote targets configured using
 	// BeeGFS metadata. Optionally check the status of each path with specific RemoteTargets and
 	// ignore any remote targets configured via BeeGFS metadata.
 	RemoteTargets []uint32
+	FilterExpr    string
 	// Usually set based on viper.GetBool(config.DebugKey). This is passed in using the GetStatusCfg
 	// to avoid an expensive call to Viper for every path.
 	Debug bool
@@ -32,6 +44,7 @@ type GetStatusResult struct {
 	Path       string
 	SyncStatus PathStatus
 	SyncReason string
+	Warning    bool
 }
 
 type PathStatus int
@@ -99,134 +112,422 @@ func (s PathStatus) String() string {
 
 // GetStatus accepts a context, an input method that controls how paths are provided, and a
 // GetStatusCfg that controls how the status is checked. If anything goes wrong during the initial
-// setup an error will be returned, otherwise GetStatus will immediately return channels where
-// results and errors are written asynchronously. The GetStatusResults channel will return the
-// status of each path, and be close once all requested paths have been checked, or after an error.
-// The error channel returns any errors walking the directory or getting jobs for each path. This
-// approach allows callers to decide when there is an error if they should immediately terminate, or
-// continue writing out the remaining paths before handling the error.
-//
-// Note this is setup more similarly to the entry.GetEntries() function rather than other functions
-// in the rst package.
-func GetStatus(ctx context.Context, pm util.PathInputMethod, cfg GetStatusCfg) (<-chan *GetStatusResult, <-chan error, error) {
+// setup an error will be returned, otherwise GetStatus returns a receive‑only channel that emits a
+// *GetStatusResult for each path, and a wait function that blocks until all processing finishes and
+// returns any error encountered. Processing respects ctx cancellation, and remote verification is
+// enabled when cfg.VerifyRemote is true.
+func GetStatus(ctx context.Context, pm util.PathInputMethod, cfg GetStatusCfg) (<-chan *GetStatusResult, func() error, error) {
+	// Reserve one core for another Goroutine walking the paths and retrieving job information from
+	// the database. If there is only a single core don't set the numWorkers less than one.
+	numWorkers := max(viper.GetInt(config.NumWorkersKey)-1, 1)
 
-	mappings, err := util.GetMappings(ctx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to fetch required mappings: %w", err)
+	pathGroup, pathGroupCtx := errgroup.WithContext(ctx)
+	paths := make(chan string, numWorkers*4)
+	pathGroup.Go(func() error {
+		defer close(paths)
+		return util.StreamPaths(pathGroupCtx, pm, paths, util.RecurseLexicographically(true), util.FilterExpr(cfg.FilterExpr))
+	})
+
+	// First path is required for setting up statusInfos walk and workers to initiate database
+	// requests and acquire BeeGFS client.
+	var ok bool
+	var initialFsPath string
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case initialFsPath, ok = <-paths:
+		if !ok {
+			return nil, nil, fmt.Errorf("no paths found")
+		}
+
 	}
 
-	var dbChan = new(chan *GetJobsResponse)
-	var dbPath *GetJobsResponse
-	dbOk := new(bool)
+	statusInfosGroup, statusInfosGroupCtx := errgroup.WithContext(ctx)
+	statusInfos := make(chan statusInfo, numWorkers*4)
+	statusInfosGroup.Go(func() (err error) {
+		defer close(statusInfos)
+		defer func() {
+			err = util.WaitForLastStage(pathGroup.Wait, err, paths)
+		}()
 
-	return util.ProcessPaths(ctx, pm, true, func(path string) (*GetStatusResult, error) {
-		return matchPathAndGetStatus(ctx, cfg, path, mappings, dbChan, &dbPath, dbOk, pm.Get())
-	}, util.RecurseLexicographically(true))
+		inputType := pm.Get()
+		if cfg.VerifyRemote {
+			return statusInfoVerifyRemoteWalk(statusInfosGroupCtx, initialFsPath, paths, statusInfos)
+		} else if inputType == util.PathInputRecursion {
+			return statusInfoRecursiveWalk(statusInfosGroupCtx, initialFsPath, paths, statusInfos)
+		}
+		return statusInfoIterativeWalk(statusInfosGroupCtx, inputType, initialFsPath, paths, statusInfos)
+	})
+
+	workerGroup, workerGroupCtx := errgroup.WithContext(ctx)
+	results := make(chan *GetStatusResult, numWorkers*4)
+	workerGroup.Go(func() (err error) {
+		defer close(results)
+		defer func() {
+			err = util.WaitForLastStage(statusInfosGroup.Wait, err, statusInfos)
+		}()
+		err = runWorkers(workerGroupCtx, cfg, initialFsPath, statusInfos, results, numWorkers)
+		return err
+	})
+
+	return results, workerGroup.Wait, nil
 }
 
-// matchPathAndGetStatus expects to be called one or more times by util.ProcessPaths(). It adjusts
-// its behavior to optimize performance based on PathInputType:
+// statusInfoVerifyRemoteWalk is used when --verify-remote flag is specified.
 //
-// If PathInputType is recurse: GetJobs() is called once treating the first fsPath as a prefix and
-// reusing the gRPC stream for subsequent calls. It expects to receive lexicographically increasing
-// fsPaths, and will handle matching fsPaths with corresponding dbPaths, advancing the dbPath is
-// needed until it finds a match, or determines there is no entry in the Remote database for that
-// fsPath. For this mode to work correctly fsPaths and dbPaths be provided in stable lexicographical
-// order. If an fsPath is received that is "smaller" than the previous fsPath then the database will
-// always return "not found". This should never happen when used from util.ProcessPaths().
+// Each fsPath will be passed to the statusWorkers where the remote storage target(s) will be check
+// for current sync status using getPathStatusFromTarget().
+func statusInfoVerifyRemoteWalk(ctx context.Context, fsPath string, paths <-chan string, statusInfos chan<- statusInfo) error {
+	var ok bool
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case statusInfos <- statusInfo{fsPath: fsPath}:
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case fsPath, ok = <-paths:
+			if !ok {
+				return nil
+			}
+		}
+	}
+}
+
+// statusInfoIterativeWalk is used when inputType is either stdin or list.
 //
-// If PathInputType is stdin or list: GetJobs() is called for each fsPath. This allows paths to be
-// provided in any order, but is not as efficient as the recurse mode when checking large directory
-// trees. It is however more efficient than the recurse mode when checking files in directories that
-// contain deep sub-directories, and only the status of the top-level files is needed.
+// GetJobs() is called for each fsPath. This allows paths to be provided in any order, but is not as
+// efficient as the recurse mode when checking large directory trees. It is however more efficient
+// than the recurse mode when checking files in directories that contain deep sub-directories, and
+// only the status of the top-level files is needed.
 //
-// Regardless if a DB match is found, the status of each fsPath is checked using getPathStatus().
-func matchPathAndGetStatus(
-	// The first time checkPathStatus is called it will call GetJobs() with this context to setup
-	// the dbChan. Because it is unknown how many times checkPathStatus will be called it is not
-	// responsible for closing the GetJobs gRPC stream which is instead done by cancelling this
-	// context. It is up to the caller to ensure this context is cancelled once all fsPaths have
-	// been checked, which if the provided context is cmd.Context() will happen automatically.
+// Regardless if a database match is found, the information is passed to the statusWorkers where
+// the status of each fsPath is checked using getPathStatusFromDatabase().
+func statusInfoIterativeWalk(ctx context.Context, inputType util.PathInputType, fsPath string, paths <-chan string, statusInfos chan<- statusInfo) error {
+	log, _ := config.GetLogger()
+	log.Debug("attempting to retrieve a single path from the remote database", zap.String("fsPath", fsPath), zap.Any("inputType", inputType))
+
+	var ok bool
+	for {
+		response := make(chan *GetJobsResponse, 1)
+		if err := GetJobs(ctx, GetJobsConfig{Path: fsPath, exactPath: true}, response); err != nil {
+			return err
+		}
+
+		dbPathInfo := <-response
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case statusInfos <- statusInfo{fsPath: fsPath, jobsResponse: dbPathInfo}:
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case fsPath, ok = <-paths:
+			if !ok {
+				return nil
+			}
+		}
+	}
+}
+
+// statusInfoRecursiveWalk is used when inputType is recurse.
+//
+// GetJobs() is called once treating the first fsPath as a prefix and reusing the gRPC stream for
+// subsequent calls. It expects to receive lexicographically increasing fsPaths, and will handle
+// matching fsPaths with corresponding dbPaths, advancing the dbPath is needed until it finds a
+// match, or determines there is no entry in the Remote database for that fsPath. For this mode to
+// work correctly fsPaths and dbPaths be provided in stable lexicographical order. If an fsPath is
+// received that is "smaller" than the previous fsPath then the database will always return "not
+// found". This should never happen when used from util.ProcessPaths().
+//
+// Regardless if a database match is found, the information is passed to the statusWorkers where the
+// status of each fsPath is checked using getPathStatusFromDatabase().
+func statusInfoRecursiveWalk(ctx context.Context, fsPath string, paths <-chan string, statusInfos chan<- statusInfo) error {
+	log, _ := config.GetLogger()
+
+	dbChan := make(chan *GetJobsResponse, 1024)
+	if err := GetJobs(ctx, GetJobsConfig{Path: fsPath, Recurse: true}, dbChan); err != nil {
+		return err
+	}
+
+	dbPath, dbOk := <-dbChan
+	if !dbOk {
+		// No database entries were found for the path so just return statusInfo with fsPath.
+		var fsOk bool
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case statusInfos <- statusInfo{fsPath: fsPath}:
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case fsPath, fsOk = <-paths:
+				if !fsOk {
+					return fmt.Errorf("directory %s does not appear to contain any synchronized files", fsPath)
+				}
+			}
+		}
+	} else if dbPath != nil && errors.Is(dbPath.Err, ErrGetJobsStreamUnavailable) {
+		return dbPath.Err
+	}
+	log.Debug("streaming multiple paths from the Remote database", zap.Any("firstDBPath", dbPath), zap.Bool("dbOk", dbOk))
+
+	var fsOk bool
+	for {
+		// When recursing we need to determine the relation of the fsPath and current dbPath and adjust
+		// accordingly before getting the path status.
+		for dbOk && fsPath > dbPath.Path {
+			// dbPath is behind, advance the dbChan until it is ahead or equal.
+
+			// TODO (https://github.com/ThinkParQ/beegfs-go/issues/194): These files can be
+			// deleted because the current file system path is lexicographically greater than
+			// the current database path which means that the database entry is for a deleted
+			// file.
+			dbPath, dbOk = <-dbChan
+			if dbPath != nil && errors.Is(dbPath.Err, ErrGetJobsStreamUnavailable) {
+				return dbPath.Err
+			}
+		}
+
+		var info statusInfo
+		if !dbOk || fsPath < dbPath.Path {
+			// The dbPath is ahead indicating no match in the DB was found for this fsPath. Call
+			// getPathStatus with a nil dbPath to still determine if the fsPath has no RST or has RSTs
+			// but has never been pushed.
+			info = statusInfo{fsPath: fsPath}
+
+		} else {
+			// Match found, advance dbChan for the next path and get the result for this path.
+			currentDbPath := dbPath
+			dbPath, dbOk = <-dbChan
+			if dbPath != nil && errors.Is(dbPath.Err, ErrGetJobsStreamUnavailable) {
+				return dbPath.Err
+			}
+			info = statusInfo{fsPath: fsPath, jobsResponse: currentDbPath}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case statusInfos <- info:
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case fsPath, fsOk = <-paths:
+			if !fsOk {
+				return nil
+			}
+		}
+	}
+}
+
+type statusInfo struct {
+	fsPath       string
+	jobsResponse *GetJobsResponse
+}
+
+func runWorkers(ctx context.Context, cfg GetStatusCfg, initialFsPath string, statusInfos <-chan statusInfo, results chan<- *GetStatusResult, numWorkers int) error {
+	mappings, err := util.GetCachedMappings(ctx, false)
+	if err != nil {
+		return fmt.Errorf("unable to fetch required mappings: %w", err)
+	}
+	mountPoint, err := config.BeeGFSClient(initialFsPath)
+	if err != nil {
+		return fmt.Errorf("unable to acquire BeeGFS client: %w", err)
+	}
+
+	var rstMap map[uint32]rst.Provider
+	if cfg.VerifyRemote {
+		rstMap, err = rst.GetRstMap(ctx, mountPoint, mappings.RstIdToConfig)
+		if err != nil {
+			return fmt.Errorf("unable to get rst mappings: %w", err)
+		}
+	}
+
+	g, gCtx := errgroup.WithContext(ctx)
+	for range numWorkers {
+		g.Go(func() error {
+			return worker(gCtx, cfg, mountPoint, rstMap, statusInfos, results)
+		})
+	}
+	return g.Wait()
+
+}
+
+func worker(
 	ctx context.Context,
 	cfg GetStatusCfg,
-	fsPath string,
-	mappings *util.Mappings,
-	// dbChan, dbPath, dbOk, and dbStreaming are used to persist dbChan state when recursively
-	// checking status for multiple paths. If the current fsPath does not match the dbPath they hold
-	// the state of dbChan so that dbPath can be used when checking status for subsequent fsPaths.
-	//
-	// dbChan is a pointer to a channel. While channels are reference types, when passed to a
-	// function by value, a new local copy of the reference is created, however since we want to be
-	// able to assign dbChan to a new channel inside the function it must passed as a pointer. This
-	// must be initially nil to ensure the dbChan can be properly initialized by the first path.
-	dbChan *chan *GetJobsResponse,
-	// dbPath must be a double pointer (**GetJobsResponse) because we need to update the caller’s
-	// pointer reference with the *GetJobsResponse retrieved from the dbChan, not just modify its
-	// contents. If we used a single pointer (`*GetJobsResponse`), the function would only modify a
-	// copy of the pointer and NOT the caller’s original variable.
-	dbPath **GetJobsResponse,
-	// dbOk only needs a single pointer (*bool) because we are modifying a boolean value, which is a
-	// primitive type and does not require reference updates.
-	dbOk *bool,
-	inputType util.PathInputType,
-) (*GetStatusResult, error) {
-
-	if *dbChan == nil {
-		log, _ := config.GetLogger()
-		// When not recursing, dbChan is always left nil and we just use a temporary channel to get
-		// back at most a single dbPath for each fsPath.
-		if inputType != util.PathInputRecursion {
-			log.Debug("attempting to retrieve a single path from the remote database", zap.String("fsPath", fsPath), zap.Any("inputType", inputType))
-			c := make(chan *GetJobsResponse, 1)
-			if err := GetJobs(ctx, GetJobsConfig{Path: fsPath, exactPath: true}, c); err != nil {
-				return nil, err
+	mountPoint filesystem.Provider,
+	rstMap map[uint32]rst.Provider,
+	statusInfos <-chan statusInfo,
+	results chan<- *GetStatusResult,
+) error {
+	var err error
+	var result *GetStatusResult
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case statusInfo, ok := <-statusInfos:
+			if !ok {
+				return nil
 			}
-			*dbPath, *dbOk = <-c
-			return getPathStatus(ctx, cfg, mappings, fsPath, *dbPath)
-		}
-		// When recursing start streaming back jobs from Remote to a reusable dbChan.
-		log.Debug("attempting to stream multiple paths from the Remote database", zap.String("fsPath", fsPath), zap.Any("inputType", inputType))
-		*dbChan = make(chan *GetJobsResponse, 1024)
-		if err := GetJobs(ctx, GetJobsConfig{Path: fsPath, Recurse: true}, *dbChan); err != nil {
-			return nil, err
-		}
-		*dbPath, *dbOk = <-(*dbChan)
-		if !*dbOk {
-			return nil, fmt.Errorf("directory %s does not appear to contain any synchronized files", fsPath)
-		}
-		log.Debug("streaming multiple paths from the Remote database", zap.Any("firstDBPath", *dbPath), zap.Bool("dbOk", *dbOk))
-	}
-	// When recursing we need to determine the relation of the fsPath and current dbPath and adjust
-	// accordingly before getting the path status.
-	for *dbOk && fsPath > (*dbPath).Path {
-		// dbPath is behind, advance the dbChan until it is ahead or equal.
-		*dbPath, *dbOk = <-(*dbChan)
-	}
 
-	if !*dbOk || fsPath < (*dbPath).Path {
-		// The dbPath is ahead indicating no match in the DB was found for this fsPath. Call
-		// getPathStatus with a nil dbPath to still determine if the fsPath has no RST or has RSTs
-		// but has never been pushed.
-		return getPathStatus(ctx, cfg, mappings, fsPath, nil)
-	}
+			if cfg.VerifyRemote {
+				result, err = getPathStatusFromTarget(ctx, cfg, mountPoint, rstMap, statusInfo.fsPath)
+			} else {
+				result, err = getPathStatusFromDatabase(ctx, cfg, mountPoint, statusInfo.fsPath, statusInfo.jobsResponse)
+			}
+			if err != nil {
+				return err
+			}
 
-	// Match found, advance dbChan for the next path and get the result for this path.
-	currentDbPath := *dbPath
-	*dbPath, *dbOk = <-(*dbChan)
-	return getPathStatus(ctx, cfg, mappings, fsPath, currentDbPath)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case results <- result:
+			}
+		}
+	}
 }
 
-// getPathStatus accepts an fsPath and dbPath and determines the SyncStatus of the path. The
-// dbPath might be nil or contain an error if there was not match in the DB for this fsPath.
-func getPathStatus(ctx context.Context, cfg GetStatusCfg, mappings *util.Mappings, fsPath string, dbPath *GetJobsResponse) (*GetStatusResult, error) {
-
-	// First stat the file so we can skip directories since they won't have entries in the Remote
-	// DB. For files the stat will be reused later to compare the current mtime.
-	beegfsClient, err := config.BeeGFSClient(fsPath)
-	if err != nil {
-		return nil, err
+// getPathStatusFromTarget retrieves the lockedInfo for the path from GetLockedInfo(). The
+// lockedInfo is compared with the remote size and mtime from the remote storage target(s) for sync
+// statuses.
+func getPathStatusFromTarget(
+	ctx context.Context,
+	cfg GetStatusCfg,
+	mountPoint filesystem.Provider,
+	rstMap map[uint32]rst.Provider,
+	fsPath string,
+) (*GetStatusResult, error) {
+	// Default to any specified targets specified in cfg otherwise attempt to use rstIds returned
+	// from GetLockedInfo.
+	lockedInfo, _, rstIds, err := rst.GetLockedInfo(ctx, mountPoint, &flex.JobRequestCfg{}, fsPath, true)
+	if len(cfg.RemoteTargets) != 0 {
+		rstIds = cfg.RemoteTargets
 	}
-	lStat, err := beegfsClient.Lstat(fsPath)
+	// GetLockedInfo returns any known information along with the defaults. So, if lockedInfo.Mode
+	// is non-zero then it is valid to check the file type and is safe to do so before checking the
+	// GetLockedInfo error.
+	fileMode := fs.FileMode(lockedInfo.Mode)
+	if fileMode.IsDir() {
+		return &GetStatusResult{
+			Path:       fsPath,
+			SyncStatus: Directory,
+			SyncReason: "Synchronization state must be checked on individual files.",
+		}, nil
+	} else if !fileMode.IsRegular() {
+		return &GetStatusResult{
+			Path:       fsPath,
+			SyncStatus: NotSupported,
+			SyncReason: fmt.Sprintf("Only regular files are currently supported (entry mode: %s).", filesystem.FileTypeToString(fileMode)),
+		}, nil
+	} else if err != nil {
+		if len(rstIds) == 0 {
+			return &GetStatusResult{
+				Path:       fsPath,
+				SyncStatus: NoTargets,
+				SyncReason: "No remote targets were specified or configured on this entry.",
+			}, nil
+		} else if errors.Is(err, rst.ErrOffloadFileNotReadable) {
+			// File is offloaded and clients cannot read stub files so request its contents
+			// from remote and update lockedInfo.
+			inMountPath, err := mountPoint.GetRelativePathWithinMount(fsPath)
+			if err != nil {
+				return nil, fmt.Errorf("unable to determine stub file target: %w", err)
+			}
+			resp, err := GetStubContents(ctx, inMountPath)
+			if err != nil {
+				if st, ok := status.FromError(err); ok {
+					switch st.Code() {
+					case codes.Unimplemented:
+						result := &GetStatusResult{Path: fsPath, SyncStatus: Offloaded, Warning: true}
+						syncReason := strings.Builder{}
+						for _, tgt := range rstIds {
+							syncReason.WriteString(fmt.Sprintf("Target %d: unable to verify the file is correctly offloaded as the remote service is missing a required rpc (please update your remote service to at least the same version as ctl)\n", tgt))
+						}
+						result.SyncReason = strings.TrimRight(syncReason.String(), "\n")
+						return result, nil
+					}
+				}
+				return nil, fmt.Errorf("unable to determine stub file target: %w", err)
+			}
+			lockedInfo.SetStubUrlRstId(*resp.RstId)
+			lockedInfo.SetStubUrlPath(*resp.Url)
+		} else if !errors.Is(err, rst.ErrFileHasNoRSTs) {
+			// Ignore ErrFileHasNoRSTs since rstIds has already been checked. The rstIds returned
+			// from GetLockedInfo does not account for cfg.RemoteTargets.
+			return nil, fmt.Errorf("unable to get file info: %w", err)
+		}
+	} else if !rst.FileExists(lockedInfo) {
+		return nil, fmt.Errorf("file does not exist (probably a bug)")
+	}
+
+	syncReason := strings.Builder{}
+	result := &GetStatusResult{Path: fsPath, SyncStatus: Synchronized}
+	for _, tgt := range rstIds {
+		client, ok := rstMap[tgt]
+		if !ok {
+			return nil, fmt.Errorf("unable to get client for remote target id %d: %w", tgt, err)
+		}
+
+		if rst.IsFileOffloaded(lockedInfo) {
+			result.SyncStatus = Offloaded
+			if tgt == lockedInfo.GetStubUrlRstId() {
+				syncReason.WriteString(fmt.Sprintf("Target %d: File contents are offloaded to this target.\n", tgt))
+			} else {
+				syncReason.WriteString(fmt.Sprintf("Target %d: File contents are not offloaded to this target.\n", tgt))
+			}
+			continue
+		}
+
+		remoteSize, remoteMtime, err := client.GetRemotePathInfo(ctx, &flex.JobRequestCfg{Path: fsPath, RemotePath: client.SanitizeRemotePath(fsPath)})
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				result.SyncStatus = NotAttempted
+				syncReason.WriteString(fmt.Sprintf("Target %d: Path has not been synchronized with this targets yet.\n", tgt))
+				continue
+			}
+			return nil, fmt.Errorf("unable to get remote resource info: %w", err)
+		}
+		lockedInfo.SetRemoteSize(remoteSize)
+		lockedInfo.SetRemoteMtime(timestamppb.New(remoteMtime))
+
+		if rst.IsFileAlreadySynced(lockedInfo) {
+			syncReason.WriteString(fmt.Sprintf("Target %d: File is synced based on the remote storage target.\n", tgt))
+		} else {
+			result.SyncStatus = Unsynchronized
+			syncReason.WriteString(fmt.Sprintf("Target %d: File is not synced with remote storage target.\n", tgt))
+		}
+	}
+
+	// Drop the final newline.
+	if syncReason.Len() != 0 {
+		result.SyncReason = strings.TrimRight(syncReason.String(), "\n")
+	}
+	return result, nil
+}
+
+// getPathStatusFromDatabase accepts an fsPath and dbPath to determine the sync status of the path. The
+// dbPath might be nil or contain an error if there was not match in the DB for this fsPath.
+func getPathStatusFromDatabase(
+	ctx context.Context,
+	cfg GetStatusCfg,
+	mountPoint filesystem.Provider,
+	fsPath string,
+	dbPath *GetJobsResponse,
+) (*GetStatusResult, error) {
+	lStat, err := mountPoint.Lstat(fsPath)
 	if err != nil {
 		return nil, err
 	}
@@ -256,40 +557,36 @@ func getPathStatus(ctx context.Context, cfg GetStatusCfg, mappings *util.Mapping
 			remoteTargets[t] = nil
 		}
 	} else {
-		entry, err := entry.GetEntry(ctx, mappings, entry.GetEntriesCfg{}, fsPath)
+		entry, err := entry.GetEntry(ctx, nil, entry.GetEntriesCfg{}, fsPath)
 		if err != nil {
 			return nil, err
 		}
 		if len(entry.Entry.Remote.RSTIDs) != 0 {
-			for _, t := range entry.Entry.Remote.RSTIDs {
-				remoteTargets[t] = nil
+			for _, tgt := range entry.Entry.Remote.RSTIDs {
+				remoteTargets[tgt] = nil
 			}
 		} else {
+			syncReason := "No remote targets were specified or configured on this entry."
+			if entry.Entry.FileState.GetDataState() == rst.DataStateOffloaded {
+				syncReason = "No remote targets were specified or configured on this entry. The contents are offloaded."
+			}
 			return &GetStatusResult{
 				Path:       fsPath,
 				SyncStatus: NoTargets,
-				SyncReason: "No remote targets were specified or configured on this entry.",
+				SyncReason: syncReason,
 			}, nil
 		}
 	}
-
-	// When recursively checking paths the dbPath will be nil if there was no entry for this fsPath.
-	if dbPath == nil {
+	// When recursively checking paths the dbPath will be nil if there was no entry for this
+	// fsPath. NotFound is expected when we are not recursively checking paths and calling
+	// GetJobs for each path.
+	if dbPath == nil || errors.Is(dbPath.Err, rst.ErrEntryNotFound) {
 		return &GetStatusResult{
 			Path:       fsPath,
 			SyncStatus: NotAttempted,
 			SyncReason: "Path has not been synchronized with any targets yet.",
 		}, nil
 	} else if dbPath.Err != nil {
-		// Otherwise we should check if there were any errors getting this entry. NotFound is
-		// expected when we are not recursively checking paths and calling GetJobs for each path.
-		if errors.Is(dbPath.Err, ErrEntryNotFound) {
-			return &GetStatusResult{
-				Path:       fsPath,
-				SyncStatus: NotAttempted,
-				SyncReason: "Path has not been synchronized with any targets yet.",
-			}, nil
-		}
 		// Otherwise an unknown error occurred which should be returned for troubleshooting. Any
 		// error here probably means the connection closed unexpectedly (e.g., Remote shut down).
 		return nil, fmt.Errorf("encountered an error reading from the Remote connection while processing file path %s: %w", fsPath, dbPath.Err)
@@ -304,56 +601,54 @@ func getPathStatus(ctx context.Context, cfg GetStatusCfg, mappings *util.Mapping
 	// First sort jobs oldest to newest so when they are added to the remote targets map only
 	// the most recent created job will be added for each remote target.
 	sort.Slice(dbPath.Results, func(i, j int) bool {
-		return dbPath.Results[i].GetJob().GetCreated().GetSeconds() < (*dbPath).Results[j].GetJob().GetCreated().GetSeconds()
+		return dbPath.Results[i].GetJob().GetCreated().GetSeconds() < dbPath.Results[j].GetJob().GetCreated().GetSeconds()
 	})
 
 	// Then only consider jobs for remote targets currently configured on the entry, or
 	// explicitly specified by the user.
-	for _, job := range (*dbPath).Results {
-		if _, ok := remoteTargets[job.GetJob().GetRequest().GetRemoteStorageTarget()]; ok {
-			remoteTargets[job.GetJob().GetRequest().GetRemoteStorageTarget()] = job
+	for _, job := range dbPath.Results {
+		rstId := job.GetJob().GetRequest().GetRemoteStorageTarget()
+		if _, ok := remoteTargets[rstId]; ok {
+			remoteTargets[rstId] = job
 		}
 	}
 
 	// Lastly assemble the results for each of the requested targets:
-	result := &GetStatusResult{
-		Path:       fsPath,
-		SyncStatus: Synchronized,
-	}
-
 	syncReason := strings.Builder{}
-	for tgt, job := range remoteTargets {
-		if job.GetJob() == nil {
+	result := &GetStatusResult{Path: fsPath, SyncStatus: Synchronized}
+	for tgt, jobResult := range remoteTargets {
+		job := jobResult.GetJob()
+		state := job.GetStatus().GetState()
+
+		if job == nil {
 			result.SyncStatus = Unsynchronized
 			syncReason.WriteString(fmt.Sprintf("Target %d: Path has no jobs for this target.\n", tgt))
-		} else if job.GetJob().GetStatus().GetState() == beeremote.Job_OFFLOADED {
+		} else if state == beeremote.Job_OFFLOADED {
 			result.SyncStatus = Offloaded
 			syncReason.WriteString(fmt.Sprintf("Target %d: File contents are offloaded to this target.\n", tgt))
-		} else if job.GetJob().GetStatus().GetState() != beeremote.Job_COMPLETED {
+		} else if state != beeremote.Job_COMPLETED {
 			result.SyncStatus = Unsynchronized
 			if cfg.Debug {
-				syncReason.WriteString(fmt.Sprintf("Target %d: Most recent job %s is not completed (state: %s).\n", tgt, job.GetJob().GetId(), job.GetJob().GetStatus().GetState()))
+				syncReason.WriteString(fmt.Sprintf("Target %d: Most recent job %s is not completed (state: %s).\n", tgt, job.GetId(), state))
 			} else {
 				syncReason.WriteString(fmt.Sprintf("Target %d: Most recent job is not completed.\n", tgt))
 			}
-		} else {
-			if !lStat.ModTime().Equal(job.GetJob().GetStopMtime().AsTime()) {
-				result.SyncStatus = Unsynchronized
-				if cfg.Debug {
-					syncReason.WriteString(fmt.Sprintf("Target %d: File has been modified since the most recent job (file mtime %s / job %s mtime %s).\n",
-						tgt, lStat.ModTime().Format(time.RFC3339), job.GetJob().GetId(), job.GetJob().GetStartMtime().AsTime().Format(time.RFC3339)))
-				} else {
-					syncReason.WriteString(fmt.Sprintf("Target %d: File has been modified since the most recent job.\n", tgt))
-				}
+		} else if !lStat.ModTime().Equal(job.GetStopMtime().AsTime()) {
+			result.SyncStatus = Unsynchronized
+			if cfg.Debug {
+				syncReason.WriteString(fmt.Sprintf("Target %d: File has been modified since the most recent job (file mtime %s / job %s mtime %s).\n",
+					tgt, lStat.ModTime().Format(time.RFC3339), job.GetId(), job.GetStartMtime().AsTime().Format(time.RFC3339)))
 			} else {
-				// Don't update SyncStatus here to ensure if a path is not synchronized with all
-				// targets it is always marked unsynchronized.
-				if cfg.Debug {
-					syncReason.WriteString(fmt.Sprintf("Target %d: File is in sync based on the most recent job (file mtime %s / job %s mtime %s).\n",
-						tgt, lStat.ModTime().Format(time.RFC3339), job.GetJob().GetId(), job.GetJob().GetStartMtime().AsTime().Format(time.RFC3339)))
-				} else {
-					syncReason.WriteString(fmt.Sprintf("Target %d: File is in sync based on the most recent job.\n", tgt))
-				}
+				syncReason.WriteString(fmt.Sprintf("Target %d: File has been modified since the most recent job.\n", tgt))
+			}
+		} else {
+			// Don't update SyncStatus here to ensure if a path is not synchronized with all
+			// targets it is always marked unsynchronized.
+			if cfg.Debug {
+				syncReason.WriteString(fmt.Sprintf("Target %d: File is in sync based on the most recent job (file mtime %s / job %s mtime %s).\n",
+					tgt, lStat.ModTime().Format(time.RFC3339), job.GetId(), job.GetStartMtime().AsTime().Format(time.RFC3339)))
+			} else {
+				syncReason.WriteString(fmt.Sprintf("Target %d: File is in sync based on the most recent job.\n", tgt))
 			}
 		}
 	}

--- a/ctl/pkg/util/paths.go
+++ b/ctl/pkg/util/paths.go
@@ -380,9 +380,14 @@ func compileFilter(query string) (FileInfoFilter, error) {
 	return func(fi FileInfo) (bool, error) {
 		out, err := expr.Run(prog, fi)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("filter eval %q on %s: %w", query, fi.Path, err)
 		}
-		return out.(bool), nil
+		result, ok := out.(bool)
+		if !ok {
+			return false, fmt.Errorf("filter expression resulted in a non-boolean value of type %T. Make sure your filter is a valid comparison (e.g., 'size>100MB')", out)
+		}
+
+		return result, nil
 	}, nil
 }
 

--- a/ctl/pkg/util/paths.go
+++ b/ctl/pkg/util/paths.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,7 +15,9 @@ import (
 	"github.com/expr-lang/expr"
 	"github.com/spf13/viper"
 	"github.com/thinkparq/beegfs-go/common/filesystem"
+	"github.com/thinkparq/beegfs-go/common/types"
 	"github.com/thinkparq/beegfs-go/ctl/pkg/config"
+	"golang.org/x/sync/errgroup"
 )
 
 type PathInputType int
@@ -160,232 +161,207 @@ func FilterExpr(f string) ProcessPathOpt {
 //
 // It returns a ResultT channel where the result for each entry will be sent. The ResultT channel
 // will be closed once all entries are processed, or if any error occurs after all valid results are
-// sent to the channel. The errs channel is NOT closed since it is used to return errors both from
-// the Goroutine responsible for providing the paths based on the PathInputMethod (for example
-// errors reading from stdin), and the Goroutines executing the processEntry function. Thus callers
-// should not wait for this channel to be closed indefinitely, and instead rely on the ResultT
-// channel to determine when all entries have been processed.
+// sent to the channel. When any walker or worker returns an error, the shared context is cancelled;
+// in-flight calls to processEntry are allowed to finish, but no new work is started.
 func ProcessPaths[ResultT any](
 	ctx context.Context,
 	method PathInputMethod,
 	singleWorker bool,
 	processEntry func(path string) (ResultT, error),
 	opts ...ProcessPathOpt,
-) (<-chan ResultT, <-chan error, error) {
+) (<-chan ResultT, func() error, error) {
 
+	numWorkers := 1
+	if !singleWorker {
+		// Reserve one core for another Goroutine walking paths. If there is only a single core
+		// don't set the numWorkers less than one.
+		numWorkers = max(viper.GetInt(config.NumWorkersKey)-1, 1)
+	}
+
+	pathsGroup, pathsGroupCtx := errgroup.WithContext(ctx)
+	paths := make(chan string, numWorkers*4)
+	pathsGroup.Go(func() error {
+		defer close(paths)
+		return StreamPaths(pathsGroupCtx, method, paths, opts...)
+	})
+
+	processGroup, processGroupCtx := errgroup.WithContext(ctx)
+	results := make(chan ResultT, numWorkers*4)
+	processGroup.Go(func() (err error) {
+		defer close(results)
+		defer func() {
+			err = WaitForLastStage(pathsGroup.Wait, err, paths)
+		}()
+		err = startProcessing(processGroupCtx, paths, results, processEntry, numWorkers)
+		return err
+	})
+
+	return results, processGroup.Wait, nil
+}
+
+// StreamPaths reads file paths from the given PathInputMethod—either stdin, directory,
+// or an explicit list—applies an optional filter expression, and streams each matching path to out.
+// It closes the out channel when done, respects ctx cancellation, and returns an error if any
+// step fails.
+func StreamPaths(ctx context.Context, method PathInputMethod, out chan<- string, opts ...ProcessPathOpt) error {
 	args := &ProcessPathOpts{}
 	for _, opt := range opts {
 		opt(args)
 	}
 
-	var resultsChan <-chan ResultT
-	// Largely arbitrary channel size selection. There are multiple writers to this channel, but the
-	// number varies based on GOMAXPROCS.
-	errChan := make(chan error, 128)
+	var err error
+	var filter FileInfoFilter
+	if args.FilterExpr != "" {
+		filter, err = compileFilter(args.FilterExpr)
+		if err != nil {
+			return fmt.Errorf("invalid filter %q: %w", args.FilterExpr, err)
+		}
+	}
 
 	if method.pathsViaStdin {
-		pathsChan := make(chan string, 1024)
-		go ReadFromStdin(ctx, method.stdinDelimiter, pathsChan, errChan)
-		resultsChan = startProcessing(ctx, pathsChan, errChan, singleWorker, args.FilterExpr, processEntry, true)
+		return walkStdin(ctx, method.stdinDelimiter, out, filter)
 	} else if method.pathsViaRecursion != "" {
-		pathsChan, err := walkDir(ctx, method.pathsViaRecursion, errChan, args.RecurseLexicographically)
-		if err != nil {
-			return nil, nil, err
-		}
-		resultsChan = startProcessing(ctx, pathsChan, errChan, singleWorker, args.FilterExpr, processEntry, false)
-	} else {
-		pathsChan := make(chan string, 1024)
-		resultsChan = startProcessing(ctx, pathsChan, errChan, singleWorker, args.FilterExpr, processEntry, true)
-		go func() {
-			// Writing to the channel needs to happen in a separate Goroutine so entriesChan can be
-			// returned immediately. Otherwise if the number of paths is larger than the entriesChan
-			// the processFunc would eventually be blocked since nothing would be reading from
-			// entriesChan.
-			defer close(pathsChan)
-			for _, e := range method.pathsViaList {
-				select {
-				case <-ctx.Done():
-					return
-				default:
-					pathsChan <- e
-				}
-			}
-		}()
+		return walkDir(ctx, method.pathsViaRecursion, out, filter, args.RecurseLexicographically)
 	}
-	return resultsChan, errChan, nil
-
+	return walkList(ctx, method.pathsViaList, out, filter)
 }
 
-// startProcessing executes processEntry() for each path sent to the paths channel.
 func startProcessing[ResultT any](
 	ctx context.Context,
 	paths <-chan string,
-	errs chan<- error,
-	singleWorker bool,
-	filterExpr string,
+	results chan<- ResultT,
 	processEntry func(path string) (ResultT, error),
-	// Some processing methods do not work when BeeGFS is not mounted. Specifically recursion is not
-	// possible since there is no file system tree mounted to recurse through.
-	allowUnmounted bool,
-) <-chan ResultT {
+	numWorkers int,
+) error {
 
-	results := make(chan ResultT, 1024)
-	var beegfsClient filesystem.Provider
-	var err error
-
-	var filterFunc func(FileInfo) (bool, error)
-	if filterExpr != "" {
-		var err error
-		filterFunc, err = compileFilter(filterExpr)
-		if err != nil {
-			// report error and return early
-			errs <- fmt.Errorf("invalid filter %q: %w", filterExpr, err)
-			close(results)
-			return results
-		}
-	}
-
-	// Spawn a goroutine that manages one or more workers that handle processing updates to each path.
-	go func() {
-		// Because multiple workers may write to this channel it is closed by the parent goroutine
-		// once all workers return.
-		defer close(results)
-		numWorkers := 1
-		if !singleWorker {
-			numWorkers = viper.GetInt(config.NumWorkersKey)
-			if numWorkers > 1 {
-				// Reserve one core for when there is another Goroutine walking a directory or reading
-				// in paths from stdin. If there is only a single core don't set the numWorkers less
-				// than one.
-				numWorkers = viper.GetInt(config.NumWorkersKey) - 1
-			}
-		}
-		wg := sync.WaitGroup{}
-		// If any of the workers encounter an error, this context is used to signal to the other
-		// workers they should exit early.
-		workerCtx, workerCancel := context.WithCancel(context.Background())
-
-		// The run loop for each worker:
-		runWorker := func() {
-			defer wg.Done()
+	g, gCtx := errgroup.WithContext(ctx)
+	for range numWorkers {
+		g.Go(func() error {
 			for {
 				select {
-				case <-workerCtx.Done():
-					return
+				case <-gCtx.Done():
+					return gCtx.Err()
 				case path, ok := <-paths:
 					if !ok {
-						return
+						return nil
 					}
-					// Automatically initialize the BeeGFS client with the first path. If this is
-					// ever moved, be aware some processEntry functions depend on having a properly
-					// initialized BeeGFSClient using the absolute path, and may need to be updated.
-					if beegfsClient == nil {
-						beegfsClient, err = config.BeeGFSClient(path)
-						if err != nil && !(errors.Is(err, filesystem.ErrUnmounted) && allowUnmounted) {
-							errs <- err
-							workerCancel()
-							return
-						}
-					}
-					searchPath, err := beegfsClient.GetRelativePathWithinMount(path)
+					result, err := processEntry(path)
 					if err != nil {
-						errs <- err
-						workerCancel()
-						return
+						return err
 					}
 
-					keep := true
-					if filterFunc != nil {
-						info, err := beegfsClient.Lstat(searchPath)
-						if err != nil {
-							errs <- err
-							workerCancel()
-							return
-						}
-						statT, ok := info.Sys().(*syscall.Stat_t)
-						if !ok {
-							errs <- errors.New("unsupported platform…")
-							workerCancel()
-							return
-						}
-						fi := statToFileInfo(path, statT)
-
-						keep, err = filterFunc(fi)
-						if err != nil {
-							errs <- fmt.Errorf("filter eval %q on %s: %w", filterExpr, path, err)
-							workerCancel()
-							return
-						}
+					select {
+					case <-gCtx.Done():
+						return gCtx.Err()
+					case results <- result:
 					}
-
-					if keep {
-						result, err := processEntry(searchPath)
-						if err != nil {
-							errs <- err
-							workerCancel()
-							return
-						}
-						results <- result
-					}
-				case <-ctx.Done():
-					return
 				}
 			}
-		}
-		for range numWorkers {
-			wg.Add(1)
-			go runWorker()
-		}
-		wg.Wait()
-	}()
-	return results
+		})
+	}
+
+	return g.Wait()
 }
 
-// Asynchronously walks a directory from startingPath, immediately returning a channel where the
-// paths will be sent, or an error if anything goes wrong setting up.
-func walkDir(ctx context.Context, startingPath string, errChan chan<- error, lexicographically bool) (<-chan string, error) {
-
-	beegfsClient, err := config.BeeGFSClient(startingPath)
-	if err != nil {
-		return nil, err
-	}
-
-	startInMount, err := beegfsClient.GetRelativePathWithinMount(startingPath)
-	if err != nil {
-		return nil, err
-	}
-
-	pathChan := make(chan string, 1024)
-
-	go func() {
-		walkDirFunc := func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-				pathChan <- path
-			}
-			return nil
+func walkStdin(ctx context.Context, delimiter byte, paths chan<- string, filter FileInfoFilter) error {
+	scanner := GetWalkStdinScanner(delimiter)
+	var err error
+	var beegfsClient filesystem.Provider
+	for scanner.Scan() {
+		path := scanner.Text()
+		if beegfsClient, err = pushFilterInMountPath(ctx, path, filter, beegfsClient, paths); err != nil {
+			return err
 		}
+	}
 
-		err := beegfsClient.WalkDir(startInMount, walkDirFunc, filesystem.Lexicographically(lexicographically))
+	return scanner.Err()
+}
+
+func walkList(ctx context.Context, pathList []string, paths chan<- string, filter FileInfoFilter) error {
+	var err error
+	var beegfsClient filesystem.Provider
+	for _, path := range pathList {
+		if beegfsClient, err = pushFilterInMountPath(ctx, path, filter, beegfsClient, paths); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func walkDir(ctx context.Context, startPath string, paths chan<- string, filter FileInfoFilter, lexicographically bool) error {
+	beegfsClient, err := config.BeeGFSClient(startPath)
+	if err != nil {
+		return err
+	}
+	startingInMountPath, err := beegfsClient.GetRelativePathWithinMount(startPath)
+	if err != nil {
+		return err
+	}
+
+	walkDirFunc := func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			errChan <- err
-			close(pathChan)
-			return
+			return err
 		}
-		close(pathChan)
-	}()
+		if _, err := pushFilterInMountPath(ctx, path, filter, beegfsClient, paths); err != nil {
+			return err
+		}
+		return nil
+	}
 
-	return pathChan, nil
+	err = beegfsClient.WalkDir(startingInMountPath, walkDirFunc, filesystem.Lexicographically(lexicographically))
+	if err != nil {
+		return err
+	}
+	return nil
 }
+
+func pushFilterInMountPath(ctx context.Context, path string, filter FileInfoFilter, client filesystem.Provider, paths chan<- string) (filesystem.Provider, error) {
+	if filter != nil {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return client, err
+		}
+		statT, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return client, fmt.Errorf("unable to retrieve stat information: unsupported platform")
+		}
+		keep, err := filter(statToFileInfo(path, statT))
+		if err != nil {
+			return client, err
+		}
+		if !keep {
+			return client, nil
+		}
+	}
+
+	if client == nil {
+		var err error
+		if client, err = config.BeeGFSClient(path); err != nil {
+			return nil, err
+		}
+	}
+
+	inMountPath, err := client.GetRelativePathWithinMount(path)
+	if err != nil {
+		return client, err
+	}
+
+	select {
+	case <-ctx.Done():
+		return client, ctx.Err()
+	case paths <- inMountPath:
+	}
+
+	return client, nil
+}
+
+const FilterFilesHelp = "Filter files by expression: fields(mtime/atime/ctime durations[s,m,h,d,M,y], size bytes[B,KB,MiB,GiB], uid, gid, mode, perm, name/path glob|regex); operators(=,!=,<,>,<=,>=,=~); logic(and|or|not); e.g. \"mtime > 365d and uid == 1000\""
+
+type FileInfoFilter func(FileInfo) (bool, error)
 
 // compileFilter turns a DSL expression into a filter function.
-func compileFilter(query string) (func(FileInfo) (bool, error), error) {
+func compileFilter(query string) (FileInfoFilter, error) {
 	// Preprocess DSL (includes octal normalization now)
 	q := preprocessDSL(query)
 
@@ -530,4 +506,33 @@ func globMatch(s, pattern string) (bool, error) {
 // regexMatch uses precompiled regex
 func regexMatch(s, pattern string) (bool, error) {
 	return regexp.MatchString(pattern, s)
+}
+
+// WaitForLastStage drains any provided channels and then blocks on wait(). Any error that's
+// returned from the wait function is prepended to err and returned. This lets you cancel a
+// downstream pipeline stage without preventing upstream stages that may still be active.
+func WaitForLastStage[T any](wait func() error, err error, chans ...<-chan T) error {
+	wg := sync.WaitGroup{}
+	wg.Add(len(chans))
+	for _, ch := range chans {
+		go func() {
+			defer wg.Done()
+			for range ch {
+			}
+		}()
+	}
+	wg.Wait()
+
+	previousErr := wait()
+	multiErr := types.MultiError{}
+	if previousErr != nil {
+		multiErr.Errors = append(multiErr.Errors, previousErr)
+	}
+	if err != nil {
+		multiErr.Errors = append(multiErr.Errors, err)
+	}
+	if len(multiErr.Errors) > 0 {
+		return &multiErr
+	}
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
-	github.com/thinkparq/protobuf v0.8.2-0.20250709071028-24f942a79ffa
+	github.com/thinkparq/protobuf v0.8.2-0.20250729105248-8a100c64c52e
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.15.0
 	golang.org/x/sys v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/thinkparq/protobuf v0.8.2-0.20250709071028-24f942a79ffa h1:KpyyeX04DSaqupPIOU/UgEAXwItdnHipj+IlrwgsZQQ=
-github.com/thinkparq/protobuf v0.8.2-0.20250709071028-24f942a79ffa/go.mod h1:AaUUy9mWaja/EggLSfzbKydAe+We+440z/6FdmPz5yI=
+github.com/thinkparq/protobuf v0.8.2-0.20250729105248-8a100c64c52e h1:1HZES9BJ7hKNvX9mssy65JOHEGFdoZJCUBVFJWR0P2Y=
+github.com/thinkparq/protobuf v0.8.2-0.20250729105248-8a100c64c52e/go.mod h1:AaUUy9mWaja/EggLSfzbKydAe+We+440z/6FdmPz5yI=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.36.0 h1:UumtzIklRBY6cI/lllNZlALOF5nNIzJVb16APdvgTXg=

--- a/rst/remote/internal/job/manager.go
+++ b/rst/remote/internal/job/manager.go
@@ -1154,6 +1154,10 @@ func (m *Manager) GetRSTConfig() ([]*flex.RemoteStorageTarget, error) {
 	return rstConfigs, nil
 }
 
+func (m *Manager) GetStubContents(path string) (uint32, string, error) {
+	return m.workerManager.GetStubContents(m.ctx, path)
+}
+
 func (m *Manager) Stop() {
 
 	m.readyMu.Lock()

--- a/rst/remote/internal/server/server.go
+++ b/rst/remote/internal/server/server.go
@@ -220,3 +220,11 @@ func (s *BeeRemoteServer) UpdateWork(ctx context.Context, request *beeremote.Upd
 	defer s.wg.Done()
 	return &beeremote.UpdateWorkResponse{}, s.jobMgr.UpdateWork(request.GetWork())
 }
+
+func (s *BeeRemoteServer) GetStubContents(ctx context.Context, request *beeremote.GetStubContentsRequest) (*beeremote.GetStubContentsResponse, error) {
+	id, url, err := s.jobMgr.GetStubContents(request.Path)
+	if err != nil {
+		return &beeremote.GetStubContentsResponse{}, err
+	}
+	return &beeremote.GetStubContentsResponse{RstId: &id, Url: &url}, nil
+}


### PR DESCRIPTION
Expose rst.getRstMap and move ErrEntryNotFound into common rst errors to prevent circular dependencies.
Improve error information when client without sysBypassFileAccessCheckOnMeta=true calls BuildJobRequest.

Refactor path utility
- Add `StreamPaths` utility to filter and stream paths based on input method so the status command can be processed each path in parallel.
- Utilize errgroup.Group to handle errors and cancellations. Only the first error will be returned.

Refactor remote status
- Add status pipeline to process paths in parallel.
- Utilize errgroup.Group to handle errors and cancellations. Only the first error will be returned.
- Add --verify-remote to verify sync status with remote target resources.
- Add --filter-files (nice to have and saved me the necessity of testing entry migrate)

### Tests Performed
- Utils.ProcessPaths() (entry {info,migrate,refresh,set}) - only tested `entry info`
  - [x] stdin
  - [x] recurse
  - [x] list

- Utils.ProcessPathsViaPipeline() (remote status)
  - stdin
    - [x] default (database)
    - [x] verify-remote
    - [x] filter
  - recurse
    - [x] default (database)
    - [x] verify-remote
    - [x] filter
  - list
    - [x] default (database)
    - [x] verify-remote
    - [x] filter

- Verify
  -  [x] `export BEEGFS_NUM_WORKERS <cmd>` works

```bash
set -x
clear
go build ctl/cmd/beegfs/main.go 
beegfs="./main --mgmtd-addr localhost:8010"
path=/mnt/beegfs/hot/test
rstId=2
otherRstId=1
rm -rf $path
mkdir -p $path

for f in synced offloaded offloadedNoRstCfg unsynced not-attempted no-rst; do
    echo test > $path/$f
done
$beegfs entry set -r $rstId $path/{synced,unsynced,offloaded,not-attempted}
$beegfs remote push -r $rstId $path/synced
$beegfs remote push -r $rstId $path/unsynced && sleep 3 && touch $path/unsynced
$beegfs remote push -r $rstId $path/offloaded -s
$beegfs remote push -r $rstId $path/offloadedNoRstCfg -s
$beegfs entry set -r $rstId $path/not-attempted
ln -s $path/synced $path/not-supported

sleep 5 # Allow the jobs time to complete

# Tests
## Verify beegfs entry info works with the various path input methods
$beegfs entry info --recurse --verbose $path
ls $path/* | $beegfs entry info - --verbose
$beegfs entry info $path/* --verbose

## Recurse
beegfs  remote status $path --verbose --recurse
BEEGFS_NUM_WORKERS=1 $beegfs remote status $path --verbose --recurse
$beegfs remote status $path --verbose --recurse
beegfs  remote status $path --verbose --recurse -r $rstId
$beegfs remote status $path --verbose --recurse -r $rstId
beegfs remote status $path --verbose --recurse -r $otherRstId
$beegfs remote status $path --verbose --recurse -r $otherRstId

$beegfs remote status $path --verbose --recurse --verify-remote
$beegfs remote status $path --verbose --recurse -r $rstId --verify-remote
$beegfs remote status $path --verbose --recurse -r $otherRstId --verify-remote
$beegfs remote status $path --verbose --recurse -r $rstId,$otherRstId --verify-remote
$beegfs remote status $path --verbose --recurse --verify-remote --filter-files "size>3B"
$beegfs remote status $path --verbose --recurse --verify-remote --filter-files "size>10B"
$beegfs remote status $path --verbose --recurse --verify-remote --filter-files "size>100B"
$beegfs remote status $path --verbose --recurse --verify-remote --filter-files "size#100B" # Invalid filter

### Push o

## Stdin
ls $path/* | $beegfs remote status - --verbose
ls $path/* | $beegfs remote status - --verbose --verify-remote
ls $path/* | $beegfs remote status - --verbose --verify-remote --filter-files "size>3B"
ls $path/* | $beegfs remote status - --verbose --verify-remote --filter-files "size>10B"
ls $path/* | $beegfs remote status - --verbose --verify-remote --filter-files "size>100B"

## List
$beegfs remote status $path/* --verbose
$beegfs remote status $path/* --verbose --verify-remote
$beegfs remote status $path/* --verbose --verify-remote --filter-files "size>3B"
$beegfs remote status $path/* --verbose --verify-remote --filter-files "size>10B"
$beegfs remote status $path/* --verbose --verify-remote --filter-files "size>100B"

## Individual files
for x in $path/*; do
    $beegfs remote status $x
    $beegfs remote status $x -r $rstId
    $beegfs remote status $x --verify-remote
    $beegfs remote status $x -r $rstId --verify-remote
done

set +x
```

### What does this PR do / why do we need it?
*Required for all PRs.*
<!--Questions that may be helpful filling out this section:

* What do we gain/lose with this PR?
-->
- Improves status command response time
- Adds the ability to verify the sync status with the remote storage targets


### Related Issue(s)
*Required when applicable.*
<!-- Link the PR to issues(s) using keywords:
* Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

### Where should the reviewer(s) start reviewing this? 
*Only required for larger PRs when this may not be immediately obvious.*
<!-- Questions that may be helpful filling out this section:

* Where should someone start (file/line) to begin reviewing the new/updated functionality in this
  PR? 
* Is there a logical progression the reviewer can follow to navigate their way through the changes
  (i.e., main.go -> api.go -> db.go)?
-->

1. Changes to `common/rst` are needed to support the `status` command changes, namely to get `lockedInfo` without needed the lock and improving error messaging.
2. Changes to `ctl/pkg/utils/paths.go`
3. Changes to the status command in `ctl/internal` and `ctl/pkg`

### Are there any specific topics we should discuss before merging?
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Are there potential tradeoffs in the implementation?
-->

### What are the next steps after this PR? 
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Is further work planned in this area after this PR is merged? 
  * If so, what issue(s) and/or PRs is it tracked in? 
-->

### Checklist before merging:
*Required for all PRs.*

When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [ ] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [ ] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?

For more details refer to the [Go coding standards](https://github.com/ThinkParQ/beegfs-go/wiki/Getting-Started-with-Go#coding-standards) and the [pull request process](https://github.com/ThinkParQ/beegfs-go/wiki/Pull-Requests).
