### PR TITLE
docs(ctl): warn that benchmark status may aggregate results from different runs

### DIFF
--- a/ctl/internal/cmd/benchmark/benchmark.go
+++ b/ctl/internal/cmd/benchmark/benchmark.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/thinkparq/beegfs-go/common/beegfs"
+	"github.com/thinkparq/beegfs-go/ctl/internal/cmdfmt"
 	"github.com/thinkparq/beegfs-go/ctl/internal/util"
 	"github.com/thinkparq/beegfs-go/ctl/pkg/config"
 	"github.com/thinkparq/beegfs-go/ctl/pkg/ctl/benchmark"
@@ -105,6 +106,11 @@ func newStatusCmd(frontendCfg *frontendCfg, backendCfg *benchmark.StorageBenchCo
 		Short: "Print the status and results from a benchmark.",
 		Long:  `Print the status and results from the current/last benchmark for the specified storage targets.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(backendCfg.TargetIDs) == 0 && len(backendCfg.StorageNodes) == 0 {
+				cmdfmt.Printf("WARNING: Without --targets or --nodes this command shows the most recent result for each storage target.\n" +
+					"Results will be aggregated even if they come from benchmarks run at different times, which can skew averages and totals.\n" +
+					"Use --nodes or --targets to filter results from a specific benchmark run if needed.\n\n")
+			}
 			backendCfg.Action = beegfs.BenchStatus
 			return storageBenchDispatcher(cmd.Context(), frontendCfg, backendCfg)
 		},


### PR DESCRIPTION
### What does this PR do / why do we need it?
*Required for all PRs.*
<!--Questions that may be helpful filling out this section:

* What do we gain/lose with this PR?
-->

There is currently no way to detect when status returns results from different benchmark runs or clear previous benchmark results when starting a new benchmark (this requires restarting storage services). Add a simple warning when status is run without targets or nodes about this behavior.

### Related Issue(s)
*Required when applicable.*
<!-- Link the PR to issues(s) using keywords:
* Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

### Where should the reviewer(s) start reviewing this? 
*Only required for larger PRs when this may not be immediately obvious.*
<!-- Questions that may be helpful filling out this section:

* Where should someone start (file/line) to begin reviewing the new/updated functionality in this
  PR? 
* Is there a logical progression the reviewer can follow to navigate their way through the changes
  (i.e., main.go -> api.go -> db.go)?
-->

### Are there any specific topics we should discuss before merging?
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Are there potential tradeoffs in the implementation?
-->

### What are the next steps after this PR? 
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Is further work planned in this area after this PR is merged? 
  * If so, what issue(s) and/or PRs is it tracked in? 
-->

### Checklist before merging:
*Required for all PRs.*

When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [ ] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [ ] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?

For more details refer to the [Go coding standards](https://github.com/ThinkParQ/beegfs-go/wiki/Getting-Started-with-Go#coding-standards) and the [pull request process](https://github.com/ThinkParQ/beegfs-go/wiki/Pull-Requests).
