### PR TITLE
fix(ctl): correctly parse grpc port from an ipv4 or ipv6 address

### DIFF
--- a/ctl/internal/cmd/node/list.go
+++ b/ctl/internal/cmd/node/list.go
@@ -2,8 +2,8 @@ package node
 
 import (
 	"fmt"
+	"net"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -101,10 +101,11 @@ func runListCmd(cmd *cobra.Command, cfg backend.GetNodes_Config,
 	defer tbl.PrintRemaining()
 	hasUnreachableNode := false
 
-	// This shouldn't happen since a valid management address in the format <ip>:<port> is required.
+	// Extract the port from the management address. Supports IPv4 (a.b.c.d:port) and IPv6
+	// ([v6]:port). We do not fail hard here because this port is only used for display.
 	grpcPort := "invalid"
-	if grpcAddr := strings.Split(mgmtd.GetAddress(), ":"); len(grpcAddr) == 2 {
-		grpcPort = grpcAddr[1]
+	if _, p, err := net.SplitHostPort(mgmtd.GetAddress()); err == nil {
+		grpcPort = p
 	}
 
 	// Print and process node list


### PR DESCRIPTION
### What does this PR do / why do we need it?
*Required for all PRs.*
<!--Questions that may be helpful filling out this section:

* What do we gain/lose with this PR?
-->

I did a spot check to ensure all BeeGFS Go projects work with IPv6. I didn't expect any major issues since they use gRPC and strings for IP addresses so it should all "just work". The only issue I found is the gRPC port for IPv6 addresses would show "invalid" in `list nodes --with-nics`. I updated it to work correctly for both IPv4 and IPv6:

```
$ beegfs node list --with-nics --mgmtd-addr=[fd37:63dc:74a4:d78d:cc30:97ff:fea6:2447]:8010
ID    TYPE        ALIAS                    NICS                                                                   
c:72  client      c125E54-6895024C-beemac  ethernet:enp0s1 (192.168.64.5:8004)                                    
c:76  client      c1273C7-689506FF-beemac  ethernet:enp0s1 (192.168.64.5:10004)                                   
m:1   meta        node_meta_1              ethernet:enp0s1 (192.168.64.5:8005)                                    
m:2   meta        node_meta_2              ethernet:enp0s1 (192.168.64.5:9005)                                    
s:1   storage     storage1                 ethernet:enp0s1 (192.168.64.5:8003)                                    
s:2   storage     storage2                 ethernet:enp0s1 (192.168.64.5:9003)                                    
mg:1  management  management               ethernet:enp0s1 (192.168.64.5:8008,8010)                               
                                           ethernet:enp0s1 ([fd37:63dc:74a4:d78d:cc30:97ff:fea6:2447]:8008,8010) 
```

I also verified Remote/Sync can use IPv6 to communicate to the mgmtd and each other.

### Related Issue(s)
*Required when applicable.*
<!-- Link the PR to issues(s) using keywords:
* Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

### Where should the reviewer(s) start reviewing this? 
*Only required for larger PRs when this may not be immediately obvious.*
<!-- Questions that may be helpful filling out this section:

* Where should someone start (file/line) to begin reviewing the new/updated functionality in this
  PR? 
* Is there a logical progression the reviewer can follow to navigate their way through the changes
  (i.e., main.go -> api.go -> db.go)?
-->

### Are there any specific topics we should discuss before merging?
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Are there potential tradeoffs in the implementation?
-->

### What are the next steps after this PR? 
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Is further work planned in this area after this PR is merged? 
  * If so, what issue(s) and/or PRs is it tracked in? 
-->

### Checklist before merging:
*Required for all PRs.*

When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [ ] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [ ] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?

For more details refer to the [Go coding standards](https://github.com/ThinkParQ/beegfs-go/wiki/Getting-Started-with-Go#coding-standards) and the [pull request process](https://github.com/ThinkParQ/beegfs-go/wiki/Pull-Requests).
