### PR TITLE
fix(ioctl): handle partial GetEntryInfoV2 response via GetEntryInfoResult field

### DIFF
--- a/common/ioctl/api.go
+++ b/common/ioctl/api.go
@@ -308,12 +308,11 @@ func GetEntryInfoV2(path string) (msg.EntryInfo, msg.GetEntryInfoResponse, error
 		FeatureFlags:  featFlags,
 	}
 
-	// arg.BasicOnly is set by the kernel when the inode is held in the global lock store (e.g.
-	// during chunk rebalancing). The ioctl still succeeds and the basic entry info fields populated
-	// above are valid, but stripe pattern, PathInfo, RST, and session fields are not populated.
-	// Return OpsErr_INODELOCKED in the response so callers can distinguish a partial result.
-	if arg.BasicOnly != 0 {
-		return entryInfo, msg.GetEntryInfoResponse{Result: beegfs.OpsErr_INODELOCKED}, nil
+	// A non-zero GetEntryInfoResult means the metadata RPC returned a non-success code; the ioctl
+	// still succeeds and the basic entry info fields above are valid, but stripe pattern, PathInfo,
+	// RST, and session fields are not populated. Pass the exact RPC result to the caller.
+	if arg.GetEntryInfoResult != 0 {
+		return entryInfo, msg.GetEntryInfoResponse{Result: beegfs.OpsErr(arg.GetEntryInfoResult)}, nil
 	}
 
 	// This matches the same checks done in common/beemsg/msg/entry.go if we were assembling

--- a/common/ioctl/api.go
+++ b/common/ioctl/api.go
@@ -308,6 +308,14 @@ func GetEntryInfoV2(path string) (msg.EntryInfo, msg.GetEntryInfoResponse, error
 		FeatureFlags:  featFlags,
 	}
 
+	// arg.BasicOnly is set by the kernel when the inode is held in the global lock store (e.g.
+	// during chunk rebalancing). The ioctl still succeeds and the basic entry info fields populated
+	// above are valid, but stripe pattern, PathInfo, RST, and session fields are not populated.
+	// Return OpsErr_INODELOCKED in the response so callers can distinguish a partial result.
+	if arg.BasicOnly != 0 {
+		return entryInfo, msg.GetEntryInfoResponse{Result: beegfs.OpsErr_INODELOCKED}, nil
+	}
+
 	// This matches the same checks done in common/beemsg/msg/entry.go if we were assembling
 	// GetEntryInfoResponse from an RPC response.
 	if arg.RSTMajorVersion > 1 || arg.RSTMinorVersion != 0 {

--- a/common/ioctl/beegfs.go
+++ b/common/ioctl/beegfs.go
@@ -237,4 +237,7 @@ type getEntryInfoV2Arg struct {
 	NumSessionsRead  uint32
 	NumSessionsWrite uint32
 	FileDataState    uint8
+	// 1 if the inode was locked during GetEntryInfo RPC (e.g. chunk rebalancing)
+	// only basic entry info fields are valid when set.
+	BasicOnly uint8
 }

--- a/common/ioctl/beegfs.go
+++ b/common/ioctl/beegfs.go
@@ -239,5 +239,6 @@ type getEntryInfoV2Arg struct {
 	FileDataState    uint8
 	// Result of the GetEntryInfo RPC. 0 = success (full data populated). Non-zero = partial
 	// result (only basic entry info valid); value is the FhgfsOpsErr code from the metadata RPC.
-	GetEntryInfoResult uint8
+	// Matches the signed 32-bit wire type of FhgfsOpsErr.
+	GetEntryInfoResult int32
 }

--- a/common/ioctl/beegfs.go
+++ b/common/ioctl/beegfs.go
@@ -237,7 +237,7 @@ type getEntryInfoV2Arg struct {
 	NumSessionsRead  uint32
 	NumSessionsWrite uint32
 	FileDataState    uint8
-	// 1 if the inode was locked during GetEntryInfo RPC (e.g. chunk rebalancing)
-	// only basic entry info fields are valid when set.
-	BasicOnly uint8
+	// Result of the GetEntryInfo RPC. 0 = success (full data populated). Non-zero = partial
+	// result (only basic entry info valid); value is the FhgfsOpsErr code from the metadata RPC.
+	GetEntryInfoResult uint8
 }


### PR DESCRIPTION
### What does this PR do / why do we need it?
*Required for all PRs.*

The beegfs-core client module's GetEntryInfoV2 ioctl exposes a `getEntryInfoResult` field in `BeegfsIoctl_GetEntryInfoV2_Arg` that carries the exact `FhgfsOpsErr` code returned by the metadata RPC. When the RPC returns a non-success result, the kernel returns success from the ioctl with the error code in getEntryInfoResult; only the basic entry info fields are valid in that case.

This PR adds the corresponding `GetEntryInfoResult uint8` field to the Go ioctl arg struct and passes its value directly as `beegfs.OpsErr(arg.GetEntryInfoResult)` in GetEntryInfoResponse.Result, letting callers distinguish a partial result from a complete one without any hardcoded error assumptions.


### Related Issue(s)
*Required when applicable.*
<!-- Link the PR to issues(s) using keywords:
* Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

### Where should the reviewer(s) start reviewing this? 
*Only required for larger PRs when this may not be immediately obvious.*
<!-- Questions that may be helpful filling out this section:

* Where should someone start (file/line) to begin reviewing the new/updated functionality in this
  PR? 
* Is there a logical progression the reviewer can follow to navigate their way through the changes
  (i.e., main.go -> api.go -> db.go)?
-->

### Are there any specific topics we should discuss before merging?
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Are there potential tradeoffs in the implementation?
-->

### What are the next steps after this PR? 
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Is further work planned in this area after this PR is merged? 
  * If so, what issue(s) and/or PRs is it tracked in? 
-->

### Checklist before merging:
*Required for all PRs.*

When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [ ] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [ ] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?

For more details refer to the [Go coding standards](https://github.com/ThinkParQ/beegfs-go/wiki/Getting-Started-with-Go#coding-standards) and the [pull request process](https://github.com/ThinkParQ/beegfs-go/wiki/Pull-Requests).
