### PR TITLE
Fix overflow check in ParseIntFromStr

### DIFF
--- a/ctl/internal/util/parser.go
+++ b/ctl/internal/util/parser.go
@@ -100,7 +100,7 @@ func ParseIntFromStr(input string) (uint64, error) {
 		return 0, fmt.Errorf("unable to parse a valid number from the provided input (%s): %w", input, err)
 	}
 	b := num * multiplier
-	if num != 0.0 && multiplier >= math.MaxUint64/num {
+	if num != 0.0 && multiplier > math.MaxUint64/num {
 		return 0, fmt.Errorf("value parsed from the provided input (%f) is larger than the maximum allowed (%d)", b, uint64(math.MaxUint64))
 	}
 	return uint64(b), nil


### PR DESCRIPTION
## Summary
- fix overflow check for decimal input in `ParseIntFromStr`

## Testing
- `go vet ./...` *(fails: modules cannot be downloaded in offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_686c01a927908325ae662dccc3a4be3f