### PR TITLE
feat(debug): allow  direct node communication and skip mgmtd node-store lookup when node ip and port is specified.

### DIFF
--- a/ctl/internal/cmd/debug/debug.go
+++ b/ctl/internal/cmd/debug/debug.go
@@ -11,12 +11,16 @@ import (
 // Creates new "node" command
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "debug <node> <command>",
+		Use:    "debug <node|host:port> <command>",
 		Hidden: true,
 		Short:  "Send various debug commands to meta or storage nodes",
 		Long: `Send various debug commands to meta or storage nodes.
 
 THIS MODE IS MEANT FOR DEBUGGING PURPOSES ONLY! IMPROPER USE CAN HAVE UNINTENDED EFFECTS AND EVEN CAUSE DAMAGE TO THE FILE SYSTEM. USE AT YOUR OWN RISK!
+
+The first argument is parsed as a meta/storage entity ID (or alias) when possible.
+If parsing fails, it is interpreted as a direct node TCP address (host:port) and the command is sent
+without fetching node information from management.
 
 Known commands for both meta and storage nodes:
   - "version": Print the node's service release version
@@ -62,18 +66,18 @@ Known storage node commands:
 These lists are not guaranteed to be exhaustive and some commands might not be available under all circumstances and can change any time.`,
 		Args: cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			node, err := beegfs.NewEntityIdParser(16, beegfs.Meta, beegfs.Storage).Parse(args[0])
-			if err != nil {
-				return err
-			}
-
-			// Combine positionals after the node argument into one string so no "" are needed
+			// Combine positionals after the node/address argument into one string so no "" are needed.
 			command := ""
 			for _, a := range args[1:] {
 				command += a + " "
 			}
+			nodeOrAddr := args[0]
 
-			return runGenericDebugCmd(cmd, node, command)
+			node, err := beegfs.NewEntityIdParser(16, beegfs.Meta, beegfs.Storage).Parse(nodeOrAddr)
+			if err == nil {
+				return runGenericDebugCmd(cmd, node, command)
+			}
+			return runGenericDebugCmdByAddr(cmd, nodeOrAddr, command)
 		},
 	}
 
@@ -82,6 +86,17 @@ These lists are not guaranteed to be exhaustive and some commands might not be a
 
 func runGenericDebugCmd(cmd *cobra.Command, node beegfs.EntityId, command string) error {
 	resp, err := dbg.GenericDebugCmd(cmd.Context(), node, command)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(resp)
+
+	return nil
+}
+
+func runGenericDebugCmdByAddr(cmd *cobra.Command, nodeAddr, command string) error {
+	resp, err := dbg.GenericDebugCmdByAddr(cmd.Context(), nodeAddr, command)
 	if err != nil {
 		return err
 	}

--- a/ctl/pkg/config/config.go
+++ b/ctl/pkg/config/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/thinkparq/beegfs-go/common/beegfs"
 	"github.com/thinkparq/beegfs-go/common/beegfs/beegrpc"
 	"github.com/thinkparq/beegfs-go/common/beemsg"
+	"github.com/thinkparq/beegfs-go/common/beemsg/util"
 	"github.com/thinkparq/beegfs-go/common/filesystem"
 	"github.com/thinkparq/beegfs-go/common/logger"
 	"github.com/thinkparq/beegfs-go/common/registry"
@@ -572,6 +573,34 @@ func NodeStore(ctx context.Context) (*beemsg.NodeStore, error) {
 		}
 	}
 	return nodeStore, nil
+}
+
+// AuthSecret returns the configured BeeMsg authentication secret.
+// If authentication is disabled this returns 0 and no error.
+func AuthSecret() (uint64, error) {
+	if viper.GetBool(AuthDisableKey) {
+		return 0, nil
+	}
+
+	authPath := viper.GetString(AuthFileKey)
+	authBytes, err := os.ReadFile(authPath)
+	if err == nil {
+		return util.GenerateAuthSecret(authBytes), nil
+	}
+
+	// Create ManagementClient only to call GetAuthSecret(); no management RPC is sent here.
+	if authPath == BeeGFSAuthDefaultPath {
+		mgmtd, mgmtdErr := ManagementClient()
+		if mgmtdErr == nil {
+			return mgmtd.GetAuthSecret(), nil
+		}
+		return 0, fmt.Errorf(
+			"couldn't read default auth file at %q: %w; auto-configuring auth via management failed: %w (if --auth-file is not set and mgmtd is down, auth-secret resolution fails)",
+			authPath, err, mgmtdErr,
+		)
+	}
+
+	return 0, fmt.Errorf("couldn't read auth file at %q (non-default path): %w", authPath, err)
 }
 
 // Resets the global state and frees resources

--- a/ctl/pkg/ctl/debug/debug.go
+++ b/ctl/pkg/ctl/debug/debug.go
@@ -2,9 +2,13 @@ package node
 
 import (
 	"context"
+	"fmt"
+	"net"
 
+	"github.com/spf13/viper"
 	"github.com/thinkparq/beegfs-go/common/beegfs"
 	"github.com/thinkparq/beegfs-go/common/beemsg/msg"
+	"github.com/thinkparq/beegfs-go/common/beemsg/util"
 	"github.com/thinkparq/beegfs-go/ctl/pkg/config"
 )
 
@@ -18,6 +22,35 @@ func GenericDebugCmd(ctx context.Context, node beegfs.EntityId, command string) 
 	err = store.RequestTCP(ctx, node, &msg.GenericDebug{Command: []byte(command)}, &resp)
 	if err != nil {
 		return "", err
+	}
+
+	return string(resp.Response), nil
+}
+
+func GenericDebugCmdByAddr(ctx context.Context, addr string, command string) (string, error) {
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		return "", fmt.Errorf("invalid node address %q: %w", addr, err)
+	}
+
+	authSecret, err := config.AuthSecret()
+	if err != nil {
+		return "", err
+	}
+
+	conns := util.NewNodeConns()
+	defer conns.CleanUp()
+
+	resp := msg.GenericDebugResp{}
+	err = conns.RequestTCP(
+		ctx,
+		[]string{addr},
+		authSecret,
+		viper.GetDuration(config.ConnTimeoutKey),
+		&msg.GenericDebug{Command: []byte(command)},
+		&resp,
+	)
+	if err != nil {
+		return "", fmt.Errorf("TCP request to %s failed: %w", addr, err)
 	}
 
 	return string(resp.Response), nil


### PR DESCRIPTION
### What does this PR do / why do we need it?
Update `beegfs debug` to accept `<node|host:port>` as the first positional.
The command first tries to parse a meta/storage entity ID; if parsing fails, it
treats the value as a direct TCP address and sends `GenericDebug` directly to
that node (without mgmtd node-store lookup). So even if the management is 
not running, beegfs CTL can send messages to daemons if the ip address and 
ports are known.

This can be helpful during integration tests to ensure that the daemons are running
and to avoid relying on log parsing to confirm that they are listening on the 
requested ports.

With this, we can use the debug command to send a debug version message to the node.
If the daemon responds, then it is running; if not, it failed to start as expected.


Also add a shared `config.AuthSecret()` helper and reuse it in direct debug
requests so auth-secret resolution stays consistent with existing config behaviour.

### Are there any specific topics we should discuss before merging?
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Are there potential tradeoffs in the implementation?
-->

### What are the next steps after this PR? 
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Is further work planned in this area after this PR is merged? 
  * If so, what issue(s) and/or PRs is it tracked in? 
-->

### Checklist before merging:
*Required for all PRs.*

When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [ ] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [ ] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?

For more details refer to the [Go coding standards](https://github.com/ThinkParQ/beegfs-go/wiki/Getting-Started-with-Go#coding-standards) and the [pull request process](https://github.com/ThinkParQ/beegfs-go/wiki/Pull-Requests).
