### PR TITLE
fix(copy): pass through exit code from copy command

### DIFF
--- a/ctl/internal/cmd/copy/copy.go
+++ b/ctl/internal/cmd/copy/copy.go
@@ -215,7 +215,12 @@ func copyRunner(bflagSet *bflag.FlagSet, paths []string, dest string) error {
 	if err := c.Start(); err != nil {
 		return fmt.Errorf("unable to start copy: %w", err)
 	}
-	if err := c.Wait(); err != nil {
+	err := c.Wait()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			log.Debug("beegfs-copy exited with non-zero status, propagating exit code", zap.Error(err))
+			os.Exit(exitErr.ExitCode())
+		}
 		return fmt.Errorf("error waiting for copy to complete: %w", err)
 	}
 	return nil


### PR DESCRIPTION
### What does this PR do / why do we need it?
When the copy command is run with a flag like `--list-diff`, it intentionally exits with a non-zero status code to indicate that differences were found.

The previous logic incorrectly interpreted this specific non-zero exit code as a generic failure, leading to a misleading error message.

This change uses os.Exit() to directly pass through the exit code from the copy command, suppressing the confusing error message while preserving the intended signal that differences were detected.

### Related Issue(s)
https://github.com/ThinkParQ/beegfs-go/issues/184

### Where should the reviewer(s) start reviewing this? 
*Only required for larger PRs when this may not be immediately obvious.*
<!-- Questions that may be helpful filling out this section:

* Where should someone start (file/line) to begin reviewing the new/updated functionality in this
  PR? 
* Is there a logical progression the reviewer can follow to navigate their way through the changes
  (i.e., main.go -> api.go -> db.go)?
-->

### Are there any specific topics we should discuss before merging?
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Are there potential tradeoffs in the implementation?
-->

### What are the next steps after this PR? 
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Is further work planned in this area after this PR is merged? 
  * If so, what issue(s) and/or PRs is it tracked in? 
-->

### Checklist before merging:
*Required for all PRs.*

When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [ ] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [ ] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?

For more details refer to the [Go coding standards](https://github.com/ThinkParQ/beegfs-go/wiki/Getting-Started-with-Go#coding-standards) and the [pull request process](https://github.com/ThinkParQ/beegfs-go/wiki/Pull-Requests).
