### PR TITLE
Falk/proxy configurable

### DIFF
--- a/common/beegfs/beegrpc/grpc.go
+++ b/common/beegfs/beegrpc/grpc.go
@@ -16,6 +16,7 @@ import (
 type connOpts struct {
 	TLSDisableVerification bool
 	TLSDisable             bool
+	UseProxy               bool
 	// TLSCaCert is the contents of a certificate file or nil if no extra certs should be applied.
 	TLSCaCert []byte
 	// AuthSecret is the contents of an auth file or nil if authentication should be disabled.
@@ -48,6 +49,12 @@ func WithAuthSecret(secret []byte) connOpt {
 	}
 }
 
+func WithProxy(enable bool) connOpt {
+	return func(co *connOpts) {
+		co.UseProxy = enable
+	}
+}
+
 // NewClientConn provides a standard method to configure TLS and BeeGFS connection authentication
 // when setting up a gRPC client connection for use with a BeeGFS gRPC client.
 func NewClientConn(address string, cOpts ...connOpt) (*grpc.ClientConn, error) {
@@ -55,6 +62,7 @@ func NewClientConn(address string, cOpts ...connOpt) (*grpc.ClientConn, error) {
 	config := &connOpts{
 		TLSDisableVerification: false,
 		TLSDisable:             false,
+		UseProxy:               false,
 		TLSCaCert:              nil,
 		AuthSecret:             nil,
 	}
@@ -63,6 +71,11 @@ func NewClientConn(address string, cOpts ...connOpt) (*grpc.ClientConn, error) {
 	}
 
 	var opts []grpc.DialOption
+	// NOTE: grpc.WithNoProxy() is marked as experimental, but has been for a long time. In the
+	// unlikely case it gets removed, we can easily replace it with a custome DialOption generator
+	if !config.UseProxy {
+		opts = append(opts, grpc.WithNoProxy())
+	}
 	// The mgmtd expects the conn auth secret to be included in the metadata with each request. We
 	// use an interceptor to inject this automatically when authentication is enabled. References:
 	// https://github.com/grpc/grpc-go/tree/master/examples/features/metadata_interceptor and

--- a/ctl/internal/config/config.go
+++ b/ctl/internal/config/config.go
@@ -78,6 +78,8 @@ func InitGlobalFlags(cmd *cobra.Command) {
 	When printing using a table, the header will be repeated after printing %s rows (set to 0 to omit printing table headers).
 	When printing JSON or pretty JSON, if the number of elements to print is greater than %s, prints multiple JSON lists separated by newlines.
 	When printing an unknown or large number of elements it is recommended to use NDJSON (Newline-Delimited JSON).`, config.OutputOptions, config.PageSizeKey, config.PageSizeKey))
+	cmd.PersistentFlags().Bool(config.UseProxyKey, false, "Use the proxy that is configured globally or in the environment when making gRPC connections.")
+	cmd.PersistentFlags().MarkHidden(config.UseProxyKey)
 	// Environment variables should start with BEEGFS_
 	viper.SetEnvPrefix("beegfs")
 	// Environment variables cannot use "-", replace with "_"

--- a/ctl/pkg/config/config.go
+++ b/ctl/pkg/config/config.go
@@ -74,6 +74,9 @@ const (
 	// the go-pretty table printer and just print columns separated by spaces).
 	PageSizeKey = "page-size"
 	OutputKey   = "output"
+	// Whether to use a proxy configured globally or via environment variables when making gRPC
+	// connections to either mgmtd or remote.
+	UseProxyKey = "use-http-proxy"
 )
 
 // Viper values for certain configuration values.
@@ -126,6 +129,7 @@ type GlobalConfig struct {
 	MgmtdTLSCertFile            string
 	MgmtdTLSDisableVerification bool
 	MgmtdTLSDisable             bool
+	MgmtdUseProxy               bool
 	AuthFile                    string
 	AuthDisable                 bool
 	RemoteAddress               string
@@ -158,6 +162,7 @@ func InitViperFromExternal(cfg GlobalConfig) {
 	globalFlagSet.String(TlsCertFile, cfg.MgmtdTLSCertFile, "")
 	globalFlagSet.Bool(TlsDisableKey, cfg.MgmtdTLSDisable, "")
 	globalFlagSet.Bool(TlsDisableVerificationKey, cfg.MgmtdTLSDisableVerification, "")
+	globalFlagSet.Bool(UseProxyKey, cfg.MgmtdUseProxy, "")
 	globalFlagSet.String(AuthFileKey, cfg.AuthFile, "")
 	globalFlagSet.Bool(AuthDisableKey, cfg.AuthDisable, "")
 	globalFlagSet.String(BeeRemoteAddrKey, cfg.RemoteAddress, "")
@@ -254,6 +259,7 @@ func ManagementClient() (*beegrpc.Mgmtd, error) {
 		beegrpc.WithTLSDisableVerification(viper.GetBool(TlsDisableVerificationKey)),
 		beegrpc.WithTLSCaCert(cert),
 		beegrpc.WithAuthSecret(authSecret),
+		beegrpc.WithProxy(viper.GetBool(UseProxyKey)),
 	)
 
 	return mgmtClient, err
@@ -289,6 +295,7 @@ func BeeRemoteClient() (beeremote.BeeRemoteClient, error) {
 		beegrpc.WithTLSDisableVerification(viper.GetBool(TlsDisableVerificationKey)),
 		beegrpc.WithTLSCaCert(cert),
 		beegrpc.WithAuthSecret(authSecret),
+		beegrpc.WithProxy(viper.GetBool(UseProxyKey)),
 	)
 
 	beeRemoteClient = beeremote.NewBeeRemoteClient(conn)

--- a/rst/remote/build/beegfs-remote.toml
+++ b/rst/remote/build/beegfs-remote.toml
@@ -132,6 +132,9 @@ path-db = "/var/lib/beegfs/remote/path.badger"
 # tls-disable: Set to disable TLS encryption and send all gRPC messages in clear text over the
 # network. Discouraged for production as it exposes data to potential interception and tampering.
 
+# use-http-proxy: Set to automatically use any proxy configured globally or via environment
+# variables for gRPC communication to the Management node. Will be propagated to Sync nodes.
+
 # auth-file: The file containing the shared secret for BeeGFS connection authentication.
 
 # auth-disable: Disable BeeGFS connection authentication (not recommended).
@@ -232,6 +235,9 @@ path-db = "/var/lib/beegfs/remote/path.badger"
 
 # tls-disable: Set to disable TLS encryption and send all gRPC messages in clear text over the
 # network. Discouraged for production as it exposes data to potential interception and tampering.
+
+# use-http-proxy: Set to automatically use any proxy configured globally or via environment
+# variables for gRPC communication to the worker node.
 
 
 #

--- a/rst/remote/cmd/beegfs-remote/main.go
+++ b/rst/remote/cmd/beegfs-remote/main.go
@@ -70,6 +70,8 @@ func main() {
 	pflag.Int("job.min-job-entries-per-rst", 2, "This many jobs for each RST configured for a particular path is guaranteed to be retained. At minimum this should be set to 1 so we always know the last sync result for an RST.")
 	pflag.Int("job.max-job-entries-per-rst", 4, "Once this threshold is exceeded, older jobs will be deleted (oldest-to-newest) until the number of jobs equals the min-job-entries-per-rst.")
 	// Hidden flags:
+	pflag.Bool("management.use-http-proxy", false, "Use proxy configured globally or in the environment for gRPC communication to the Management node.")
+	pflag.CommandLine.MarkHidden("management.use-http-proxy")
 	pflag.Int("developer.perf-profiling-port", 0, "Specify a port where performance profiles will be made available on the localhost via pprof (0 disables performance profiling).")
 	pflag.CommandLine.MarkHidden("developer.perf-profiling-port")
 	pflag.Bool("developer.dump-config", false, "Dump the full configuration and immediately exit.")
@@ -135,6 +137,7 @@ Using environment variables:
 			MgmtdTLSCertFile:            initialCfg.Management.TLSCertFile,
 			MgmtdTLSDisableVerification: initialCfg.Management.TLSDisableVerification,
 			MgmtdTLSDisable:             initialCfg.Management.TLSDisable,
+			MgmtdUseProxy:               initialCfg.Management.UseProxy,
 			AuthFile:                    initialCfg.Management.AuthFile,
 			AuthDisable:                 initialCfg.Management.AuthDisable,
 			RemoteAddress:               initialCfg.Server.Address,
@@ -199,6 +202,7 @@ Using environment variables:
 		beegrpc.WithTLSDisableVerification(initialCfg.Management.TLSDisableVerification),
 		beegrpc.WithTLSCaCert(cert),
 		beegrpc.WithAuthSecret(authSecret),
+		beegrpc.WithProxy(initialCfg.Management.UseProxy),
 	); err != nil {
 		// If the mgmtd is actually offline, usually we'll never get to this point. Startup will
 		// hang earlier trying to determine the BeeGFS mount point. This is why we don't do any
@@ -226,6 +230,7 @@ Using environment variables:
 		MgmtdTlsCert:                cert,
 		MgmtdTlsDisableVerification: initialCfg.Management.TLSDisableVerification,
 		MgmtdTlsDisable:             initialCfg.Management.TLSDisable,
+		MgmtdUseProxy:               initialCfg.Management.UseProxy,
 		AuthSecret:                  authSecret,
 		AuthDisable:                 initialCfg.Management.AuthDisable,
 	}.Build()

--- a/rst/remote/internal/config/config.go
+++ b/rst/remote/internal/config/config.go
@@ -41,6 +41,7 @@ type MgmtdConfig struct {
 	TLSCertFile            string `mapstructure:"tls-cert-file"`
 	TLSDisableVerification bool   `mapstructure:"tls-disable-verification"`
 	TLSDisable             bool   `mapstructure:"tls-disable"`
+	UseProxy               bool   `mapstructure:"use-http-proxy"`
 	AuthFile               string `mapstructure:"auth-file"`
 	AuthDisable            bool   `mapstructure:"auth-disable"`
 }

--- a/rst/remote/internal/worker/beesync.go
+++ b/rst/remote/internal/worker/beesync.go
@@ -43,6 +43,7 @@ func (n *BeeSyncNode) connect(config *flex.UpdateConfigRequest, bulkUpdate *flex
 		beegrpc.WithTLSCaCert(cert),
 		beegrpc.WithTLSDisableVerification(n.config.TLSDisableVerification),
 		beegrpc.WithTLSDisable(n.config.TlsDisable),
+		beegrpc.WithProxy(n.config.UseProxy),
 	)
 	if err != nil {
 		return false, err

--- a/rst/remote/internal/worker/config.go
+++ b/rst/remote/internal/worker/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	TlsCertFile            string `mapstructure:"tls-cert-file"`
 	TLSDisableVerification bool   `mapstructure:"tls-disable-verification"`
 	TlsDisable             bool   `mapstructure:"tls-disable"`
+	UseProxy               bool   `mapstructure:"use-http-proxy"`
 	MaxReconnectBackOff    int    `mapstructure:"max-reconnect-back-off"`
 	DisconnectTimeout      int    `mapstructure:"disconnect-timeout"`
 	SendRetries            int    `mapstructure:"send-retries"`

--- a/rst/sync/build/beegfs-sync.toml
+++ b/rst/sync/build/beegfs-sync.toml
@@ -134,3 +134,6 @@ tls-disable = false
 
 # tls-disable: Set to disable TLS encryption and send all gRPC messages in clear text over the
 # network. Discouraged for production as it exposes data to potential interception and tampering.
+
+# use-http-proxy: Set to automatically use any proxy configured globally or via environment
+# variables for gRPC communication to the Remote node.

--- a/rst/sync/cmd/beegfs-sync/main.go
+++ b/rst/sync/cmd/beegfs-sync/main.go
@@ -55,6 +55,8 @@ func main() {
 	pflag.Bool("remote.tls-disable-verification", false, "If TLS verification should be disabled when connecting to BeeGFS Remote (not recommended).")
 	pflag.Bool("remote.tls-disable", false, "Disable TLS entirely for gRPC communication to the Remote node.")
 	// Hidden flags:
+	pflag.Bool("remote.use-http-proxy", false, "Use proxy configured globally or in the environment for gRPC communication to the Remote node.")
+	pflag.CommandLine.MarkHidden("remote.use-http-proxy")
 	pflag.Int("developer.perf-profiling-port", 0, "Specify a port where performance profiles will be made available on the localhost via pprof (0 disables performance profiling).")
 	pflag.CommandLine.MarkHidden("developer.perf-profiling-port")
 	pflag.Bool("developer.dump-config", false, "Dump the full configuration and immediately exit.")

--- a/rst/sync/internal/beeremote/client.go
+++ b/rst/sync/internal/beeremote/client.go
@@ -19,6 +19,7 @@ type Config struct {
 	TlsCertFile            string `mapstructure:"tls-cert-file"`
 	TLSDisableVerification bool   `mapstructure:"tls-disable-verification"`
 	TlsDisable             bool   `mapstructure:"tls-disable"`
+	UseProxy               bool   `mapstructure:"use-http-proxy"`
 }
 
 // Client is setup so the provider can be swapped out after the client is initialized.

--- a/rst/sync/internal/beeremote/grpc.go
+++ b/rst/sync/internal/beeremote/grpc.go
@@ -41,6 +41,7 @@ func (c *grpcProvider) init(cfg Config) error {
 		beegrpc.WithTLSCaCert(cert),
 		beegrpc.WithTLSDisableVerification(cfg.TLSDisableVerification),
 		beegrpc.WithTLSDisable(cfg.TlsDisable),
+		beegrpc.WithProxy(cfg.UseProxy),
 	)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrUnableToConnect, err)
@@ -67,6 +68,7 @@ func (c *grpcProvider) init(cfg Config) error {
 			MgmtdTLSCertFile:            syncMgmtdTLSCertFile,
 			MgmtdTLSDisableVerification: cfg.dynamic.MgmtdTlsDisableVerification,
 			MgmtdTLSDisable:             cfg.dynamic.MgmtdTlsDisable,
+			MgmtdUseProxy:               cfg.dynamic.MgmtdUseProxy,
 			AuthFile:                    syncAuthFile,
 			AuthDisable:                 cfg.dynamic.AuthDisable,
 			RemoteAddress:               cfg.dynamic.Address,

--- a/watch/build/beegfs-watch.toml
+++ b/watch/build/beegfs-watch.toml
@@ -129,6 +129,9 @@ poll-frequency = 1
 # tls-disable: Set to disable TLS encryption and send all gRPC messages in clear text over the
 # network. Discouraged for production as it exposes data to potential interception and tampering.
 
+# use-http-proxy: Set to automatically use any proxy configured globally or via environment
+# variables for gRPC communication to the Management node.
+
 # auth-file: The file containing the shared secret for BeeGFS connection authentication.
 
 # auth-disable: Disable BeeGFS connection authentication (not recommended).
@@ -244,3 +247,6 @@ poll-frequency = 1
 
 # grpc-tls-disable: Set to disable TLS encryption and send all gRPC messages in clear text over the
 # network. Discouraged for production as it exposes data to potential interception and tampering.
+
+# grpc-use-http-proxy: Set to automatically use any proxy configured globally or via environment
+# variables for gRPC communication to the subscriber.

--- a/watch/cmd/beegfs-watch/main.go
+++ b/watch/cmd/beegfs-watch/main.go
@@ -61,6 +61,8 @@ func main() {
 	pflag.Int("handler.max-wait-for-response-after-connect", 2, "When a subscriber connects/reconnects wait this long for the subscriber to acknowledge the sequence ID of the last event it received successfully. This prevents sending duplicate events if the connection was disrupted unexpectedly.")
 	pflag.Int("handler.poll-frequency", 1, "How often subscribers should poll the metadata buffer for new events (causes more CPU utilization when idle).")
 	// Hidden flags:
+	pflag.Bool("management.use-http-proxy", false, "Use proxy configured globally or in the environment for gRPC communication to the Management node.")
+	pflag.CommandLine.MarkHidden("management.use-http-proxy")
 	pflag.Int("developer.perf-profiling-port", 0, "Specify a port where performance profiles will be made available on the localhost via pprof (0 disables performance profiling).")
 	pflag.CommandLine.MarkHidden("developer.perf-profiling-port")
 	pflag.Bool("developer.dump-config", false, "Dump the full configuration and immediately exit.")
@@ -165,6 +167,7 @@ Using environment variables:
 		beegrpc.WithTLSDisableVerification(initialCfg.Management.TLSDisableVerification),
 		beegrpc.WithTLSCaCert(cert),
 		beegrpc.WithAuthSecret(authSecret),
+		beegrpc.WithProxy(initialCfg.Management.UseProxy),
 	); err != nil {
 		// If the mgmtd is actually offline, usually we'll never get to this point. Startup will
 		// hang earlier trying to determine the BeeGFS mount point. This is why we don't do any

--- a/watch/internal/config/config.go
+++ b/watch/internal/config/config.go
@@ -38,6 +38,7 @@ type MgmtdConfig struct {
 	TLSCertFile            string `mapstructure:"tls-cert-file"`
 	TLSDisableVerification bool   `mapstructure:"tls-disable-verification"`
 	TLSDisable             bool   `mapstructure:"tls-disable"`
+	UseProxy               bool   `mapstructure:"use-http-proxy"`
 	AuthFile               string `mapstructure:"auth-file"`
 	AuthDisable            bool   `mapstructure:"auth-disable"`
 }

--- a/watch/internal/subscriber/config.go
+++ b/watch/internal/subscriber/config.go
@@ -25,6 +25,7 @@ type GrpcConfig struct {
 	TLSCertFile            string `mapstructure:"grpc-tls-cert-file"`
 	TLSDisableVerification bool   `mapstructure:"grpc-tls-disable-verification"`
 	TlsDisable             bool   `mapstructure:"grpc-tls-disable"`
+	UseProxy               bool   `mapstructure:"grpc-use-http-proxy"`
 	DisconnectTimeout      int    `mapstructure:"grpc-disconnect-timeout"`
 }
 

--- a/watch/internal/subscriber/grpc.go
+++ b/watch/internal/subscriber/grpc.go
@@ -70,6 +70,7 @@ func (s *GRPCSubscriber) Connect() (retry bool, err error) {
 		beegrpc.WithTLSCaCert(cert),
 		beegrpc.WithTLSDisableVerification(s.TLSDisableVerification),
 		beegrpc.WithTLSDisable(s.TlsDisable),
+		beegrpc.WithProxy(s.UseProxy),
 	)
 	if err != nil {
 		return true, fmt.Errorf("unable to connect to the subscriber: %w", err)


### PR DESCRIPTION
### What does this PR do / why do we need it?

Makes the use of proxies that are configured globally or in environment variables optional, sets the default to not use proxies, and adds options to use proxies if desired to CTL, Remote, Sync and Watch.
 
### Related Issue(s)

Issue was discovered during internal testing on systems that use proxies for outgoing HTTP traffic. The presence of HTTPS_PROXY (case insensitive) in the environment made CTL try to connect to mgmtd via the configured proxy which is neither possible nor desired in almost all cases.

### Where should the reviewer(s) start reviewing this? 

Mostly very similar changes to all the components. It probably makes sense to start with the CTL changes and work from there.

This also depends on a change to the protobuf used to propagate configuration from Remote to Sync nodes.

### Are there any specific topics we should discuss before merging?

Do the changes to the propagation mechanism between Remote and Sync make sense? It seems like some of the values in the merged configuration are actually never used (see code comment).

### Checklist before merging

- [x] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [x] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?
- [ ] TODO update protobuf dependency after protobuf changes are merged 