### PR TITLE
fix(ctl): entry info fields silently falling back to default values

### DIFF
--- a/common/rst/jobrequest.go
+++ b/common/rst/jobrequest.go
@@ -189,9 +189,12 @@ func prepareJobRequests(ctx context.Context, remote beeremote.BeeRemoteClient, c
 	if err != nil {
 		return nil, err
 	}
-	entry := entryInfo.Entry
+	e := entryInfo.Entry
+	if e.Details == nil {
+		return nil, fmt.Errorf("full entry details unavailable for %s: %s", pathInfo.Path, e.EntryInfoPopulated)
+	}
 
-	if entry.FileState.GetDataState() == DataStateOffloaded {
+	if e.Details.FileState.GetDataState() == DataStateOffloaded {
 		// Attempt to retrieve the stub file content from remote and use the rstId to create the job
 		// requests. Otherwise, send the request to job-builder to complete.
 		resp, err := remote.GetStubContents(ctx, &beeremote.GetStubContentsRequest{Path: pathInfo.Path})
@@ -210,12 +213,12 @@ func prepareJobRequests(ctx context.Context, remote beeremote.BeeRemoteClient, c
 		return []*beeremote.JobRequest{request}, nil
 	}
 
-	if len(entry.Remote.RSTIDs) == 0 {
+	if len(e.Details.Remote.RSTIDs) == 0 {
 		return nil, fmt.Errorf("unable to build job request(s)! --%s must be specified: %w", RemoteTargetFlag, ErrFileHasNoRSTs)
 	}
 
 	var requests []*beeremote.JobRequest
-	for _, rstId := range entry.Remote.RSTIDs {
+	for _, rstId := range e.Details.Remote.RSTIDs {
 		client, ok := rstMap[rstId]
 		if !ok {
 			return nil, fmt.Errorf("remote storage target ID %d from file metadata does not exist in the configuration: %w", rstId, ErrFileHasNoRSTs)

--- a/common/rst/rst.go
+++ b/common/rst/rst.go
@@ -669,12 +669,17 @@ func GetLockedInfo(
 	}
 	lockedInfo.Exists = true
 
+	if entryInfo.Entry.Details == nil {
+		return lockedInfo, writeLockSet, rstIds, entryInfoMsg, ownerNode,
+			fmt.Errorf("%w: entry details unavailable (%s)", ErrGetLockedInfoFatal, entryInfo.Entry.EntryInfoPopulated)
+	}
+
 	if rstIds == nil {
-		rstIds = entryInfo.Entry.Remote.RSTIDs
+		rstIds = entryInfo.Entry.Details.Remote.RSTIDs
 	}
 
 	if !skipAccessLock {
-		if !entryInfo.Entry.FileState.IsReadWriteLocked() {
+		if !entryInfo.Entry.Details.FileState.IsReadWriteLocked() {
 			err = entry.SetAccessFlags(ctx, inMountPath, LockedAccessFlags)
 			if err != nil {
 				return
@@ -692,7 +697,7 @@ func GetLockedInfo(
 	lockedInfo.Mtime = timestamppb.New(stat.ModTime())
 	lockedInfo.Mode = uint32(stat.Mode())
 
-	if entryInfo.Entry.FileState.GetDataState() == DataStateOffloaded {
+	if entryInfo.Entry.Details.FileState.GetDataState() == DataStateOffloaded {
 		if lockedInfo.StubUrlRstId, lockedInfo.StubUrlPath, err = GetOffloadedUrlPartsFromFile(mountPoint, inMountPath); err != nil {
 			if errors.Is(err, syscall.EWOULDBLOCK) {
 				return lockedInfo, writeLockSet, rstIds, entryInfoMsg, ownerNode, ErrOffloadFileNotReadable
@@ -771,12 +776,15 @@ func parseRstUrl(url []byte) (uint32, string, error) {
 	return uint32(num), s3Key, nil
 }
 
-func CheckEntry(entry entry.Entry, ignoreReaders bool, ignoreWriters bool) error {
+func CheckEntry(e entry.Entry, ignoreReaders bool, ignoreWriters bool) error {
+	if e.Details == nil {
+		return fmt.Errorf("entry details unavailable (%s)", e.EntryInfoPopulated)
+	}
 	var err error
-	if !ignoreWriters && entry.NumSessionsWrite > 0 {
+	if !ignoreWriters && e.Details.NumSessionsWrite > 0 {
 		err = ErrFileOpenForWriting
 	}
-	if !ignoreReaders && entry.NumSessionsRead > 0 {
+	if !ignoreReaders && e.Details.NumSessionsRead > 0 {
 		// Not using errors.Join because it adds a newline when printing each error which looks
 		// awkward in the CTL output.
 		if err != nil {

--- a/ctl/README.md
+++ b/ctl/README.md
@@ -76,10 +76,11 @@ func main() {
 			log.Fatal(err)
 		}
 
-		fmt.Printf("Entry Info - Path: %s, Entry ID: %s, File State: %s\n",
-			entryInfo.Entry.FileName,
-			entryInfo.Entry.EntryID,
-			entryInfo.Entry.FileState.String())
+		fmt.Printf("Entry Info - Path: %s, Entry ID: %s", entryInfo.Entry.FileName, entryInfo.Entry.EntryID)
+		if entryInfo.Entry.Details != nil {
+			fmt.Printf(", File State: %s", entryInfo.Entry.Details.FileState.String())
+		}
+		fmt.Println()
 	}
 	getAndPrintEntry()
 

--- a/ctl/internal/cmd/entry/info.go
+++ b/ctl/internal/cmd/entry/info.go
@@ -165,60 +165,68 @@ func assembleRetroEntry(info *entry.GetEntryCombinedInfo, frontendCfg entryInfoC
 		printMetaNodeInfo(info.Entry, false)
 	}
 
-	fmt.Fprintf(entryToPrint, "Stripe pattern details:\n")
-	fmt.Fprintf(entryToPrint, "+ Type: %s\n", info.Entry.Pattern.Type)
-	if viper.GetBool(config.RawKey) {
-		fmt.Fprintf(entryToPrint, "+ Chunksize: %d\n", info.Entry.Pattern.Chunksize)
+	var details *entry.EntryDetails
+	if info.Entry.Details == nil {
+		fmt.Fprintf(entryToPrint, "Stripe pattern details: <not available> (%s)\n", info.Entry.EntryInfoPopulated)
+		fmt.Fprintf(entryToPrint, "Remote Storage Target Details: <not available> (%s)\n", info.Entry.EntryInfoPopulated)
 	} else {
-		fmt.Fprintf(entryToPrint, "+ Chunksize: %s\n", unitconv.FormatPrefix(float64(info.Entry.Pattern.Chunksize), unitconv.Base1024, 0))
-	}
-	fmt.Fprintf(entryToPrint, "+ Number of storage targets: ")
-	actualNumStorageTgts := len(info.Entry.Pattern.TargetIDs)
-	if actualNumStorageTgts == 0 {
-		// Expected if this is a directory.
-		fmt.Fprintf(entryToPrint, "desired: %d\n", info.Entry.Pattern.DefaultNumTargets)
-	} else {
-		fmt.Fprintf(entryToPrint, "desired: %d; actual: %d\n", info.Entry.Pattern.DefaultNumTargets, actualNumStorageTgts)
-	}
+		details = info.Entry.Details
 
-	if info.Entry.Type == beegfs.EntryDirectory {
-		fmt.Fprintf(entryToPrint, "+ Storage Pool: %d  (%s)\n", info.Entry.Pattern.StoragePoolID, info.Entry.Pattern.StoragePoolName)
-	}
-
-	if actualNumStorageTgts != 0 {
-		if info.Entry.Pattern.Type == beegfs.StripePatternBuddyMirror {
-			fmt.Fprintf(entryToPrint, "+ Storage mirror buddy groups:\n")
-			for _, tgt := range info.Entry.Pattern.TargetIDs {
-				fmt.Fprintf(entryToPrint, "  + %d\n", tgt)
-			}
+		fmt.Fprintf(entryToPrint, "Stripe pattern details:\n")
+		fmt.Fprintf(entryToPrint, "+ Type: %s\n", details.Pattern.Type)
+		if viper.GetBool(config.RawKey) {
+			fmt.Fprintf(entryToPrint, "+ Chunksize: %d\n", details.Pattern.Chunksize)
 		} else {
-			fmt.Fprintf(entryToPrint, "+ Storage targets:\n")
-			for _, tgt := range info.Entry.Pattern.TargetIDs {
-				// This differs slightly from the v7 CTL. The v7 method of getting target mappings
-				// first determined the node ID, then used this to determine the alias. It was
-				// possible to get the node ID but not the alias which printed <unknown(nodeNumID)>.
-				// The new target mapper works differently, looking up the node ID and alias at
-				// once, so if anything goes wrong we can't even print the node ID.
-				node, ok := info.Entry.Pattern.StorageTargets[beegfs.NumId(tgt)]
-				if ok && node != nil {
-					fmt.Fprintf(entryToPrint, "+ %d @ %s [ID: %d]\n", tgt, node.Alias, node.LegacyId.NumId)
-				} else {
-					fmt.Fprintf(entryToPrint, "+ %d @ <unknown>\n", tgt)
-				}
+			fmt.Fprintf(entryToPrint, "+ Chunksize: %s\n", unitconv.FormatPrefix(float64(details.Pattern.Chunksize), unitconv.Base1024, 0))
+		}
+		fmt.Fprintf(entryToPrint, "+ Number of storage targets: ")
+		actualNumStorageTgts := len(details.Pattern.TargetIDs)
+		if actualNumStorageTgts == 0 {
+			// Expected if this is a directory.
+			fmt.Fprintf(entryToPrint, "desired: %d\n", details.Pattern.DefaultNumTargets)
+		} else {
+			fmt.Fprintf(entryToPrint, "desired: %d; actual: %d\n", details.Pattern.DefaultNumTargets, actualNumStorageTgts)
+		}
 
+		if info.Entry.Type == beegfs.EntryDirectory {
+			fmt.Fprintf(entryToPrint, "+ Storage Pool: %d  (%s)\n", details.Pattern.StoragePoolID, details.Pattern.StoragePoolName)
+		}
+
+		if actualNumStorageTgts != 0 {
+			if details.Pattern.Type == beegfs.StripePatternBuddyMirror {
+				fmt.Fprintf(entryToPrint, "+ Storage mirror buddy groups:\n")
+				for _, tgt := range details.Pattern.TargetIDs {
+					fmt.Fprintf(entryToPrint, "  + %d\n", tgt)
+				}
+			} else {
+				fmt.Fprintf(entryToPrint, "+ Storage targets:\n")
+				for _, tgt := range details.Pattern.TargetIDs {
+					// This differs slightly from the v7 CTL. The v7 method of getting target mappings
+					// first determined the node ID, then used this to determine the alias. It was
+					// possible to get the node ID but not the alias which printed <unknown(nodeNumID)>.
+					// The new target mapper works differently, looking up the node ID and alias at
+					// once, so if anything goes wrong we can't even print the node ID.
+					node, ok := details.Pattern.StorageTargets[beegfs.NumId(tgt)]
+					if ok && node != nil {
+						fmt.Fprintf(entryToPrint, "+ %d @ %s [ID: %d]\n", tgt, node.Alias, node.LegacyId.NumId)
+					} else {
+						fmt.Fprintf(entryToPrint, "+ %d @ <unknown>\n", tgt)
+					}
+
+				}
 			}
 		}
-	}
 
-	if len(info.Entry.Remote.Targets) != 0 {
-		fmt.Fprintf(entryToPrint, "Remote Storage Target Details:\n")
-		fmt.Fprintf(entryToPrint, "+ CoolDown: %d\n", info.Entry.Remote.CoolDownPeriod)
-		fmt.Fprintf(entryToPrint, "+ Remote Storage Targets:\n")
-		for rstID, rst := range info.Entry.Remote.Targets {
-			if rst == nil {
-				fmt.Fprintf(entryToPrint, "  + <not available> [ID: %d]\n", rstID)
-			} else {
-				fmt.Fprintf(entryToPrint, "  + %s [ID: %d]\n", rst.Name, rstID)
+		if len(details.Remote.Targets) != 0 {
+			fmt.Fprintf(entryToPrint, "Remote Storage Target Details:\n")
+			fmt.Fprintf(entryToPrint, "+ CoolDown: %d\n", details.Remote.CoolDownPeriod)
+			fmt.Fprintf(entryToPrint, "+ Remote Storage Targets:\n")
+			for rstID, rst := range details.Remote.Targets {
+				if rst == nil {
+					fmt.Fprintf(entryToPrint, "  + <not available> [ID: %d]\n", rstID)
+				} else {
+					fmt.Fprintf(entryToPrint, "  + %s [ID: %d]\n", rst.Name, rstID)
+				}
 			}
 		}
 	}
@@ -235,7 +243,11 @@ func assembleRetroEntry(info *entry.GetEntryCombinedInfo, frontendCfg entryInfoC
 		}
 
 		if info.Entry.Type == beegfs.EntryRegularFile {
-			fmt.Fprintf(entryToPrint, "File state: %s\n", info.Entry.FileState)
+			if details != nil {
+				fmt.Fprintf(entryToPrint, "File state: %s\n", details.FileState)
+			} else {
+				fmt.Fprintf(entryToPrint, "File state: <not available> (%s)\n", info.Entry.EntryInfoPopulated)
+			}
 		}
 
 		if info.Entry.EntryID != "root" && len(info.Entry.Verbose.DentryPath) != 0 {
@@ -249,8 +261,12 @@ func assembleRetroEntry(info *entry.GetEntryCombinedInfo, frontendCfg entryInfoC
 			printMetaNodeInfo(info.Entry, true)
 		}
 		if info.Entry.Type == beegfs.EntryRegularFile {
-			fmt.Fprintf(entryToPrint, "Client Sessions\n")
-			fmt.Fprintf(entryToPrint, "+ Reading: %d\n+ Writing: %d\n", info.Entry.NumSessionsRead, info.Entry.NumSessionsWrite)
+			if details != nil {
+				fmt.Fprintf(entryToPrint, "Client Sessions\n")
+				fmt.Fprintf(entryToPrint, "+ Reading: %d\n+ Writing: %d\n", details.NumSessionsRead, details.NumSessionsWrite)
+			} else {
+				fmt.Fprintf(entryToPrint, "Client Sessions: <not available> (%s)\n", info.Entry.EntryInfoPopulated)
+			}
 		}
 	}
 	return entryToPrint.String()
@@ -278,16 +294,28 @@ func assembleTableRow(info *entry.GetEntryCombinedInfo, rowLen int) []any {
 		row = append(row, "(unmirrored)")
 	}
 
+	if info.Entry.Details == nil {
+		// Entry details from GetEntryInfoResponse are unavailable (e.g., inode locked during
+		// rebalancing). Fill all remaining columns with "(unavailable)".
+		unavailable := fmt.Sprintf("(unavailable: %s)", info.Entry.EntryInfoPopulated)
+		for len(row) < rowLen {
+			row = append(row, unavailable)
+		}
+		return row
+	}
+
+	d := info.Entry.Details
+
 	if info.Entry.Type == beegfs.EntryDirectory {
-		row = append(row, fmt.Sprintf("%s (%d)", info.Entry.Pattern.StoragePoolName, info.Entry.Pattern.StoragePoolID))
+		row = append(row, fmt.Sprintf("%s (%d)", d.Pattern.StoragePoolName, d.Pattern.StoragePoolID))
 	} else {
 		row = append(row, fmt.Sprintf("(%s)", info.Entry.Type))
 	}
 
 	if viper.GetBool(config.RawKey) {
-		row = append(row, fmt.Sprintf("%s (%dx%d)", info.Entry.Pattern.Type, info.Entry.Pattern.DefaultNumTargets, info.Entry.Pattern.Chunksize))
+		row = append(row, fmt.Sprintf("%s (%dx%d)", d.Pattern.Type, d.Pattern.DefaultNumTargets, d.Pattern.Chunksize))
 	} else {
-		row = append(row, fmt.Sprintf("%s (%dx%s)", info.Entry.Pattern.Type, info.Entry.Pattern.DefaultNumTargets, unitconv.FormatPrefix(float64(info.Entry.Pattern.Chunksize), unitconv.Base1024, 0)))
+		row = append(row, fmt.Sprintf("%s (%dx%s)", d.Pattern.Type, d.Pattern.DefaultNumTargets, unitconv.FormatPrefix(float64(d.Pattern.Chunksize), unitconv.Base1024, 0)))
 	}
 
 	fmtTgtIDsFunc := func(targetIDs []uint16) string {
@@ -311,17 +339,17 @@ func assembleTableRow(info *entry.GetEntryCombinedInfo, rowLen int) []any {
 	if info.Entry.Type == beegfs.EntryDirectory {
 		row = append(row, "(directory)", "(directory)")
 	} else {
-		if info.Entry.Pattern.Type == beegfs.StripePatternBuddyMirror {
-			row = append(row, "(mirrored)", fmtTgtIDsFunc(info.Entry.Pattern.TargetIDs))
+		if d.Pattern.Type == beegfs.StripePatternBuddyMirror {
+			row = append(row, "(mirrored)", fmtTgtIDsFunc(d.Pattern.TargetIDs))
 		} else {
-			row = append(row, fmtTgtIDsFunc(info.Entry.Pattern.TargetIDs), "(unmirrored)")
+			row = append(row, fmtTgtIDsFunc(d.Pattern.TargetIDs), "(unmirrored)")
 		}
 	}
 
-	if len(info.Entry.Remote.Targets) != 0 {
+	if len(d.Remote.Targets) != 0 {
 		i := 0
 		var rstBuilder strings.Builder
-		for rstID, rst := range info.Entry.Remote.Targets {
+		for rstID, rst := range d.Remote.Targets {
 			if i > 0 {
 				rstBuilder.WriteString(",")
 			}
@@ -332,15 +360,15 @@ func assembleTableRow(info *entry.GetEntryCombinedInfo, rowLen int) []any {
 			}
 			i++
 		}
-		row = append(row, rstBuilder.String(), fmt.Sprintf("%ds", info.Entry.Remote.CoolDownPeriod))
+		row = append(row, rstBuilder.String(), fmt.Sprintf("%ds", d.Remote.CoolDownPeriod))
 	} else {
 		row = append(row, "(none)", "(n/a)")
 	}
 
 	if info.Entry.Type == beegfs.EntryRegularFile {
 		row = append(row,
-			fmt.Sprintf("Reading: %d, Writing: %d", info.Entry.NumSessionsRead, info.Entry.NumSessionsWrite),
-			info.Entry.FileState.GetAccessFlags(), info.Entry.FileState.GetDataState())
+			fmt.Sprintf("Reading: %d, Writing: %d", d.NumSessionsRead, d.NumSessionsWrite),
+			d.FileState.GetAccessFlags(), d.FileState.GetDataState())
 	} else {
 		row = append(row, fmt.Sprintf("(%s)", info.Entry.Type.String()), "(n/a)", "(n/a)")
 	}

--- a/ctl/internal/cmd/entry/info.go
+++ b/ctl/internal/cmd/entry/info.go
@@ -165,41 +165,48 @@ func assembleRetroEntry(info *entry.GetEntryCombinedInfo, frontendCfg entryInfoC
 		printMetaNodeInfo(info.Entry, false)
 	}
 
+	if info.Entry.Details == nil {
+		fmt.Fprintf(entryToPrint, "Entry details: <not available> (%s)\n", info.Entry.EntryInfoPopulated)
+		return entryToPrint.String()
+	}
+
+	d := info.Entry.Details
+
 	fmt.Fprintf(entryToPrint, "Stripe pattern details:\n")
-	fmt.Fprintf(entryToPrint, "+ Type: %s\n", info.Entry.Pattern.Type)
+	fmt.Fprintf(entryToPrint, "+ Type: %s\n", d.Pattern.Type)
 	if viper.GetBool(config.RawKey) {
-		fmt.Fprintf(entryToPrint, "+ Chunksize: %d\n", info.Entry.Pattern.Chunksize)
+		fmt.Fprintf(entryToPrint, "+ Chunksize: %d\n", d.Pattern.Chunksize)
 	} else {
-		fmt.Fprintf(entryToPrint, "+ Chunksize: %s\n", unitconv.FormatPrefix(float64(info.Entry.Pattern.Chunksize), unitconv.Base1024, 0))
+		fmt.Fprintf(entryToPrint, "+ Chunksize: %s\n", unitconv.FormatPrefix(float64(d.Pattern.Chunksize), unitconv.Base1024, 0))
 	}
 	fmt.Fprintf(entryToPrint, "+ Number of storage targets: ")
-	actualNumStorageTgts := len(info.Entry.Pattern.TargetIDs)
+	actualNumStorageTgts := len(d.Pattern.TargetIDs)
 	if actualNumStorageTgts == 0 {
 		// Expected if this is a directory.
-		fmt.Fprintf(entryToPrint, "desired: %d\n", info.Entry.Pattern.DefaultNumTargets)
+		fmt.Fprintf(entryToPrint, "desired: %d\n", d.Pattern.DefaultNumTargets)
 	} else {
-		fmt.Fprintf(entryToPrint, "desired: %d; actual: %d\n", info.Entry.Pattern.DefaultNumTargets, actualNumStorageTgts)
+		fmt.Fprintf(entryToPrint, "desired: %d; actual: %d\n", d.Pattern.DefaultNumTargets, actualNumStorageTgts)
 	}
 
 	if info.Entry.Type == beegfs.EntryDirectory {
-		fmt.Fprintf(entryToPrint, "+ Storage Pool: %d  (%s)\n", info.Entry.Pattern.StoragePoolID, info.Entry.Pattern.StoragePoolName)
+		fmt.Fprintf(entryToPrint, "+ Storage Pool: %d  (%s)\n", d.Pattern.StoragePoolID, d.Pattern.StoragePoolName)
 	}
 
 	if actualNumStorageTgts != 0 {
-		if info.Entry.Pattern.Type == beegfs.StripePatternBuddyMirror {
+		if d.Pattern.Type == beegfs.StripePatternBuddyMirror {
 			fmt.Fprintf(entryToPrint, "+ Storage mirror buddy groups:\n")
-			for _, tgt := range info.Entry.Pattern.TargetIDs {
+			for _, tgt := range d.Pattern.TargetIDs {
 				fmt.Fprintf(entryToPrint, "  + %d\n", tgt)
 			}
 		} else {
 			fmt.Fprintf(entryToPrint, "+ Storage targets:\n")
-			for _, tgt := range info.Entry.Pattern.TargetIDs {
+			for _, tgt := range d.Pattern.TargetIDs {
 				// This differs slightly from the v7 CTL. The v7 method of getting target mappings
 				// first determined the node ID, then used this to determine the alias. It was
 				// possible to get the node ID but not the alias which printed <unknown(nodeNumID)>.
 				// The new target mapper works differently, looking up the node ID and alias at
 				// once, so if anything goes wrong we can't even print the node ID.
-				node, ok := info.Entry.Pattern.StorageTargets[beegfs.NumId(tgt)]
+				node, ok := d.Pattern.StorageTargets[beegfs.NumId(tgt)]
 				if ok && node != nil {
 					fmt.Fprintf(entryToPrint, "+ %d @ %s [ID: %d]\n", tgt, node.Alias, node.LegacyId.NumId)
 				} else {
@@ -210,11 +217,11 @@ func assembleRetroEntry(info *entry.GetEntryCombinedInfo, frontendCfg entryInfoC
 		}
 	}
 
-	if len(info.Entry.Remote.Targets) != 0 {
+	if len(d.Remote.Targets) != 0 {
 		fmt.Fprintf(entryToPrint, "Remote Storage Target Details:\n")
-		fmt.Fprintf(entryToPrint, "+ CoolDown: %d\n", info.Entry.Remote.CoolDownPeriod)
+		fmt.Fprintf(entryToPrint, "+ CoolDown: %d\n", d.Remote.CoolDownPeriod)
 		fmt.Fprintf(entryToPrint, "+ Remote Storage Targets:\n")
-		for rstID, rst := range info.Entry.Remote.Targets {
+		for rstID, rst := range d.Remote.Targets {
 			if rst == nil {
 				fmt.Fprintf(entryToPrint, "  + <not available> [ID: %d]\n", rstID)
 			} else {
@@ -235,7 +242,7 @@ func assembleRetroEntry(info *entry.GetEntryCombinedInfo, frontendCfg entryInfoC
 		}
 
 		if info.Entry.Type == beegfs.EntryRegularFile {
-			fmt.Fprintf(entryToPrint, "File state: %s\n", info.Entry.FileState)
+			fmt.Fprintf(entryToPrint, "File state: %s\n", d.FileState)
 		}
 
 		if info.Entry.EntryID != "root" && len(info.Entry.Verbose.DentryPath) != 0 {
@@ -250,7 +257,7 @@ func assembleRetroEntry(info *entry.GetEntryCombinedInfo, frontendCfg entryInfoC
 		}
 		if info.Entry.Type == beegfs.EntryRegularFile {
 			fmt.Fprintf(entryToPrint, "Client Sessions\n")
-			fmt.Fprintf(entryToPrint, "+ Reading: %d\n+ Writing: %d\n", info.Entry.NumSessionsRead, info.Entry.NumSessionsWrite)
+			fmt.Fprintf(entryToPrint, "+ Reading: %d\n+ Writing: %d\n", d.NumSessionsRead, d.NumSessionsWrite)
 		}
 	}
 	return entryToPrint.String()
@@ -278,16 +285,28 @@ func assembleTableRow(info *entry.GetEntryCombinedInfo, rowLen int) []any {
 		row = append(row, "(unmirrored)")
 	}
 
+	if info.Entry.Details == nil {
+		// Entry details from GetEntryInfoResponse are unavailable (e.g., inode locked during
+		// rebalancing). Fill all remaining columns with "(unavailable)".
+		unavailable := fmt.Sprintf("(unavailable: %s)", info.Entry.EntryInfoPopulated)
+		for len(row) < rowLen {
+			row = append(row, unavailable)
+		}
+		return row
+	}
+
+	d := info.Entry.Details
+
 	if info.Entry.Type == beegfs.EntryDirectory {
-		row = append(row, fmt.Sprintf("%s (%d)", info.Entry.Pattern.StoragePoolName, info.Entry.Pattern.StoragePoolID))
+		row = append(row, fmt.Sprintf("%s (%d)", d.Pattern.StoragePoolName, d.Pattern.StoragePoolID))
 	} else {
 		row = append(row, fmt.Sprintf("(%s)", info.Entry.Type))
 	}
 
 	if viper.GetBool(config.RawKey) {
-		row = append(row, fmt.Sprintf("%s (%dx%d)", info.Entry.Pattern.Type, info.Entry.Pattern.DefaultNumTargets, info.Entry.Pattern.Chunksize))
+		row = append(row, fmt.Sprintf("%s (%dx%d)", d.Pattern.Type, d.Pattern.DefaultNumTargets, d.Pattern.Chunksize))
 	} else {
-		row = append(row, fmt.Sprintf("%s (%dx%s)", info.Entry.Pattern.Type, info.Entry.Pattern.DefaultNumTargets, unitconv.FormatPrefix(float64(info.Entry.Pattern.Chunksize), unitconv.Base1024, 0)))
+		row = append(row, fmt.Sprintf("%s (%dx%s)", d.Pattern.Type, d.Pattern.DefaultNumTargets, unitconv.FormatPrefix(float64(d.Pattern.Chunksize), unitconv.Base1024, 0)))
 	}
 
 	fmtTgtIDsFunc := func(targetIDs []uint16) string {
@@ -311,17 +330,17 @@ func assembleTableRow(info *entry.GetEntryCombinedInfo, rowLen int) []any {
 	if info.Entry.Type == beegfs.EntryDirectory {
 		row = append(row, "(directory)", "(directory)")
 	} else {
-		if info.Entry.Pattern.Type == beegfs.StripePatternBuddyMirror {
-			row = append(row, "(mirrored)", fmtTgtIDsFunc(info.Entry.Pattern.TargetIDs))
+		if d.Pattern.Type == beegfs.StripePatternBuddyMirror {
+			row = append(row, "(mirrored)", fmtTgtIDsFunc(d.Pattern.TargetIDs))
 		} else {
-			row = append(row, fmtTgtIDsFunc(info.Entry.Pattern.TargetIDs), "(unmirrored)")
+			row = append(row, fmtTgtIDsFunc(d.Pattern.TargetIDs), "(unmirrored)")
 		}
 	}
 
-	if len(info.Entry.Remote.Targets) != 0 {
+	if len(d.Remote.Targets) != 0 {
 		i := 0
 		var rstBuilder strings.Builder
-		for rstID, rst := range info.Entry.Remote.Targets {
+		for rstID, rst := range d.Remote.Targets {
 			if i > 0 {
 				rstBuilder.WriteString(",")
 			}
@@ -332,15 +351,15 @@ func assembleTableRow(info *entry.GetEntryCombinedInfo, rowLen int) []any {
 			}
 			i++
 		}
-		row = append(row, rstBuilder.String(), fmt.Sprintf("%ds", info.Entry.Remote.CoolDownPeriod))
+		row = append(row, rstBuilder.String(), fmt.Sprintf("%ds", d.Remote.CoolDownPeriod))
 	} else {
 		row = append(row, "(none)", "(n/a)")
 	}
 
 	if info.Entry.Type == beegfs.EntryRegularFile {
 		row = append(row,
-			fmt.Sprintf("Reading: %d, Writing: %d", info.Entry.NumSessionsRead, info.Entry.NumSessionsWrite),
-			info.Entry.FileState.GetAccessFlags(), info.Entry.FileState.GetDataState())
+			fmt.Sprintf("Reading: %d, Writing: %d", d.NumSessionsRead, d.NumSessionsWrite),
+			d.FileState.GetAccessFlags(), d.FileState.GetDataState())
 	} else {
 		row = append(row, fmt.Sprintf("(%s)", info.Entry.Type.String()), "(n/a)", "(n/a)")
 	}

--- a/ctl/pkg/ctl/entry/chooser.go
+++ b/ctl/pkg/ctl/entry/chooser.go
@@ -10,10 +10,18 @@ import (
 )
 
 var (
-	// This can happen in a system with hard links where a rebalance is started for the first link
-	// and we encounter additional links to the same inode. Testing shows target IDs will be empty
-	// when this happens.
+	// ErrEntryHasNoTargets is returned when the stripe pattern has no target IDs. Historically this
+	// was the primary indicator that an inode was locked during chunk rebalancing, because the old
+	// code path silently populated Entry fields from a failed GetEntryInfoResponse, resulting in a
+	// zero-value (empty) stripe pattern. Now that Entry.Details is nil when the response fails,
+	// ErrEntryDetailsUnavailable should be returned in that case instead. This error is retained
+	// for any scenario where the RPC succeeds but the stripe pattern is genuinely empty.
 	ErrEntryHasNoTargets = errors.New("stripe pattern is currently empty")
+	// ErrEntryDetailsUnavailable is returned when Entry.Details is nil, meaning the
+	// GetEntryInfoResponse did not succeed (e.g., the inode was locked during chunk rebalancing).
+	// This replaces the previous behavior where a locked inode would silently produce zero-value
+	// fields, causing ErrEntryHasNoTargets to be returned instead.
+	ErrEntryDetailsUnavailable = errors.New("entry details unavailable")
 )
 
 func getRandomIDChooser() func(fromDstIDs []uint16, idsAlreadyInStripePattern []uint16) (uint16, error) {
@@ -70,7 +78,11 @@ func getMigrationForEntry(
 	dstGroups []uint16,
 ) (rebalanceType msg.RebalanceIDType, srcIDs []uint16, dstIDs []uint16, unmodifiedIDs []uint16, err error) {
 
-	if len(entry.Entry.Pattern.TargetIDs) == 0 {
+	if entry.Entry.Details == nil {
+		return 0, nil, nil, nil, fmt.Errorf("%w: %s", ErrEntryDetailsUnavailable, entry.Entry.EntryInfoPopulated)
+	}
+
+	if len(entry.Entry.Details.Pattern.TargetIDs) == 0 {
 		return 0, nil, nil, nil, ErrEntryHasNoTargets
 	}
 
@@ -81,14 +93,14 @@ func getMigrationForEntry(
 	dstIDs = make([]uint16, 0, 4)
 	unmodifiedIDs = make([]uint16, 0, 4)
 	var rebalanceIDType msg.RebalanceIDType = msg.RebalanceIDTypeInvalid
-	switch entry.Entry.Pattern.Type {
+	switch entry.Entry.Details.Pattern.Type {
 	case beegfs.StripePatternBuddyMirror:
 		rebalanceIDType = msg.RebalanceIDTypeGroup
-		for _, group := range entry.Entry.Pattern.TargetIDs {
+		for _, group := range entry.Entry.Details.Pattern.TargetIDs {
 			if _, ok := srcGroups[group]; ok {
-				randomID, err := targetChooser(dstGroups, entry.Entry.Pattern.TargetIDs)
+				randomID, err := targetChooser(dstGroups, entry.Entry.Details.Pattern.TargetIDs)
 				if err != nil {
-					return msg.RebalanceIDTypeInvalid, nil, nil, nil, fmt.Errorf("insufficient available destination groups to migrate entry away from the specified groups (entry is currently assigned to groups %v)", entry.Entry.Pattern.TargetIDs)
+					return msg.RebalanceIDTypeInvalid, nil, nil, nil, fmt.Errorf("insufficient available destination groups to migrate entry away from the specified groups (entry is currently assigned to groups %v)", entry.Entry.Details.Pattern.TargetIDs)
 				}
 				srcIDs = append(srcIDs, group)
 				dstIDs = append(dstIDs, randomID)
@@ -98,11 +110,11 @@ func getMigrationForEntry(
 		}
 	case beegfs.StripePatternRaid0:
 		rebalanceIDType = msg.RebalanceIDTypeTarget
-		for _, target := range entry.Entry.Pattern.TargetIDs {
+		for _, target := range entry.Entry.Details.Pattern.TargetIDs {
 			if _, ok := srcTargets[target]; ok {
-				randomID, err := targetChooser(dstTargets, entry.Entry.Pattern.TargetIDs)
+				randomID, err := targetChooser(dstTargets, entry.Entry.Details.Pattern.TargetIDs)
 				if err != nil {
-					return msg.RebalanceIDTypeInvalid, nil, nil, nil, fmt.Errorf("insufficient available destination targets to migrate entry away from the specified targets (entry is currently assigned to targets %v)", entry.Entry.Pattern.TargetIDs)
+					return msg.RebalanceIDTypeInvalid, nil, nil, nil, fmt.Errorf("insufficient available destination targets to migrate entry away from the specified targets (entry is currently assigned to targets %v)", entry.Entry.Details.Pattern.TargetIDs)
 				}
 				srcIDs = append(srcIDs, target)
 				dstIDs = append(dstIDs, randomID)
@@ -111,7 +123,7 @@ func getMigrationForEntry(
 			}
 		}
 	default:
-		return msg.RebalanceIDTypeInvalid, nil, nil, nil, fmt.Errorf("unsupported pattern type: %s", entry.Entry.Pattern.Type)
+		return msg.RebalanceIDTypeInvalid, nil, nil, nil, fmt.Errorf("unsupported pattern type: %s", entry.Entry.Details.Pattern.Type)
 	}
 
 	return rebalanceIDType, srcIDs, dstIDs, unmodifiedIDs, nil

--- a/ctl/pkg/ctl/entry/chooser_test.go
+++ b/ctl/pkg/ctl/entry/chooser_test.go
@@ -25,10 +25,12 @@ func TestStartRebalancingJobs(t *testing.T) {
 			name: "Raid0 Rebalance Needed",
 			entry: &GetEntryCombinedInfo{
 				Entry: Entry{
-					Pattern: patternConfig{
-						StripePattern: msg.StripePattern{
-							Type:      beegfs.StripePatternRaid0,
-							TargetIDs: []uint16{2},
+					Details: &EntryDetails{
+						Pattern: patternConfig{
+							StripePattern: msg.StripePattern{
+								Type:      beegfs.StripePatternRaid0,
+								TargetIDs: []uint16{2},
+							},
 						},
 					},
 				},
@@ -42,10 +44,12 @@ func TestStartRebalancingJobs(t *testing.T) {
 			name: "Raid0 Rebalance Needed (out-of-order targets)",
 			entry: &GetEntryCombinedInfo{
 				Entry: Entry{
-					Pattern: patternConfig{
-						StripePattern: msg.StripePattern{
-							Type:      beegfs.StripePatternRaid0,
-							TargetIDs: []uint16{101, 103, 104, 102},
+					Details: &EntryDetails{
+						Pattern: patternConfig{
+							StripePattern: msg.StripePattern{
+								Type:      beegfs.StripePatternRaid0,
+								TargetIDs: []uint16{101, 103, 104, 102},
+							},
 						},
 					},
 				},
@@ -59,10 +63,12 @@ func TestStartRebalancingJobs(t *testing.T) {
 			name: "Raid0 Rebalance Needed (out-of-order targets / insufficient dstTargets)",
 			entry: &GetEntryCombinedInfo{
 				Entry: Entry{
-					Pattern: patternConfig{
-						StripePattern: msg.StripePattern{
-							Type:      beegfs.StripePatternRaid0,
-							TargetIDs: []uint16{101, 103, 104, 102},
+					Details: &EntryDetails{
+						Pattern: patternConfig{
+							StripePattern: msg.StripePattern{
+								Type:      beegfs.StripePatternRaid0,
+								TargetIDs: []uint16{101, 103, 104, 102},
+							},
 						},
 					},
 				},
@@ -77,10 +83,12 @@ func TestStartRebalancingJobs(t *testing.T) {
 			name: "Raid0 Rebalance Needed (insufficient dstTargets)",
 			entry: &GetEntryCombinedInfo{
 				Entry: Entry{
-					Pattern: patternConfig{
-						StripePattern: msg.StripePattern{
-							Type:      beegfs.StripePatternRaid0,
-							TargetIDs: []uint16{1, 2},
+					Details: &EntryDetails{
+						Pattern: patternConfig{
+							StripePattern: msg.StripePattern{
+								Type:      beegfs.StripePatternRaid0,
+								TargetIDs: []uint16{1, 2},
+							},
 						},
 					},
 				},
@@ -95,10 +103,12 @@ func TestStartRebalancingJobs(t *testing.T) {
 			name: "Raid0 Rebalance Needed (insufficient dstTargets due to dstTargets already in stripe)",
 			entry: &GetEntryCombinedInfo{
 				Entry: Entry{
-					Pattern: patternConfig{
-						StripePattern: msg.StripePattern{
-							Type:      beegfs.StripePatternRaid0,
-							TargetIDs: []uint16{1, 2, 3, 4},
+					Details: &EntryDetails{
+						Pattern: patternConfig{
+							StripePattern: msg.StripePattern{
+								Type:      beegfs.StripePatternRaid0,
+								TargetIDs: []uint16{1, 2, 3, 4},
+							},
 						},
 					},
 				},
@@ -113,10 +123,12 @@ func TestStartRebalancingJobs(t *testing.T) {
 			name: "BuddyMirror Rebalance Needed",
 			entry: &GetEntryCombinedInfo{
 				Entry: Entry{
-					Pattern: patternConfig{
-						StripePattern: msg.StripePattern{
-							Type:      beegfs.StripePatternBuddyMirror,
-							TargetIDs: []uint16{4, 5, 6},
+					Details: &EntryDetails{
+						Pattern: patternConfig{
+							StripePattern: msg.StripePattern{
+								Type:      beegfs.StripePatternBuddyMirror,
+								TargetIDs: []uint16{4, 5, 6},
+							},
 						},
 					},
 				},
@@ -130,10 +142,12 @@ func TestStartRebalancingJobs(t *testing.T) {
 			name: "BuddyMirror Rebalance Needed (insufficient dstGroups)",
 			entry: &GetEntryCombinedInfo{
 				Entry: Entry{
-					Pattern: patternConfig{
-						StripePattern: msg.StripePattern{
-							Type:      beegfs.StripePatternBuddyMirror,
-							TargetIDs: []uint16{5, 6, 7},
+					Details: &EntryDetails{
+						Pattern: patternConfig{
+							StripePattern: msg.StripePattern{
+								Type:      beegfs.StripePatternBuddyMirror,
+								TargetIDs: []uint16{5, 6, 7},
+							},
 						},
 					},
 				},
@@ -148,10 +162,12 @@ func TestStartRebalancingJobs(t *testing.T) {
 			name: "No Rebalance Needed",
 			entry: &GetEntryCombinedInfo{
 				Entry: Entry{
-					Pattern: patternConfig{
-						StripePattern: msg.StripePattern{
-							Type:      beegfs.StripePatternRaid0,
-							TargetIDs: []uint16{9},
+					Details: &EntryDetails{
+						Pattern: patternConfig{
+							StripePattern: msg.StripePattern{
+								Type:      beegfs.StripePatternRaid0,
+								TargetIDs: []uint16{9},
+							},
 						},
 					},
 				},

--- a/ctl/pkg/ctl/entry/create.go
+++ b/ctl/pkg/ctl/entry/create.go
@@ -81,6 +81,10 @@ func generateAndVerifyMakeFileReq(userCfg *CreateEntryCfg, parent *GetEntryCombi
 		return nil, fmt.Errorf("permissions must be set")
 	}
 
+	if parent.Entry.Details == nil {
+		return nil, fmt.Errorf("full entry details unavailable for parent: %s", parent.Entry.EntryInfoPopulated)
+	}
+
 	var err error
 	request := &msg.MakeFileWithPatternRequest{
 		UserID:  *userCfg.UserID,
@@ -91,8 +95,8 @@ func generateAndVerifyMakeFileReq(userCfg *CreateEntryCfg, parent *GetEntryCombi
 		Umask:      0000,
 		ParentInfo: *parent.Entry.origEntryInfoMsg,
 		// Start with the parent pattern and RST config.
-		Pattern: parent.Entry.Pattern.StripePattern,
-		RST:     parent.Entry.Remote.RemoteStorageTarget,
+		Pattern: parent.Entry.Details.Pattern.StripePattern,
+		RST:     parent.Entry.Details.Remote.RemoteStorageTarget,
 		// NewFileName must be set by the caller.
 	}
 
@@ -124,7 +128,7 @@ func generateAndVerifyMakeFileReq(userCfg *CreateEntryCfg, parent *GetEntryCombi
 		// below to ensure it is valid for the configured stripe pattern.
 		storagePool, err = mappings.StoragePoolToConfig.Get(beegfs.LegacyId{
 			NodeType: beegfs.Storage,
-			NumId:    beegfs.NumId(parent.Entry.Pattern.StoragePoolID),
+			NumId:    beegfs.NumId(parent.Entry.Details.Pattern.StoragePoolID),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("error looking up pool for parent entry %s: %w", *userCfg.FileCfg.Pool, err)

--- a/ctl/pkg/ctl/entry/entry.go
+++ b/ctl/pkg/ctl/entry/entry.go
@@ -71,8 +71,27 @@ type Entry struct {
 	FileName       string
 	Type           beegfs.EntryType
 	FeatureFlags   beegfs.EntryFeatureFlags
-	Pattern        patternConfig
-	Remote         remoteConfig
+	// Details contains fields populated from the GetEntryInfoResponse. It is nil when the response
+	// did not succeed (check EntryInfoPopulated for the specific error code). This notably occurs
+	// when the inode is in the metadata's inode lock store (e.g., during chunk rebalancing).
+	Details *EntryDetails
+	// Only populated if GetEntryConfig.Verbose.
+	Verbose Verbose
+	// Only populated if getEntries() is called with includeOrigMsg. This is mostly useful for other
+	// modes like set pattern that need to include the EntryInfo message so they don't need to recreate
+	// the message from scratch.
+	origEntryInfoMsg *msg.EntryInfo
+	// EntryInfoPopulated indicates whether the GetEntryInfoResponse was successfully populated.
+	// When not OpsErr_SUCCESS, Details will be nil.
+	EntryInfoPopulated beegfs.OpsErr
+}
+
+// EntryDetails contains fields populated from the GetEntryInfoResponse RPC. This struct is nil on
+// Entry when the response did not succeed. All new fields derived from GetEntryInfoResponse should
+// be added here so the display layer automatically handles the unavailable case.
+type EntryDetails struct {
+	Pattern patternConfig
+	Remote  remoteConfig
 	// NumSessionsRead is only applicable for regular files. Note sessions is the number of clients
 	// that have this file open for reading at least once. If the same file has the a file opened
 	// multiple times, it is still treated as a single session for that client.
@@ -86,12 +105,6 @@ type Entry struct {
 	// operations or if access is restricted. The data state value is arbitrary and meaningful only to the
 	// data management application (or users).
 	FileState beegfs.FileState
-	// Only populated if GetEntryConfig.Verbose.
-	Verbose Verbose
-	// Only populated if getEntries() is called with includeOrigMsg. This is mostly useful for other
-	// modes like set pattern that need to include the EntryInfo message so they don't need to recreate
-	// the message from scratch.
-	origEntryInfoMsg *msg.EntryInfo
 }
 
 // patternConfig embeds the BeeMsg defined stripe pattern alongside fields that map various
@@ -129,12 +142,24 @@ func (entryInfo *GetEntryCombinedInfo) GetOrigEntryInfo() *msg.EntryInfo {
 func newEntry(ctx context.Context, mappings *util.Mappings, entry msg.EntryInfo, ownerNode beegfs.Node, entryInfo msg.GetEntryInfoResponse) Entry {
 
 	e := Entry{
-		MetaOwnerNode: ownerNode,
-		ParentEntryID: string(entry.ParentEntryID),
-		EntryID:       string(entry.EntryID),
-		FileName:      string(entry.FileName),
-		Type:          entry.EntryType,
-		FeatureFlags:  entry.FeatureFlags,
+		MetaOwnerNode:      ownerNode,
+		ParentEntryID:      string(entry.ParentEntryID),
+		EntryID:            string(entry.EntryID),
+		FileName:           string(entry.FileName),
+		Type:               entry.EntryType,
+		FeatureFlags:       entry.FeatureFlags,
+		EntryInfoPopulated: entryInfo.Result,
+	}
+
+	if entry.FeatureFlags.IsBuddyMirrored() {
+		e.MetaBuddyGroup = int(entry.OwnerID)
+	}
+
+	if entryInfo.Result != beegfs.OpsErr_SUCCESS {
+		return e
+	}
+
+	e.Details = &EntryDetails{
 		Pattern: patternConfig{
 			StripePattern:   entryInfo.Pattern,
 			StoragePoolName: "<unknown>",
@@ -147,10 +172,6 @@ func newEntry(ctx context.Context, mappings *util.Mappings, entry msg.EntryInfo,
 		NumSessionsRead:  entryInfo.NumSessionsRead,
 		NumSessionsWrite: entryInfo.NumSessionsWrite,
 		FileState:        entryInfo.FileState,
-	}
-
-	if entry.FeatureFlags.IsBuddyMirrored() {
-		e.MetaBuddyGroup = int(entry.OwnerID)
 	}
 
 	fetchedMappings := false
@@ -174,7 +195,7 @@ func newEntry(ctx context.Context, mappings *util.Mappings, entry msg.EntryInfo,
 		pool, err = mappings.StoragePoolToConfig.Get(beegfs.LegacyId{NumId: beegfs.NumId(entryInfo.Pattern.StoragePoolID), NodeType: beegfs.Storage})
 	}
 	if err == nil {
-		e.Pattern.StoragePoolName = pool.Pool.Alias.String()
+		e.Details.Pattern.StoragePoolName = pool.Pool.Alias.String()
 	}
 
 	if entryInfo.Pattern.Type == beegfs.StripePatternRaid0 {
@@ -185,9 +206,9 @@ func newEntry(ctx context.Context, mappings *util.Mappings, entry msg.EntryInfo,
 				node, err = mappings.TargetToNode.Get(beegfs.LegacyId{NumId: beegfs.NumId(tgt), NodeType: beegfs.Storage})
 			}
 			if err != nil {
-				e.Pattern.StorageTargets[beegfs.NumId(tgt)] = nil
+				e.Details.Pattern.StorageTargets[beegfs.NumId(tgt)] = nil
 			} else {
-				e.Pattern.StorageTargets[beegfs.NumId(tgt)] = &node
+				e.Details.Pattern.StorageTargets[beegfs.NumId(tgt)] = &node
 			}
 		}
 	}
@@ -200,9 +221,9 @@ func newEntry(ctx context.Context, mappings *util.Mappings, entry msg.EntryInfo,
 				rst, ok = mappings.RstIdToConfig[id]
 			}
 			if !ok {
-				e.Remote.Targets[id] = nil
+				e.Details.Remote.Targets[id] = nil
 			} else {
-				e.Remote.Targets[id] = rst
+				e.Details.Remote.Targets[id] = rst
 			}
 		}
 	}
@@ -890,6 +911,9 @@ func SetDirRstIds(ctx context.Context, path string, rstIds []uint32) error {
 	if entryInfo.Entry.Type != beegfs.EntryDirectory {
 		return fmt.Errorf("entry is not a directory: %s", path)
 	}
+	if entryInfo.Entry.Details == nil {
+		return fmt.Errorf("full entry details unavailable for %s: %s", path, entryInfo.Entry.EntryInfoPopulated)
+	}
 	euid := syscall.Geteuid()
 	if euid < 0 || euid > math.MaxUint32 {
 		return fmt.Errorf("effective user ID %d is out of bounds (not a uint32)", euid)
@@ -897,8 +921,8 @@ func SetDirRstIds(ctx context.Context, path string, rstIds []uint32) error {
 
 	request := &msg.SetDirPatternRequest{
 		EntryInfo: *entryInfo.Entry.origEntryInfoMsg,
-		Pattern:   entryInfo.Entry.Pattern.StripePattern,
-		RST:       entryInfo.Entry.Remote.RemoteStorageTarget,
+		Pattern:   entryInfo.Entry.Details.Pattern.StripePattern,
+		RST:       entryInfo.Entry.Details.Remote.RemoteStorageTarget,
 	}
 	request.SetUID(uint32(euid))
 	request.RST.RSTIDs = rstIds

--- a/ctl/pkg/ctl/entry/entry.go
+++ b/ctl/pkg/ctl/entry/entry.go
@@ -71,8 +71,27 @@ type Entry struct {
 	FileName       string
 	Type           beegfs.EntryType
 	FeatureFlags   beegfs.EntryFeatureFlags
-	Pattern        patternConfig
-	Remote         remoteConfig
+	// Details contains fields populated from the GetEntryInfoResponse. It is nil when the response
+	// did not succeed (check EntryInfoPopulated for the specific error code). This notably occurs
+	// when the inode is in the metadata's inode lock store (e.g., during chunk rebalancing).
+	Details *EntryDetails
+	// Only populated if GetEntryConfig.Verbose.
+	Verbose Verbose
+	// Only populated if getEntries() is called with includeOrigMsg. This is mostly useful for other
+	// modes like set pattern that need to include the EntryInfo message so they don't need to recreate
+	// the message from scratch.
+	origEntryInfoMsg *msg.EntryInfo
+	// EntryInfoPopulated indicates whether the GetEntryInfoResponse was successfully populated.
+	// When not OpsErr_SUCCESS, Details will be nil.
+	EntryInfoPopulated beegfs.OpsErr
+}
+
+// EntryDetails contains fields populated from the GetEntryInfoResponse RPC. This struct is nil on
+// Entry when the response did not succeed. All new fields derived from GetEntryInfoResponse should
+// be added here so the display layer automatically handles the unavailable case.
+type EntryDetails struct {
+	Pattern patternConfig
+	Remote  remoteConfig
 	// NumSessionsRead is only applicable for regular files. Note sessions is the number of clients
 	// that have this file open for reading at least once. If the same file has the a file opened
 	// multiple times, it is still treated as a single session for that client.
@@ -86,12 +105,6 @@ type Entry struct {
 	// operations or if access is restricted. The data state value is arbitrary and meaningful only to the
 	// data management application (or users).
 	FileState beegfs.FileState
-	// Only populated if GetEntryConfig.Verbose.
-	Verbose Verbose
-	// Only populated if getEntries() is called with includeOrigMsg. This is mostly useful for other
-	// modes like set pattern that need to include the EntryInfo message so they don't need to recreate
-	// the message from scratch.
-	origEntryInfoMsg *msg.EntryInfo
 }
 
 // patternConfig embeds the BeeMsg defined stripe pattern alongside fields that map various
@@ -129,12 +142,24 @@ func (entryInfo *GetEntryCombinedInfo) GetOrigEntryInfo() *msg.EntryInfo {
 func newEntry(ctx context.Context, mappings *util.Mappings, entry msg.EntryInfo, ownerNode beegfs.Node, entryInfo msg.GetEntryInfoResponse) Entry {
 
 	e := Entry{
-		MetaOwnerNode: ownerNode,
-		ParentEntryID: string(entry.ParentEntryID),
-		EntryID:       string(entry.EntryID),
-		FileName:      string(entry.FileName),
-		Type:          entry.EntryType,
-		FeatureFlags:  entry.FeatureFlags,
+		MetaOwnerNode:      ownerNode,
+		ParentEntryID:      string(entry.ParentEntryID),
+		EntryID:            string(entry.EntryID),
+		FileName:           string(entry.FileName),
+		Type:               entry.EntryType,
+		FeatureFlags:       entry.FeatureFlags,
+		EntryInfoPopulated: entryInfo.Result,
+	}
+
+	if entry.FeatureFlags.IsBuddyMirrored() {
+		e.MetaBuddyGroup = int(entry.OwnerID)
+	}
+
+	if entryInfo.Result != beegfs.OpsErr_SUCCESS {
+		return e
+	}
+
+	e.Details = &EntryDetails{
 		Pattern: patternConfig{
 			StripePattern:   entryInfo.Pattern,
 			StoragePoolName: "<unknown>",
@@ -147,10 +172,6 @@ func newEntry(ctx context.Context, mappings *util.Mappings, entry msg.EntryInfo,
 		NumSessionsRead:  entryInfo.NumSessionsRead,
 		NumSessionsWrite: entryInfo.NumSessionsWrite,
 		FileState:        entryInfo.FileState,
-	}
-
-	if entry.FeatureFlags.IsBuddyMirrored() {
-		e.MetaBuddyGroup = int(entry.OwnerID)
 	}
 
 	fetchedMappings := false
@@ -174,7 +195,7 @@ func newEntry(ctx context.Context, mappings *util.Mappings, entry msg.EntryInfo,
 		pool, err = mappings.StoragePoolToConfig.Get(beegfs.LegacyId{NumId: beegfs.NumId(entryInfo.Pattern.StoragePoolID), NodeType: beegfs.Storage})
 	}
 	if err == nil {
-		e.Pattern.StoragePoolName = pool.Pool.Alias.String()
+		e.Details.Pattern.StoragePoolName = pool.Pool.Alias.String()
 	}
 
 	if entryInfo.Pattern.Type == beegfs.StripePatternRaid0 {
@@ -185,9 +206,9 @@ func newEntry(ctx context.Context, mappings *util.Mappings, entry msg.EntryInfo,
 				node, err = mappings.TargetToNode.Get(beegfs.LegacyId{NumId: beegfs.NumId(tgt), NodeType: beegfs.Storage})
 			}
 			if err != nil {
-				e.Pattern.StorageTargets[beegfs.NumId(tgt)] = nil
+				e.Details.Pattern.StorageTargets[beegfs.NumId(tgt)] = nil
 			} else {
-				e.Pattern.StorageTargets[beegfs.NumId(tgt)] = &node
+				e.Details.Pattern.StorageTargets[beegfs.NumId(tgt)] = &node
 			}
 		}
 	}
@@ -200,9 +221,9 @@ func newEntry(ctx context.Context, mappings *util.Mappings, entry msg.EntryInfo,
 				rst, ok = mappings.RstIdToConfig[id]
 			}
 			if !ok {
-				e.Remote.Targets[id] = nil
+				e.Details.Remote.Targets[id] = nil
 			} else {
-				e.Remote.Targets[id] = rst
+				e.Details.Remote.Targets[id] = rst
 			}
 		}
 	}
@@ -322,7 +343,9 @@ func GetEntry(ctx context.Context, mappings *util.Mappings, cfg GetEntriesCfg, p
 					Err: types.MultiError{Errors: []error{err}},
 				}
 			} else {
-				entryWithParent.Parent = newEntry(ctx, mappings, parentEntry, parentOwner, msg.GetEntryInfoResponse{})
+				entryWithParent.Parent = newEntry(ctx, mappings, parentEntry, parentOwner, msg.GetEntryInfoResponse{
+					Result: beegfs.OpsErr_NODATA,
+				})
 				entryWithParent.Entry.Verbose = newVerbose(resp.Path, entryWithParent.Entry, entryWithParent.Parent)
 				if cfg.IncludeOrigMsg {
 					entryWithParent.Parent.origEntryInfoMsg = &parentEntry
@@ -890,6 +913,9 @@ func SetDirRstIds(ctx context.Context, path string, rstIds []uint32) error {
 	if entryInfo.Entry.Type != beegfs.EntryDirectory {
 		return fmt.Errorf("entry is not a directory: %s", path)
 	}
+	if entryInfo.Entry.Details == nil {
+		return fmt.Errorf("full entry details unavailable for %s: %s", path, entryInfo.Entry.EntryInfoPopulated)
+	}
 	euid := syscall.Geteuid()
 	if euid < 0 || euid > math.MaxUint32 {
 		return fmt.Errorf("effective user ID %d is out of bounds (not a uint32)", euid)
@@ -897,8 +923,8 @@ func SetDirRstIds(ctx context.Context, path string, rstIds []uint32) error {
 
 	request := &msg.SetDirPatternRequest{
 		EntryInfo: *entryInfo.Entry.origEntryInfoMsg,
-		Pattern:   entryInfo.Entry.Pattern.StripePattern,
-		RST:       entryInfo.Entry.Remote.RemoteStorageTarget,
+		Pattern:   entryInfo.Entry.Details.Pattern.StripePattern,
+		RST:       entryInfo.Entry.Details.Remote.RemoteStorageTarget,
 	}
 	request.SetUID(uint32(euid))
 	request.RST.RSTIDs = rstIds

--- a/ctl/pkg/ctl/entry/migrate.go
+++ b/ctl/pkg/ctl/entry/migrate.go
@@ -386,17 +386,21 @@ func migrateEntry(ctx context.Context, mappings *util.Mappings, migration migrat
 		return result, nil
 	}
 
-	result.StartingIDs = fmt.Sprintf("%v", entry.Entry.Pattern.TargetIDs)
+	if entry.Entry.Details != nil {
+		result.StartingIDs = fmt.Sprintf("%v", entry.Entry.Details.Pattern.TargetIDs)
+	} else {
+		result.StartingIDs = "(unavailable)"
+	}
 	// Non-directory entries that are not inlined (into a dentry) may have have multiple links
 	// (i.e., hard links). This means the migration might encounter the same entry multiple times
 	// through different paths. When this happens one of three scenarios is possible:
 	//
 	// (1) The entry is still being rebalanced and is in the inode lock store. When this happens
-	// entry.Entry.Pattern.TargetIDs is empty so getMigrationForEntry returns ErrEntryHasNoTargets
-	// which is caught below and the result for the entry is MigrateNotNeeded.
+	// entry.Entry.Details is nil (returning ErrEntryDetailsUnavailable) or
+	// Details.Pattern.TargetIDs is empty (returning ErrEntryHasNoTargets). Both are caught below.
 	//
 	// (2) The entry has already been rebalanced so none of the srcTargets/Groups will be in
-	// entry.Entry.Pattern.TargetIDs causing getMigrationForEntry() to return an empty srcIDs slice,
+	// Details.Pattern.TargetIDs causing getMigrationForEntry() to return an empty srcIDs slice,
 	// and the result for the entry is MigrateNotNeeded.
 	//
 	// (3) The entry still needs to be rebalanced but is not in the inode lock store by the time the
@@ -438,7 +442,7 @@ func migrateEntry(ctx context.Context, mappings *util.Mappings, migration migrat
 	// Determine if the entry needs migration and if so, if there are enough targets/groups:
 	rebalanceType, srcIDs, destIDs, unmodifiedIDs, err := getMigrationForEntry(entry, migration.srcTargets, migration.srcGroups, migration.dstTargets, migration.dstGroups)
 	if err != nil {
-		if errors.Is(err, ErrEntryHasNoTargets) {
+		if errors.Is(err, ErrEntryHasNoTargets) || errors.Is(err, ErrEntryDetailsUnavailable) {
 			result.StartingIDs = "(unavailable)"
 			result.Status = MigrateNotNeeded
 			result.Message = fmt.Sprintf("a migration appears to already be in progress: %s", err)
@@ -570,7 +574,7 @@ func tmpFileMigrate(ctx context.Context, migration tmpFileMigration) error {
 	// tempFile is the full absolute path to the temp file.
 	tempFile := filepath.Join(filepath.Dir(migration.entry.Path), tempFileBase)
 
-	newPattern := migration.entry.Entry.Pattern.StripePattern
+	newPattern := migration.entry.Entry.Details.Pattern.StripePattern
 	if migration.storagePool != 0 {
 		// Clear the target IDs from the original stripe pattern and update the storage pool ID to
 		// the one being migrated to. This will cause the metadata server to automatically handle
@@ -580,13 +584,13 @@ func tmpFileMigrate(ctx context.Context, migration tmpFileMigration) error {
 	} else {
 		newPattern.TargetIDs = migration.unmodifiedIDs
 		newPattern.TargetIDs = append(newPattern.TargetIDs, migration.dstIDs...)
-		if len(newPattern.TargetIDs) != len(migration.entry.Entry.Pattern.StripePattern.TargetIDs) {
+		if len(newPattern.TargetIDs) != len(migration.entry.Entry.Details.Pattern.StripePattern.TargetIDs) {
 			// With temp files we could technically change the stripe width, but we shouldn't
 			// implicitly do so until we add explicit support for migrating between different
 			// numbers of targets with https://github.com/ThinkParQ/beegfs-go/issues/76. WARNING:
 			// Whenever we do so, ensure to set the newPattern.Length correctly, its is not just the
 			// number of TargetIDs.
-			return fmt.Errorf("length of the new pattern (%v) does not match the length of the original pattern (%v)", newPattern.TargetIDs, migration.entry.Entry.Pattern.StripePattern.TargetIDs)
+			return fmt.Errorf("length of the new pattern (%v) does not match the length of the original pattern (%v)", newPattern.TargetIDs, migration.entry.Entry.Details.Pattern.StripePattern.TargetIDs)
 		}
 	}
 
@@ -603,7 +607,7 @@ func tmpFileMigrate(ctx context.Context, migration tmpFileMigration) error {
 		ParentInfo:  *migration.entry.Parent.origEntryInfoMsg,
 		NewFileName: []byte(tempFileBase),
 		Pattern:     newPattern,
-		RST:         migration.entry.Entry.Remote.RemoteStorageTarget,
+		RST:         migration.entry.Entry.Details.Remote.RemoteStorageTarget,
 	}
 
 	var resp = &msg.MakeFileWithPatternResponse{}

--- a/ctl/pkg/ctl/entry/migrate.go
+++ b/ctl/pkg/ctl/entry/migrate.go
@@ -386,17 +386,21 @@ func migrateEntry(ctx context.Context, mappings *util.Mappings, migration migrat
 		return result, nil
 	}
 
-	result.StartingIDs = fmt.Sprintf("%v", entry.Entry.Pattern.TargetIDs)
+	if entry.Entry.Details != nil {
+		result.StartingIDs = fmt.Sprintf("%v", entry.Entry.Details.Pattern.TargetIDs)
+	} else {
+		result.StartingIDs = "(unavailable)"
+	}
 	// Non-directory entries that are not inlined (into a dentry) may have have multiple links
 	// (i.e., hard links). This means the migration might encounter the same entry multiple times
 	// through different paths. When this happens one of three scenarios is possible:
 	//
 	// (1) The entry is still being rebalanced and is in the inode lock store. When this happens
-	// entry.Entry.Pattern.TargetIDs is empty so getMigrationForEntry returns ErrEntryHasNoTargets
-	// which is caught below and the result for the entry is MigrateNotNeeded.
+	// entry.Entry.Details is nil (returning ErrEntryDetailsUnavailable) or
+	// Details.Pattern.TargetIDs is empty (returning ErrEntryHasNoTargets). Both are caught below.
 	//
 	// (2) The entry has already been rebalanced so none of the srcTargets/Groups will be in
-	// entry.Entry.Pattern.TargetIDs causing getMigrationForEntry() to return an empty srcIDs slice,
+	// Details.Pattern.TargetIDs causing getMigrationForEntry() to return an empty srcIDs slice,
 	// and the result for the entry is MigrateNotNeeded.
 	//
 	// (3) The entry still needs to be rebalanced but is not in the inode lock store by the time the
@@ -438,7 +442,7 @@ func migrateEntry(ctx context.Context, mappings *util.Mappings, migration migrat
 	// Determine if the entry needs migration and if so, if there are enough targets/groups:
 	rebalanceType, srcIDs, destIDs, unmodifiedIDs, err := getMigrationForEntry(entry, migration.srcTargets, migration.srcGroups, migration.dstTargets, migration.dstGroups)
 	if err != nil {
-		if errors.Is(err, ErrEntryHasNoTargets) {
+		if errors.Is(err, ErrEntryHasNoTargets) || errors.Is(err, ErrEntryDetailsUnavailable) {
 			result.StartingIDs = "(unavailable)"
 			result.Status = MigrateNotNeeded
 			result.Message = fmt.Sprintf("a migration appears to already be in progress: %s", err)
@@ -558,6 +562,9 @@ type tmpFileMigration struct {
 	egid          uint32
 }
 
+// tmpFileMigrate handles migrating files using a temporary file. It is intended to be called
+// through migrateEntry() which handles verifying migration.entry.Entry.Details and
+// migration.entry.Parent.origEntryInfoMsg are not nil.
 func tmpFileMigrate(ctx context.Context, migration tmpFileMigration) error {
 
 	store, err := config.NodeStore(ctx)
@@ -570,7 +577,7 @@ func tmpFileMigrate(ctx context.Context, migration tmpFileMigration) error {
 	// tempFile is the full absolute path to the temp file.
 	tempFile := filepath.Join(filepath.Dir(migration.entry.Path), tempFileBase)
 
-	newPattern := migration.entry.Entry.Pattern.StripePattern
+	newPattern := migration.entry.Entry.Details.Pattern.StripePattern
 	if migration.storagePool != 0 {
 		// Clear the target IDs from the original stripe pattern and update the storage pool ID to
 		// the one being migrated to. This will cause the metadata server to automatically handle
@@ -580,13 +587,13 @@ func tmpFileMigrate(ctx context.Context, migration tmpFileMigration) error {
 	} else {
 		newPattern.TargetIDs = migration.unmodifiedIDs
 		newPattern.TargetIDs = append(newPattern.TargetIDs, migration.dstIDs...)
-		if len(newPattern.TargetIDs) != len(migration.entry.Entry.Pattern.StripePattern.TargetIDs) {
+		if len(newPattern.TargetIDs) != len(migration.entry.Entry.Details.Pattern.StripePattern.TargetIDs) {
 			// With temp files we could technically change the stripe width, but we shouldn't
 			// implicitly do so until we add explicit support for migrating between different
 			// numbers of targets with https://github.com/ThinkParQ/beegfs-go/issues/76. WARNING:
 			// Whenever we do so, ensure to set the newPattern.Length correctly, its is not just the
 			// number of TargetIDs.
-			return fmt.Errorf("length of the new pattern (%v) does not match the length of the original pattern (%v)", newPattern.TargetIDs, migration.entry.Entry.Pattern.StripePattern.TargetIDs)
+			return fmt.Errorf("length of the new pattern (%v) does not match the length of the original pattern (%v)", newPattern.TargetIDs, migration.entry.Entry.Details.Pattern.StripePattern.TargetIDs)
 		}
 	}
 
@@ -603,7 +610,7 @@ func tmpFileMigrate(ctx context.Context, migration tmpFileMigration) error {
 		ParentInfo:  *migration.entry.Parent.origEntryInfoMsg,
 		NewFileName: []byte(tempFileBase),
 		Pattern:     newPattern,
-		RST:         migration.entry.Entry.Remote.RemoteStorageTarget,
+		RST:         migration.entry.Entry.Details.Remote.RemoteStorageTarget,
 	}
 
 	var resp = &msg.MakeFileWithPatternResponse{}
@@ -751,13 +758,13 @@ func tmpFileMigrateLink(migration tmpFileMigration) error {
 
 		// newTargets := migration.unmodifiedIDs
 		// newTargets = append(newTargets, migration.dstIDs...)
-		// if len(newTargets) != len(migration.entry.Entry.Pattern.StripePattern.TargetIDs) {
+		// if len(newTargets) != len(migration.entry.Entry.Details.Pattern.StripePattern.TargetIDs) {
 		// 	// With temp files we could technically change the stripe width, but we shouldn't
 		// 	// implicitly do so until we add explicit support for migrating between different
 		// 	// numbers of targets with https://github.com/ThinkParQ/beegfs-go/issues/76. WARNING:
 		// 	// Whenever we do so, ensure to set the newPattern.Length correctly, its is not just the
 		// 	// number of TargetIDs.
-		// 	return fmt.Errorf("length of the new pattern (%v) does not match the length of the original pattern (%v)", newTargets, migration.entry.Entry.Pattern.StripePattern.TargetIDs)
+		// 	return fmt.Errorf("length of the new pattern (%v) does not match the length of the original pattern (%v)", newTargets, migration.entry.Entry.Details.Pattern.StripePattern.TargetIDs)
 		// }
 		// err = ioctl.CreateFile(
 		// 	client.GetMountPath()+tempFile,
@@ -771,7 +778,7 @@ func tmpFileMigrateLink(migration tmpFileMigration) error {
 		// )
 
 		// log, _ := config.GetLogger()
-		// log.Debug("migrating using preferred targets", zap.Any("newTargets", newTargets), zap.Any("oldTargets", migration.entry.Entry.Pattern.StripePattern.TargetIDs))
+		// log.Debug("migrating using preferred targets", zap.Any("newTargets", newTargets), zap.Any("oldTargets", migration.entry.Entry.Details.Pattern.StripePattern.TargetIDs))
 	}
 
 	if err != nil {

--- a/ctl/pkg/ctl/entry/set.go
+++ b/ctl/pkg/ctl/entry/set.go
@@ -147,11 +147,14 @@ func setEntry(ctx context.Context, mappings *util.Mappings, cfg SetEntryCfg, pat
 	return handleFile(ctx, store, entry, cfg, path)
 }
 func handleDirectory(ctx context.Context, mappings *util.Mappings, store *beemsg.NodeStore, entry *GetEntryCombinedInfo, cfg SetEntryCfg, path string) (SetEntryResult, error) {
+	if entry.Entry.Details == nil {
+		return SetEntryResult{}, fmt.Errorf("full entry details unavailable for %s: %s", path, entry.Entry.EntryInfoPopulated)
+	}
 	// Start with the current settings for this entry:
 	request := &msg.SetDirPatternRequest{
 		EntryInfo: *entry.Entry.origEntryInfoMsg,
-		Pattern:   entry.Entry.Pattern.StripePattern,
-		RST:       entry.Entry.Remote.RemoteStorageTarget,
+		Pattern:   entry.Entry.Details.Pattern.StripePattern,
+		RST:       entry.Entry.Details.Remote.RemoteStorageTarget,
 	}
 	request.SetUID(*cfg.actorEUID)
 
@@ -185,7 +188,7 @@ func handleDirectory(ctx context.Context, mappings *util.Mappings, store *beemsg
 				poolID = *cfg.Pool
 			} else {
 				poolID = beegfs.LegacyId{
-					NumId:    beegfs.NumId(entry.Entry.Pattern.StoragePoolID),
+					NumId:    beegfs.NumId(entry.Entry.Details.Pattern.StoragePoolID),
 					NodeType: beegfs.Storage,
 				}
 			}
@@ -228,11 +231,14 @@ func handleDirectory(ctx context.Context, mappings *util.Mappings, store *beemsg
 
 // Handles regular files and all non-directory types (e.g., symlinks).
 func handleFile(ctx context.Context, store *beemsg.NodeStore, entry *GetEntryCombinedInfo, cfg SetEntryCfg, searchPath string) (SetEntryResult, error) {
+	if entry.Entry.Details == nil {
+		return SetEntryResult{}, fmt.Errorf("full entry details unavailable for %s: %s", searchPath, entry.Entry.EntryInfoPopulated)
+	}
 
 	// Start with the current settings for this entry
 	request := &msg.SetFilePatternRequest{
 		EntryInfo: *entry.Entry.origEntryInfoMsg,
-		RST:       entry.Entry.Remote.RemoteStorageTarget,
+		RST:       entry.Entry.Details.Remote.RemoteStorageTarget,
 	}
 
 	// Determine whether any RST related fields are provided in newCfg
@@ -287,8 +293,11 @@ func handleFile(ctx context.Context, store *beemsg.NodeStore, entry *GetEntryCom
 var setFileStateIoctl = probecache.New(5 * time.Minute)
 
 func handleFileStateUpdate(ctx context.Context, store *beemsg.NodeStore, entry *GetEntryCombinedInfo, cfg SetEntryCfg, searchPath string) (SetEntryResult, error) {
+	if entry.Entry.Details == nil {
+		return SetEntryResult{}, fmt.Errorf("full entry details unavailable for %s: %s", searchPath, entry.Entry.EntryInfoPopulated)
+	}
 	// Get current file state from entry
-	currentFileState := entry.Entry.FileState
+	currentFileState := entry.Entry.Details.FileState
 
 	// Start with current access flags and data state
 	newAccessFlags := currentFileState.GetAccessFlags()

--- a/ctl/pkg/ctl/rst/status.go
+++ b/ctl/pkg/ctl/rst/status.go
@@ -561,13 +561,16 @@ func getPathStatusFromDatabase(
 		if err != nil {
 			return nil, err
 		}
-		if len(entry.Entry.Remote.RSTIDs) != 0 {
-			for _, tgt := range entry.Entry.Remote.RSTIDs {
+		if entry.Entry.Details == nil {
+			return nil, fmt.Errorf("entry details unavailable for %s: %s", fsPath, entry.Entry.EntryInfoPopulated)
+		}
+		if len(entry.Entry.Details.Remote.RSTIDs) != 0 {
+			for _, tgt := range entry.Entry.Details.Remote.RSTIDs {
 				remoteTargets[tgt] = nil
 			}
 		} else {
 			syncReason := "No remote targets were specified or configured on this entry."
-			if entry.Entry.FileState.GetDataState() == rst.DataStateOffloaded {
+			if entry.Entry.Details.FileState.GetDataState() == rst.DataStateOffloaded {
 				syncReason = "No remote targets were specified or configured on this entry. The contents are offloaded."
 			}
 			return &GetStatusResult{

--- a/ctl/pkg/ctl/rst/status.go
+++ b/ctl/pkg/ctl/rst/status.go
@@ -561,13 +561,21 @@ func getPathStatusFromDatabase(
 		if err != nil {
 			return nil, err
 		}
-		if len(entry.Entry.Remote.RSTIDs) != 0 {
-			for _, tgt := range entry.Entry.Remote.RSTIDs {
+		if entry.Entry.Details == nil {
+			return &GetStatusResult{
+				Path:       fsPath,
+				SyncStatus: Unknown,
+				SyncReason: fmt.Sprintf("Entry details unavailable (%s); check if the inode is locked by another process such as background rebalancing.", entry.Entry.EntryInfoPopulated),
+				Warning:    true,
+			}, nil
+		}
+		if len(entry.Entry.Details.Remote.RSTIDs) != 0 {
+			for _, tgt := range entry.Entry.Details.Remote.RSTIDs {
 				remoteTargets[tgt] = nil
 			}
 		} else {
 			syncReason := "No remote targets were specified or configured on this entry."
-			if entry.Entry.FileState.GetDataState() == rst.DataStateOffloaded {
+			if entry.Entry.Details.FileState.GetDataState() == rst.DataStateOffloaded {
 				syncReason = "No remote targets were specified or configured on this entry. The contents are offloaded."
 			}
 			return &GetStatusResult{


### PR DESCRIPTION
### What does this PR do / why do we need it?
*Required for all PRs.*
<!--Questions that may be helpful filling out this section:

* What do we gain/lose with this PR?
-->

The new errors surfaced when using the `GetEntryInfoV2` ioctl and subsequent changes in https://github.com/ThinkParQ/beegfs-go/pull/317 prompted the realization that `beegfs entry info`only worked before because `newEntry()` was never checking if `entryInfo msg.GetEntryInfoResponse`actually contained valid data (based on `entryInfo.Result`). At best this returned misleading output in CTL, at worst there are other places that make assumptions based on the validity of that data.

Before when GetEntryInfoResponse failed (e.g., OpsErr_INODELOCKED during chunk rebalancing), fields
derived from that response previously defaulted to Go zero values, causing consumers like 'beegfs
entry info' to silently display misleading data (e.g., Chunksize: 0, Reading: 0, Writing: 0).

This change extracts Pattern, Remote, NumSessionsRead, NumSessionsWrite, and FileState into a new
EntryDetails struct. Entry.Details is a pointer that is nil when EntryInfoPopulated != SUCCESS, so:

- Display functions gate all response-derived output behind a single nil check, showing
  (unavailable) instead of zero values.
- Backend consumers (set, migrate, create, RST) get explicit nil guards that surface errors instead
  of silently operating on empty data.
- Future fields added to EntryDetails are automatically handled by the display layer without
  requiring frontend changes.

Also introduces ErrEntryDetailsUnavailable in the migrate/chooser path, replacing the previous
behavior where a locked inode silently produced zero-value fields that triggered
ErrEntryHasNoTargets.

Assisted-by: Claude:claude-opus-4-6

### Related Issue(s)
*Required when applicable.*
<!-- Link the PR to issues(s) using keywords:
* Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

### Where should the reviewer(s) start reviewing this? 
*Only required for larger PRs when this may not be immediately obvious.*
<!-- Questions that may be helpful filling out this section:

* Where should someone start (file/line) to begin reviewing the new/updated functionality in this
  PR? 
* Is there a logical progression the reviewer can follow to navigate their way through the changes
  (i.e., main.go -> api.go -> db.go)?
-->

### Are there any specific topics we should discuss before merging?
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Are there potential tradeoffs in the implementation?
-->

### What are the next steps after this PR? 
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Is further work planned in this area after this PR is merged? 
  * If so, what issue(s) and/or PRs is it tracked in? 
-->

### Checklist before merging:
*Required for all PRs.*

When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [ ] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [ ] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?

For more details refer to the [Go coding standards](https://github.com/ThinkParQ/beegfs-go/wiki/Getting-Started-with-Go#coding-standards) and the [pull request process](https://github.com/ThinkParQ/beegfs-go/wiki/Pull-Requests).
