### PR TITLE
Swartzn/fix/remote node connection handler

### DIFF
--- a/rst/remote/internal/job/manager_test.go
+++ b/rst/remote/internal/job/manager_test.go
@@ -77,7 +77,7 @@ func TestManage(t *testing.T) {
 				Expectations: []worker.MockExpectation{
 					{
 						MethodName: "connect",
-						ReturnArgs: []any{false, nil},
+						ReturnArgs: []any{nil},
 					},
 					{
 						MethodName: "SubmitWork",
@@ -243,7 +243,7 @@ func TestUpdateJobRequestDelete(t *testing.T) {
 				Expectations: []worker.MockExpectation{
 					{
 						MethodName: "connect",
-						ReturnArgs: []any{false, nil},
+						ReturnArgs: []any{nil},
 					},
 					{
 						MethodName: "SubmitWork",
@@ -553,7 +553,7 @@ func TestManageErrorHandling(t *testing.T) {
 				Expectations: []worker.MockExpectation{
 					{
 						MethodName: "connect",
-						ReturnArgs: []any{false, nil},
+						ReturnArgs: []any{nil},
 					},
 					{
 						MethodName: "SubmitWork",
@@ -716,7 +716,7 @@ func TestUpdateJobResults(t *testing.T) {
 				Expectations: []worker.MockExpectation{
 					{
 						MethodName: "connect",
-						ReturnArgs: []any{false, nil},
+						ReturnArgs: []any{nil},
 					},
 					{
 						MethodName: "SubmitWork",
@@ -907,7 +907,7 @@ func TestUpdateWorkIgnoresTerminalStateJob(t *testing.T) {
 				Expectations: []worker.MockExpectation{
 					{
 						MethodName: "connect",
-						ReturnArgs: []any{false, nil},
+						ReturnArgs: []any{nil},
 					},
 					{
 						MethodName: "SubmitWork",
@@ -1038,7 +1038,7 @@ func TestSubmitJobRequestSentinelErrorHandling(t *testing.T) {
 				Expectations: []worker.MockExpectation{
 					{
 						MethodName: "connect",
-						ReturnArgs: []any{false, nil},
+						ReturnArgs: []any{nil},
 					},
 					{
 						MethodName: "SubmitWork",
@@ -1303,7 +1303,7 @@ func TestUpdateJobStateDeferFiresOnTerminalTransition(t *testing.T) {
 		MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{MethodName: "disconnect", ReturnArgs: []any{nil}},
 			},
 		},
@@ -1654,7 +1654,7 @@ func TestJobCounterOnSubmitAndWork(t *testing.T) {
 				MaxReconnectBackOff: 5,
 				MockConfig: worker.MockConfig{
 					Expectations: []worker.MockExpectation{
-						{MethodName: "connect", ReturnArgs: []any{false, nil}},
+						{MethodName: "connect", ReturnArgs: []any{nil}},
 						{
 							MethodName: "SubmitWork",
 							Args:       []any{mock.Anything},
@@ -1735,7 +1735,7 @@ func TestJobCounterMixedWorkResults(t *testing.T) {
 		MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{
 					MethodName: "SubmitWork",
 					Args:       []any{mock.Anything},
@@ -1789,7 +1789,7 @@ func TestJobCounterOnSubmitSentinelErrors(t *testing.T) {
 		MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{MethodName: "disconnect", ReturnArgs: []any{nil}},
 			},
 		},
@@ -1947,7 +1947,7 @@ func TestJobCounterCancelFromFailed(t *testing.T) {
 		MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{MethodName: "disconnect", ReturnArgs: []any{nil}},
 			},
 		},
@@ -2046,7 +2046,7 @@ func TestJobCounterForceCancelUnknown(t *testing.T) {
 		MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{
 					MethodName: "UpdateWork",
 					Args:       []any{mock.Anything},
@@ -2114,7 +2114,7 @@ func TestJobCounterGC(t *testing.T) {
 		MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{
 					MethodName: "SubmitWork",
 					Args:       []any{mock.Anything},
@@ -2194,7 +2194,7 @@ func TestJobCounterOnSubmitWorkError(t *testing.T) {
 		MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{
 					MethodName: "SubmitWork",
 					Args:       []any{mock.Anything},
@@ -2241,7 +2241,7 @@ func TestJobCounterNeverNegativeOnRestart(t *testing.T) {
 		MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{MethodName: "disconnect", ReturnArgs: []any{nil}},
 			},
 		},
@@ -2385,7 +2385,7 @@ func scheduledWorkerConfigs() []worker.Config {
 		MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{
 					MethodName: "SubmitWork",
 					Args:       []any{mock.Anything},

--- a/rst/remote/internal/worker/beesync.go
+++ b/rst/remote/internal/worker/beesync.go
@@ -33,13 +33,13 @@ func newBeeSyncNode(baseNode *baseNode) Worker {
 	return beeSyncNode
 }
 
-func (n *BeeSyncNode) connect(config *flex.UpdateConfigRequest, bulkUpdate *flex.BulkUpdateWorkRequest, requiredFeatures map[string]*flex.Feature) (bool, error) {
+func (n *BeeSyncNode) connect(config *flex.UpdateConfigRequest, bulkUpdate *flex.BulkUpdateWorkRequest, requiredFeatures map[string]*flex.Feature) error {
 	var cert []byte
 	var err error
 	if !n.config.TlsDisable && n.config.TlsCertFile != "" {
 		cert, err = os.ReadFile(n.config.TlsCertFile)
 		if err != nil {
-			return false, fmt.Errorf("reading certificate file failed: %w", err)
+			return fmt.Errorf("reading certificate file failed: %w", err)
 		}
 	}
 	n.conn, err = beegrpc.NewClientConn(
@@ -50,7 +50,7 @@ func (n *BeeSyncNode) connect(config *flex.UpdateConfigRequest, bulkUpdate *flex
 		beegrpc.WithProxy(n.config.UseProxy),
 	)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	n.client = flex.NewWorkerNodeClient(n.conn)
@@ -59,23 +59,23 @@ func (n *BeeSyncNode) connect(config *flex.UpdateConfigRequest, bulkUpdate *flex
 	// a heartbeat rpc call to determine a valid address for the sync node to reach remote.
 	host, port, err := net.SplitHostPort(config.BeeRemote.Address)
 	if err != nil {
-		return false, err
+		return err
 	}
 	ip := net.ParseIP(host)
 	if ip != nil && ip.IsUnspecified() {
 		var pr peer.Peer
 		_, err := n.client.Heartbeat(n.nodeCtx, &flex.HeartbeatRequest{}, grpc.Peer(&pr))
 		if err != nil {
-			return true, fmt.Errorf("failed to determine remote address for sync node: %w", err)
+			return fmt.Errorf("failed to determine remote address for sync node: %w", err)
 		}
 
 		if pr.LocalAddr == nil {
-			return false, fmt.Errorf("failed to determine remote address for sync node")
+			return fmt.Errorf("failed to determine remote address for sync node")
 		}
 
 		host, _, err = net.SplitHostPort(pr.LocalAddr.String())
 		if err != nil {
-			return false, fmt.Errorf("failed to determine remote address for sync node: %w", err)
+			return fmt.Errorf("failed to determine remote address for sync node: %w", err)
 		}
 		config = proto.Clone(config).(*flex.UpdateConfigRequest)
 		remoteAddr := net.JoinHostPort(host, port)
@@ -85,9 +85,9 @@ func (n *BeeSyncNode) connect(config *flex.UpdateConfigRequest, bulkUpdate *flex
 
 	// Verify the sync node capabilities support remote.
 	if clientRegistry, _, err := registry.GetComponentRegistry(n.rpcCtx, n.client); err != nil {
-		return true, fmt.Errorf("failed to determine sync node capabilities: %w", err)
+		return fmt.Errorf("failed to determine sync node capabilities: %w", err)
 	} else if err = clientRegistry.RequireFeatures(requiredFeatures); err != nil {
-		return true, fmt.Errorf("incompatible sync node: %w", err)
+		return fmt.Errorf("incompatible sync node: %w", err)
 	}
 
 	configureResp, err := n.client.UpdateConfig(n.rpcCtx, config)
@@ -97,30 +97,30 @@ func (n *BeeSyncNode) connect(config *flex.UpdateConfigRequest, bulkUpdate *flex
 			// Note this is just a hint to the user, other error conditions may have the same
 			// message so we don't adjust behavior (i.e., treat it as fatal).
 			if strings.Contains(st.Message(), "error reading server preface: EOF") {
-				return true, fmt.Errorf("%w (hint: check TLS is configured correctly on the client and server)", err)
+				return fmt.Errorf("%w (hint: check TLS is configured correctly on the client and server)", err)
 			}
 		}
-		return true, err
+		return err
 	}
 
 	// If we could send the message but the node didn't update the configuration
 	// correctly probably we can't recover with a simple retry so consider fatal.
 	if configureResp.GetResult() != flex.UpdateConfigResponse_SUCCESS {
-		return false, fmt.Errorf("%s: node rejected config update: %s", configureResp.GetResult(), configureResp.GetMessage())
+		return fmt.Errorf("%s: node rejected config update: %s", configureResp.GetResult(), configureResp.GetMessage())
 	}
 
 	updateWRResp, err := n.client.BulkUpdateWork(n.rpcCtx, bulkUpdate)
 	if err != nil {
-		return true, err
+		return err
 	}
 
 	// If we could send the message but the node couldn't update the WRs,
 	// probably we can't recover with a simply retry so consider fatal.
 	if !updateWRResp.GetSuccess() {
-		return false, fmt.Errorf("bulk update of work requests on node failed with message %s", updateWRResp.GetMessage())
+		return fmt.Errorf("bulk update of work requests on node failed with message %s", updateWRResp.GetMessage())
 	}
 
-	return false, nil
+	return nil
 }
 
 func (n *BeeSyncNode) heartbeat(request *flex.HeartbeatRequest) (*flex.HeartbeatResponse, error) {

--- a/rst/remote/internal/worker/beesync_connect_test.go
+++ b/rst/remote/internal/worker/beesync_connect_test.go
@@ -94,9 +94,8 @@ func TestBeeSyncNodeConnectRequiresAllFeatures(t *testing.T) {
 		"extra-feature":             nil,
 	}
 	config, bulk := connectInputs()
-	retry, err := node.connect(config, bulk, required)
+	err := node.connect(config, bulk, required)
 
-	assert.True(t, retry)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "incompatible sync node")
 	assert.ErrorIs(t, err, registry.ErrUnsupportedFeature)
@@ -115,8 +114,7 @@ func TestBeeSyncNodeConnectHandlesUnimplementedCapabilities(t *testing.T) {
 		registry.FeatureFilterFiles: nil,
 	}
 	config, bulk := connectInputs()
-	retry, err := node.connect(config, bulk, required)
+	err := node.connect(config, bulk, required)
 
-	assert.True(t, retry)
 	assert.ErrorIs(t, err, registry.ErrCapabilitiesNotSupported)
 }

--- a/rst/remote/internal/worker/config.go
+++ b/rst/remote/internal/worker/config.go
@@ -111,23 +111,23 @@ func newWorkerNodeFromConfig(log *zap.Logger, config Config) (Worker, error) {
 	// default values (which should be set using flags). For now just ensure these are not set to
 	// zero here, otherwise weird things can happen.
 
-	if config.MaxReconnectBackOff == 0 {
+	if config.MaxReconnectBackOff <= 0 {
 		config.MaxReconnectBackOff = 60
 	}
 
-	if config.DisconnectTimeout == 0 {
+	if config.DisconnectTimeout <= 0 {
 		config.DisconnectTimeout = 30
 	}
 
-	if config.SendRetries == 0 {
+	if config.SendRetries <= 0 {
 		config.SendRetries = 10
 	}
 
-	if config.RetryInterval == 0 {
+	if config.RetryInterval <= 0 {
 		config.RetryInterval = 1
 	}
 
-	if config.HeartbeatInterval == 0 {
+	if config.HeartbeatInterval <= 0 {
 		config.HeartbeatInterval = 10
 	}
 

--- a/rst/remote/internal/worker/mock.go
+++ b/rst/remote/internal/worker/mock.go
@@ -24,9 +24,9 @@ func newMockNode(baseNode *baseNode) Worker {
 	return mockNode
 }
 
-func (n *MockNode) connect(config *flex.UpdateConfigRequest, bulkUpdate *flex.BulkUpdateWorkRequest, requiredFeatures map[string]*flex.Feature) (bool, error) {
+func (n *MockNode) connect(config *flex.UpdateConfigRequest, bulkUpdate *flex.BulkUpdateWorkRequest, requiredFeatures map[string]*flex.Feature) error {
 	args := n.Called()
-	return args.Bool(0), args.Error(1)
+	return args.Error(0)
 }
 
 func (n *MockNode) heartbeat(request *flex.HeartbeatRequest) (*flex.HeartbeatResponse, error) {

--- a/rst/remote/internal/worker/worker.go
+++ b/rst/remote/internal/worker/worker.go
@@ -46,16 +46,14 @@ type Worker interface {
 //
 //   - connect: Establishes a gRPC connection and initializes a gRPC client of the appropriate type
 //     that is reused for all unary RPCs. After the new client is setup it should update the
-//     configuration and state of any existing work requests on the node. It returns (true, err) for
-//     transient RPC/network errors, (false, err) for configuration issues requiring manual changes,
-//     and (false, nil) when the connection succeeds.
+//     configuration and state of any existing work requests on the node.
 //   - heartbeat: Sends a heartbeat request to verify the node is online and ready.
 //   - disconnect: Cleanup the gRPC connection and client that was created for this node.
 //     It should return an error if there were any problems freeing these resources.
 //
 // Note: Connect and disconnect operations should be idempotent and safe to call multiple times.
 type grpcClientHandler interface {
-	connect(*flex.UpdateConfigRequest, *flex.BulkUpdateWorkRequest, map[string]*flex.Feature) (isErrorTransient bool, err error)
+	connect(*flex.UpdateConfigRequest, *flex.BulkUpdateWorkRequest, map[string]*flex.Feature) error
 	heartbeat(*flex.HeartbeatRequest) (*flex.HeartbeatResponse, error)
 	disconnect() error
 }
@@ -189,8 +187,7 @@ func (n *baseNode) Handle(wg *sync.WaitGroup, config *flex.UpdateConfigRequest, 
 }
 
 // waitUntilConnected attempts to connect to a worker node until either a connection succeeds or the
-// node context is cancelled. For any transient errors, an exponential backoff delay will be observed
-// before retrying. For all other errors the MaxReconnectBackOff delay will be observed before
+// node context is cancelled. For any error, an exponential backoff delay will be observed before
 // retrying.
 func (n *baseNode) waitUntilConnected(config *flex.UpdateConfigRequest, wrUpdates *flex.BulkUpdateWorkRequest, requiredFeatures map[string]*flex.Feature) error {
 	var reconnectBackOff float64 = 1
@@ -206,20 +203,14 @@ func (n *baseNode) waitUntilConnected(config *flex.UpdateConfigRequest, wrUpdate
 		case <-n.nodeCtx.Done():
 			return n.nodeCtx.Err()
 		case <-time.After(retryDelay):
-			if isErrorTransient, err := n.connect(config, wrUpdates, requiredFeatures); err != nil {
-				if isErrorTransient {
-					// We'll retry to connect with an exponential back off. We'll add some jitter to avoid load spikes.
-					reconnectBackOff *= 2 + rand.Float64()
-					if reconnectBackOff > float64(n.config.MaxReconnectBackOff) {
-						reconnectBackOff = float64(n.config.MaxReconnectBackOff) - rand.Float64()
-					}
-					retryDelay = time.Duration(reconnectBackOff * float64(time.Second))
-					n.log.Warn("unable to connect to node because of transient error (retrying)", zap.Error(err), zap.Duration("retry_in", retryDelay))
-				} else {
-					// We'll retry to connect after the maximum reconnect backoff. We'll subtract some jitter to avoid load spikes.
-					retryDelay = time.Duration((float64(n.config.MaxReconnectBackOff) - rand.Float64()) * float64(time.Second))
-					n.log.Warn("unable to connect to node because of non-transient error (retrying). Check node configuration", zap.Error(err), zap.Duration("retry_in", retryDelay))
+			if err := n.connect(config, wrUpdates, requiredFeatures); err != nil {
+				// We'll retry to connect with an exponential back off. We'll add some jitter to avoid load spikes.
+				reconnectBackOff *= 2 + rand.Float64()
+				if reconnectBackOff > float64(n.config.MaxReconnectBackOff) {
+					reconnectBackOff = float64(n.config.MaxReconnectBackOff) - rand.Float64()
 				}
+				retryDelay = time.Duration(reconnectBackOff * float64(time.Second))
+				n.log.Warn("unable to connect to node (retrying)", zap.Error(err), zap.Duration("retry_in", retryDelay))
 			} else {
 				n.setState(ONLINE)
 				n.log.Info("connected to node")

--- a/rst/remote/internal/worker/worker.go
+++ b/rst/remote/internal/worker/worker.go
@@ -2,6 +2,8 @@ package worker
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -34,26 +36,26 @@ type Worker interface {
 	//   UpdateConfig(*flex.WorkerNodeConfigRequest) (*flex.WorkerNodeConfigResponse, error)
 }
 
-// grpcClientHandler defines the interface for managing gRPC connections in
-// worker nodes. Implementers of this interface are responsible for establishing
-// and terminating gRPC connections and clients specific to their node type.
-// This interface enables a common handler implementation through dependency
-// injection. Implementations must ensure that they set the grpcClientHandler in
+// grpcClientHandler defines the interface for managing gRPC connections in worker nodes.
+// Implementers of this interface are responsible for establishing and terminating gRPC connections
+// and clients specific to their node type. This interface enables a common handler implementation
+// through dependency injection. Implementations must ensure that they set the grpcClientHandler in
 // their respective constructor functions.
 //
-// The interface consists of two methods:
+// The interface consists of three methods:
+//
 //   - connect: Establishes a gRPC connection and initializes a gRPC client of the appropriate type
 //     that is reused for all unary RPCs. After the new client is setup it should update the
-//     configuration and state of any existing work requests on the node. It should return false if
-//     an error occurred that is fatal (i.e., remote node was unable to update config or WRs) or
-//     true if an transient error occurred that can be retried (i.e., network connectivity).
+//     configuration and state of any existing work requests on the node. It returns (true, err) for
+//     transient RPC/network errors, (false, err) for configuration issues requiring manual changes,
+//     and (false, nil) when the connection succeeds.
+//   - heartbeat: Sends a heartbeat request to verify the node is online and ready.
 //   - disconnect: Cleanup the gRPC connection and client that was created for this node.
 //     It should return an error if there were any problems freeing these resources.
 //
-// Note: Connect and disconnect operations should be idempotent and safe to call
-// multiple times.
+// Note: Connect and disconnect operations should be idempotent and safe to call multiple times.
 type grpcClientHandler interface {
-	connect(*flex.UpdateConfigRequest, *flex.BulkUpdateWorkRequest, map[string]*flex.Feature) (retry bool, err error)
+	connect(*flex.UpdateConfigRequest, *flex.BulkUpdateWorkRequest, map[string]*flex.Feature) (isErrorTransient bool, err error)
 	heartbeat(*flex.HeartbeatRequest) (*flex.HeartbeatResponse, error)
 	disconnect() error
 }
@@ -159,126 +161,139 @@ func (n *baseNode) Handle(wg *sync.WaitGroup, config *flex.UpdateConfigRequest, 
 	n.nodeMu.Lock()
 	defer n.nodeMu.Unlock()
 
-	// Ticker used to control the interval at which heartbeat requests are send to worker nodes.
-	ticker := time.NewTicker(time.Duration(n.config.HeartbeatInterval) * time.Second)
-	defer ticker.Stop()
-	// Set to true if the handler was stopped.
-	done := false
+	shutdown := func(reason error) {
+		n.log.Info("node is shutting down", zap.Error(reason))
+		n.setOffline()
+	}
+
 	for {
-		if n.GetState() == OFFLINE {
-			if n.connectLoop(config, wrUpdates, requiredFeatures) {
-				n.setState(ONLINE)
-			connectedLoop:
-				for {
-					select {
-					case <-n.nodeCtx.Done():
-						n.log.Debug("node is shutting down because its context was cancelled")
-						done = true
-						break connectedLoop
-					case err := <-n.rpcErr:
-						n.log.Error("placing node offline due to an error", zap.Error(err))
-						break connectedLoop
-					case <-ticker.C:
-						// When worker nodes start up they wait for BeeRemote to configure them and
-						// tell what to do with any outstanding requests (in case they were
-						// cancelled while the node was offline). Because BeeRemote and worker nodes
-						// communicate using unary RPCs, unless requests are actively being assigned
-						// to this worker, it is possible for the worker to reboot and BeeRemote to
-						// never notice. This is because BeeRemote doesn't poll the status of
-						// requests once they are assigned to a node, and worker nodes don't know
-						// where to reach BeeRemote until it tells them. While it is not important
-						// we immediately detect when a node is offline or rebooted (because unary
-						// RPCs will trigger a reconnect and retry automatically), the heartbeat
-						// mechanism ensures worker nodes aren't stuck indefinitely waiting for
-						// configuration from BeeRemote.
-						resp, err := n.heartbeat(&flex.HeartbeatRequest{})
-						if err != nil {
-							n.log.Error("failed to receive heartbeat response from node, placing offline and attempting to reconnect", zap.Error(err))
-							break connectedLoop
-						} else if !resp.GetIsReady() {
-							n.log.Error("received a heartbeat response but the node is not ready, placing offline and attempting to update its configuration")
-							break connectedLoop
-						}
-						n.log.Debug("received heartbeat from worker node", zap.Any("response", resp))
-						// Otherwise continue.
-					}
-				}
-			}
-		}
-		// We'll first set the node state to offline so the node is not assigned
-		// more WRs and any RPC requests that do/did make it through are
-		// rejected. We'll then wait up to the disconnect timeout for any active
-		// RPCs to gracefully complete before cancelling the shared RPC context
-		// and immediately trying to disconnect the node. Probably this is a bit
-		// excessive, but allows for tight control over the shutdown process.
-		n.setState(OFFLINE)
-		allDone := make(chan struct{})
-		go func() {
-			n.rpcWG.Wait()
-			select {
-			case allDone <- struct{}{}:
-			default:
-				// Don't leak the goroutine if we reached the timeout and aren't
-				// listening on the channel anymore.
+		if err := n.waitUntilConnected(config, wrUpdates, requiredFeatures); err != nil {
+			if errors.Is(err, context.Canceled) {
+				shutdown(err)
 				return
 			}
-		}()
-		select {
-		case <-allDone:
-		case <-time.After(time.Duration(n.config.DisconnectTimeout) * time.Second):
+			n.log.Error("unexpected error while connecting to node", zap.Error(err))
 		}
-		// If we hit the timeout this allows us to cancel the context for any
-		// outstanding RPCs and ensure they complete before disconnecting.
-		// Otherwise this is essentially a no-op and we'll go straight to the
-		// disconnect without further waiting.
-		n.rpcCancel()
-		n.rpcWG.Wait()
-		err := n.disconnect()
-		if err != nil {
-			n.log.Error("error disconnecting node", zap.Error(err))
+
+		if n.GetState() == ONLINE {
+			err := n.manageConnection()
+			if errors.Is(err, context.Canceled) {
+				shutdown(err)
+				return
+			}
+			n.log.Error("placing node offline due to an error", zap.Error(err))
 		}
-		if done {
-			return
-		}
+
+		n.setOffline()
 	}
 }
 
-// connectLoop() attempts to connect to a worker node. If the node is not ready
-// or there is an error it will attempt to reconnect with an exponential
-// backoff. If it returns false there was an unrecoverable error and the caller
-// should first call doDisconnect() before reconnecting.
-func (n *baseNode) connectLoop(config *flex.UpdateConfigRequest, wrUpdates *flex.BulkUpdateWorkRequest, requiredFeatures map[string]*flex.Feature) bool {
-	n.log.Info("connecting to node")
+// waitUntilConnected attempts to connect to a worker node until either a connection succeeds or the
+// node context is cancelled. For any transient errors, an exponential backoff delay will be observed
+// before retrying. For all other errors the MaxReconnectBackOff delay will be observed before
+// retrying.
+func (n *baseNode) waitUntilConnected(config *flex.UpdateConfigRequest, wrUpdates *flex.BulkUpdateWorkRequest, requiredFeatures map[string]*flex.Feature) error {
 	var reconnectBackOff float64 = 1
+	var retryDelay time.Duration
 
 	// If a disconnect happened previously the RPC context would be cancelled.
 	// Ensure it is initialized when connecting.
 	n.rpcCtx, n.rpcCancel = context.WithCancel(context.Background())
 
+	n.log.Info("connecting to node")
 	for {
 		select {
 		case <-n.nodeCtx.Done():
-			n.log.Info("not attempting to connect to node because its context was cancelled")
-			return false
-		case <-time.After(time.Second * time.Duration(reconnectBackOff)):
-			retry, err := n.connect(config, wrUpdates, requiredFeatures)
-			if err != nil {
-				if !retry {
-					n.log.Error("unable to connect to node (unable to retry)", zap.Error(err))
-					return false
+			return n.nodeCtx.Err()
+		case <-time.After(retryDelay):
+			if isErrorTransient, err := n.connect(config, wrUpdates, requiredFeatures); err != nil {
+				if isErrorTransient {
+					// We'll retry to connect with an exponential back off. We'll add some jitter to avoid load spikes.
+					reconnectBackOff *= 2 + rand.Float64()
+					if reconnectBackOff > float64(n.config.MaxReconnectBackOff) {
+						reconnectBackOff = float64(n.config.MaxReconnectBackOff) - rand.Float64()
+					}
+					retryDelay = time.Duration(reconnectBackOff * float64(time.Second))
+					n.log.Warn("unable to connect to node because of transient error (retrying)", zap.Error(err), zap.Duration("retry_in", retryDelay))
+				} else {
+					// We'll retry to connect after the maximum reconnect backoff. We'll subtract some jitter to avoid load spikes.
+					retryDelay = time.Duration((float64(n.config.MaxReconnectBackOff) - rand.Float64()) * float64(time.Second))
+					n.log.Warn("unable to connect to node because of non-transient error (retrying). Check node configuration", zap.Error(err), zap.Duration("retry_in", retryDelay))
 				}
-				// We'll retry to connect with an exponential back off. We'll add some jitter to avoid load spikes.
-				reconnectBackOff *= 2 + rand.Float64()
-				if reconnectBackOff > float64(n.config.MaxReconnectBackOff) {
-					reconnectBackOff = float64(n.config.MaxReconnectBackOff) - rand.Float64()
-				}
-
-				n.log.Warn("unable to connect to node (retrying)", zap.Error(err), zap.Any("retry_in_seconds", reconnectBackOff))
-				continue
+			} else {
+				n.setState(ONLINE)
+				n.log.Info("connected to node")
+				return nil
 			}
-			n.log.Info("connected to node")
-			return true
 		}
+	}
+}
+
+// manageConnection checks for node heartbeats and returns on a rpc error or context cancellation.
+func (n *baseNode) manageConnection() error {
+	// Ticker used to control the interval at which heartbeat requests are send to worker nodes.
+	ticker := time.NewTicker(time.Duration(n.config.HeartbeatInterval) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-n.nodeCtx.Done():
+			return n.nodeCtx.Err()
+		case err := <-n.rpcErr:
+			return err
+		case <-ticker.C:
+			// When worker nodes start up they wait for BeeRemote to configure them and tell what to
+			// do with any outstanding requests (in case they were cancelled while the node was
+			// offline). Because BeeRemote and worker nodes communicate using unary RPCs, unless
+			// requests are actively being assigned to this worker, it is possible for the worker to
+			// reboot and BeeRemote to never notice. This is because BeeRemote doesn't poll the
+			// status of requests once they are assigned to a node, and worker nodes don't know
+			// where to reach BeeRemote until it tells them. While it is not important we
+			// immediately detect when a node is offline or rebooted (because unary RPCs will
+			// trigger a reconnect and retry automatically), the heartbeat mechanism ensures worker
+			// nodes aren't stuck indefinitely waiting for configuration from BeeRemote.
+			resp, err := n.heartbeat(&flex.HeartbeatRequest{})
+			if err != nil {
+				return fmt.Errorf("failed to receive heartbeat response: %w", err)
+			}
+
+			n.log.Debug("received heartbeat from worker node", zap.Any("response", resp))
+			if !resp.GetIsReady() {
+				return fmt.Errorf("received a heartbeat response but the node is not ready")
+			}
+		}
+	}
+}
+
+// setOffline stops all new work request assigments and waits any for any outstanding rpcs to
+// complete before disconnecting. If the configured DisconnectTimeout time expires before the rpcs
+// can gracefully complete, the rpc context will be cancelled.
+func (n *baseNode) setOffline() {
+	// We'll first set the node state to offline so the node is not assigned more WRs and any RPC
+	// requests that do/did make it through are rejected. We'll then wait up to the disconnect
+	// timeout for any active RPCs to gracefully complete before cancelling the shared RPC context
+	// and immediately trying to disconnect the node. Probably this is a bit excessive, but allows
+	// for tight control over the shutdown process.
+	n.setState(OFFLINE)
+
+	allDone := make(chan struct{})
+	go func() {
+		n.rpcWG.Wait()
+		close(allDone)
+	}()
+	select {
+	case <-allDone:
+	case <-time.After(time.Duration(n.config.DisconnectTimeout) * time.Second):
+	}
+
+	// If we hit the timeout this allows us to cancel the context for any outstanding RPCs and
+	// ensure they complete before disconnecting.
+	n.rpcCancel()
+	n.rpcWG.Wait()
+
+	err := n.disconnect()
+	if err != nil {
+		n.log.Error("error disconnecting node", zap.Error(err))
 	}
 }
 

--- a/rst/remote/internal/workermgr/manager_test.go
+++ b/rst/remote/internal/workermgr/manager_test.go
@@ -134,7 +134,7 @@ func schedulingWorkerConfig() worker.Config {
 		ID: "0", Name: "test-node-0", Type: worker.Mock, MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{
 					MethodName: "SubmitWork", Args: []any{mock.Anything},
 					ReturnArgs: []any{flex.Work_Status_builder{State: flex.Work_SCHEDULED}.Build(), nil},
@@ -152,7 +152,7 @@ func schedulingAndCancellingWorkerConfig() worker.Config {
 		ID: "0", Name: "test-node-0", Type: worker.Mock, MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{
 					MethodName: "SubmitWork", Args: []any{mock.Anything},
 					ReturnArgs: []any{flex.Work_Status_builder{State: flex.Work_SCHEDULED}.Build(), nil},
@@ -174,7 +174,7 @@ func TestWorkCounterNoPool(t *testing.T) {
 		ID: "0", Name: "test-node-0", Type: worker.Mock, MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{MethodName: "disconnect", ReturnArgs: []any{nil}},
 			},
 		},
@@ -207,7 +207,7 @@ func TestWorkCounterSubmitWorkError(t *testing.T) {
 		ID: "0", Name: "test-node-0", Type: worker.Mock, MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{
 					MethodName: "SubmitWork", Args: []any{mock.Anything},
 					ReturnArgs: []any{nil, fmt.Errorf("simulated submit failure")},
@@ -324,7 +324,7 @@ func TestWorkCounterUpdateJobUnassigned(t *testing.T) {
 		ID: "0", Name: "test-node-0", Type: worker.Mock, MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{MethodName: "disconnect", ReturnArgs: []any{nil}},
 			},
 		},
@@ -370,7 +370,7 @@ func TestWorkCounterUpdateJobPoolNotFound(t *testing.T) {
 		ID: "0", Name: "test-node-0", Type: worker.Mock, MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{MethodName: "disconnect", ReturnArgs: []any{nil}},
 			},
 		},
@@ -433,7 +433,7 @@ func TestWorkCounterUpdateJobNodeResponse(t *testing.T) {
 				ID: "0", Name: "test-node-0", Type: worker.Mock, MaxReconnectBackOff: 5,
 				MockConfig: worker.MockConfig{
 					Expectations: []worker.MockExpectation{
-						{MethodName: "connect", ReturnArgs: []any{false, nil}},
+						{MethodName: "connect", ReturnArgs: []any{nil}},
 						{
 							MethodName: "SubmitWork", Args: []any{mock.Anything},
 							ReturnArgs: []any{flex.Work_Status_builder{State: flex.Work_SCHEDULED}.Build(), nil},
@@ -477,7 +477,7 @@ func minimalWorkerConfig() worker.Config {
 		ID: "0", Name: "test-node-0", Type: worker.Mock, MaxReconnectBackOff: 5,
 		MockConfig: worker.MockConfig{
 			Expectations: []worker.MockExpectation{
-				{MethodName: "connect", ReturnArgs: []any{false, nil}},
+				{MethodName: "connect", ReturnArgs: []any{nil}},
 				{MethodName: "disconnect", ReturnArgs: []any{nil}},
 			},
 		},


### PR DESCRIPTION
This patch does solidifies the worker connect/connection handler behavior. The connection handler should only stop trying to reconnect to the worker when remote itself is shutting down. So I propose two alternatives with a preference for the second,

1) Redefine `retry` in the `grpcClientHandler` interface's `connect` function to `isErrTransient`. This keeps the beesync connection code the same but realigns the interface with the expected behavior. This allows us to cleanly adjust remote's worker connection handler so that there are two error types: 1) transient errors (rpc/network) and 2) non-transient errors (version/config). Keeping these error types separate allows for a fixed retry delay for the non-transient errors.
   * _To see this implementation, just look at the first commit._

2) Remove `retry/isErrTransient` altogether from the `grpcClientHandler` interface's `connect` function. This unifies the errors so that they are all retried under the same exponential backoff mechanism.
   * _To see this implementation, look at all the changes together._

### What does this PR do / why do we need it?
*Required for all PRs.*
<!--Questions that may be helpful filling out this section:

* What do we gain/lose with this PR?
-->


- Fixes the remote worker node shutdown.
- Aligns grpcClientHandler connect semantics with the expected behavior.

### Related Issue(s)
*Required when applicable.*
<!-- Link the PR to issues(s) using keywords:
* Reference: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

### Where should the reviewer(s) start reviewing this? 
*Only required for larger PRs when this may not be immediately obvious.*
<!-- Questions that may be helpful filling out this section:

* Where should someone start (file/line) to begin reviewing the new/updated functionality in this
  PR? 
* Is there a logical progression the reviewer can follow to navigate their way through the changes
  (i.e., main.go -> api.go -> db.go)?
-->

### Are there any specific topics we should discuss before merging?
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Are there potential tradeoffs in the implementation?
-->

### What are the next steps after this PR? 
*Not required.*
<!-- Questions that may be helpful filling out this section:

* Is further work planned in this area after this PR is merged? 
  * If so, what issue(s) and/or PRs is it tracked in? 
-->

### Checklist before merging:
*Required for all PRs.*

When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [ ] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [ ] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?

For more details refer to the [Go coding standards](https://github.com/ThinkParQ/beegfs-go/wiki/Getting-Started-with-Go#coding-standards) and the [pull request process](https://github.com/ThinkParQ/beegfs-go/wiki/Pull-Requests).
