### PR TITLE
fix(ctl): setting remote-targets to none had no effect

### DIFF
--- a/common/beemsg/msg/entry.go
+++ b/common/beemsg/msg/entry.go
@@ -395,13 +395,29 @@ type RemoteStorageTarget struct {
 	CoolDownPeriod uint16
 	Reserved       uint16
 	FilePolicies   uint16
-	RSTIDs         []uint32
+	// RSTIDs distinguishes three caller intents that Serialize translates into wire state:
+	//   nil          - caller isn't expressing any RST config (combined with zero-valued
+	//                  CoolDownPeriod/Reserved/FilePolicies and majorVersion still 0, Serialize
+	//                  leaves majorVersion at 0 and the server skips RST processing).
+	//   []uint32{}   - non-nil but empty; caller wants to clear RST config. Serialize bumps
+	//                  majorVersion to 1 so the server treats it as a clear rather than skipping.
+	//   [x, y, ...]  - caller wants to set RST config to these IDs.
+	RSTIDs []uint32
 }
 
 func (m *RemoteStorageTarget) Serialize(s *beeserde.Serializer) {
+	// The server distinguishes "this message carries RST intent" from "it doesn't" by looking at
+	// the major/minor version: when both are 0, meta handlers (e.g. SetDirPatternMsgEx /
+	// SetFilePatternMsgEx) skip RST processing entirely. That sentinel is why a chunksize-only
+	// update doesn't accidentally rewrite RST config.
+	//
+	// If the caller populated any RST-carrying field we need to bump the version so the server
+	// actually processes the message. Important: the RSTIDs check below is "!= nil" rather than
+	// "len() > 0" because a non-nil empty slice is a meaningful state (clear RST) that must still
+	// bump the version — otherwise the clear request gets silently dropped on the server side. Do
+	// not simplify it.
 	if m.majorVersion == 0 && m.minorVersion == 0 {
-		if m.CoolDownPeriod != 0 || m.Reserved != 0 || m.FilePolicies != 0 || len(m.RSTIDs) > 0 {
-			// Handle setting the initial major and minor versions
+		if m.CoolDownPeriod != 0 || m.Reserved != 0 || m.FilePolicies != 0 || m.RSTIDs != nil {
 			m.majorVersion = 1
 			m.minorVersion = 0
 		}


### PR DESCRIPTION
### What does this PR do / why do we need it?
*Required for all PRs.*
<!--Questions that may be helpful filling out this section:

* What do we gain/lose with this PR?
-->

This manifested as 'beegfs entry set --remote-targets=none' reporting success but leaving the
existing RST config in place. This broke because 318af940 (on main, unreleased) added the
GetEntryInfoV2 ioctl path. 

The ioctl package builds msg.RemoteStorageTarget via a struct literal and can't set the unexported
majorVersion/minorVersion fields, so entries fetched via the ioctl come back with majorVersion=0
regardless of whether the directory has RST config. As a result CTL would fetch the entry via the
ioctl (majorVersion=0), the user would clear RSTIDs to []uint32{} (non-nil empty), then Serialize's
len(RSTIDs) > 0 check left majorVersion at 0, and the meta handler's !hasInvalidVersion() gate would
silently skip the clear.

This fixes the Serialize gate to RSTIDs != nil so a non-nil empty slice (the explicit 'clear'
signal) bumps the version. It also documents the nil/empty/populated tri-state on the field and in
Serialize to keep future changes from reverting to len() > 0.

The fact the ioctl does not set a major/minor version is not an issue, since the GetEntryInfoV2
ioctl will only ever populate 1.0 RST configuration. The ioctl also correctly leaves RSTIDs as nil
if there are no RSTIDs in the entryInfoResp.

Assisted-by: Claude:claude-opus-4-7

### Related Issue(s)
*Required when applicable.*
<!-- Link the PR to issues(s) using keywords:
* Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

### Where should the reviewer(s) start reviewing this? 
*Only required for larger PRs when this may not be immediately obvious.*
<!-- Questions that may be helpful filling out this section:

* Where should someone start (file/line) to begin reviewing the new/updated functionality in this
  PR? 
* Is there a logical progression the reviewer can follow to navigate their way through the changes
  (i.e., main.go -> api.go -> db.go)?
-->

### Are there any specific topics we should discuss before merging?
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Are there potential tradeoffs in the implementation?
-->

### What are the next steps after this PR? 
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Is further work planned in this area after this PR is merged? 
  * If so, what issue(s) and/or PRs is it tracked in? 
-->

### Checklist before merging:
*Required for all PRs.*

When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [ ] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [ ] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?

For more details refer to the [Go coding standards](https://github.com/ThinkParQ/beegfs-go/wiki/Getting-Started-with-Go#coding-standards) and the [pull request process](https://github.com/ThinkParQ/beegfs-go/wiki/Pull-Requests).
