### PR TITLE
wdavis/feat/add iotest mechanism to beegfs-go to drive client io

### DIFF
--- a/ctl/internal/cmd/iotest/DESIGN.md
+++ b/ctl/internal/cmd/iotest/DESIGN.md
@@ -1,0 +1,290 @@
+# iotest package design
+
+`beegfs iotest` is a family of IO testing tools for BeeGFS filesystems. The
+package is split into two groups: **standalone commands** that run locally
+without coordination, and **framework-managed workloads** that support
+multi-node SSH fan-out, lifecycle management, and a shared status model.
+
+---
+
+## File map
+
+| File | Role |
+|------|------|
+| `iotest.go` | Command registration entry point |
+| `framework.go` | Core framework: lifecycle, status, SSH fan-out |
+| `nodes.go` | Node parsing and SSH launch helpers |
+| `trace.go` | Zap-based IO trace logger (used by soak, smoke) |
+| `dump.go` | Standalone: inspect a single data file |
+| `verify.go` | Standalone: verify data files written by soak/smoke |
+| `smoke.go` | Standalone: single-node write+verify sanity check |
+| `bench.go` | Framework workload: bandwidth benchmark |
+| `soak.go` | Framework workload: long-running integrity stress test |
+| `inval.go` | Framework workload: cache invalidation measurement |
+
+---
+
+## Entry point
+
+`iotest.go` wires everything up. Standalone commands (`smoke`, `verify`,
+`dump`, `bench run/verify`) are added directly. Framework-managed workloads
+(`soak`, `bench`, `inval`) are passed to `NewFrameworkCmds`, which
+generates the shared `start` / `status` / `stop` subcommands automatically.
+
+---
+
+## Framework (`framework.go`)
+
+### Tool interface
+
+Every framework-managed workload implements `Tool`:
+
+```go
+type Tool interface {
+    Name() string
+    Run(ctx context.Context, cfg RunConfig) error
+}
+```
+
+Tools are intentionally dumb: they run work, increment a counter, and respect
+the stop signal. Everything else — SSH fan-out, status files, table rendering,
+wait/watch — is handled by the framework.
+
+Five optional interfaces extend the base:
+
+| Interface | Method | Purpose |
+|-----------|--------|---------|
+| `FlagProvider` | `RegisterFlags(*cobra.Command)` | Register tool-specific flags on `start`; the framework forwards them verbatim to remote nodes |
+| `Describer` | `Description() string` | One-line description in `start` help text |
+| `StatusFormatter` | `FormatExtraStatus(node string, data json.RawMessage) string` | Render tool-specific JSON below the status table |
+| `CompletionHinter` | `CompletionHint(path string) string` | Print post-run guidance after `--wait`/`--watch` completes |
+| `StatusFootnote` | `FormatStatusFootnote() string` | Print a one-time explanatory footer after all per-node `FormatExtraStatus` blocks |
+
+### RunConfig
+
+The framework passes this to `Tool.Run`:
+
+```go
+type RunConfig struct {
+    Path           string
+    TotalOps       *atomic.Int64   // increment once per completed operation
+    StopSignal     *atomic.Bool    // poll; return nil when true
+    SetExtraStatus func(v any)     // write tool-specific JSON into the status file
+}
+```
+
+### Status files
+
+Each running workload writes a `.iotest-<workload>-<node>.json` file to
+`--path`. The format is `workloadStatus`:
+
+```
+node, workload, status ("running"|"done"|"failed"),
+startTime, endTime, totalOps, error, extraData (opaque JSON blob)
+```
+
+The framework writes an initial `running` record on start, ticks a 5-second
+update goroutine while running, and writes a final `done`/`failed` record when
+`Tool.Run` returns. The update goroutine is explicitly stopped and drained
+before writing the final record so it cannot race and overwrite "done".
+
+A separate `.iotest-invocation.json` records `os.Args` and start time; it is
+excluded from the status glob and shown as a header line in status output.
+
+### Stop signal
+
+`beegfs iotest stop` creates `.iotest.stop` in `--path`. The framework's
+`watchStopSignal` goroutine polls for this file every second and sets
+`RunConfig.StopSignal`. Tools are expected to check this and return `nil`
+cleanly when it is set.
+
+### Local execution (`startLocal`)
+
+Runs all selected tools concurrently in goroutines on the local node. Refuses
+to start a workload that is already running (checks status files for
+`status=running` on the local hostname). Clears any stale stop signal before
+starting.
+
+### Multi-node execution (`startMultiNode`)
+
+Fans out one SSH session per (tool × node) pair concurrently. Each session
+runs `nohup beegfs <args> > .iotest-<workload>-<node>.log 2>&1 &` and returns
+immediately — the framework does not wait for completion. Status is tracked
+through the shared status files on the BeeGFS path.
+
+`buildRemoteArgsForWorkload` strips `--nodes` (prevents recursion),
+`--fresh` (already cleaned before fan-out), and other workload names from
+positional args so each remote session runs a single workload.
+
+### Wait / Watch
+
+`--wait` polls silently and prints the table once on completion.
+`--watch` redraws the table on each tick using a terminal refresher.
+Both call `util.TerminalAlert()` when all workloads reach a terminal state.
+
+### `--fresh`
+
+Before starting, removes all `iotest-*` and `.iotest-*` files from `--path`.
+A blocklist of system directories (`/`, `/tmp`, `/home`, etc.) prevents
+accidental deletion. The clean happens on the invoking node only, before
+SSH fan-out.
+
+---
+
+## Node helpers (`nodes.go`)
+
+`parseNodes` accepts `-N` as either a comma-separated list or a file path
+(newlines or commas as delimiters, `#` comments). Produces `[]NodeSpec`.
+
+`sshStartBackground` launches the remote process via
+`ssh -o BatchMode=yes <node> 'nohup beegfs ... > <log> 2>&1 &'`. It returns
+as soon as the background process is launched. `shellJoin` single-quotes each
+argument for safe shell interpolation.
+
+---
+
+## Standalone tools
+
+### `smoke.go`
+
+Single-node write+verify using the `block`/`xattrstore`/`verifier` integrity
+stack. Writes N blocks, verifies them immediately, cleans up. Quick sanity
+check that integrity machinery works on a given filesystem. Supports an
+`--iolog-level` zap trace logger via `trace.go`.
+
+### `verify.go`
+
+Accepts a file or directory (globs `iotest-soak-*`). For each file: checks
+xattrs are present (prints a helpful error with BeeGFS-specific advice if
+not), then calls `verifier.VerifyFile` which produces `Span` objects
+classified by coverage:
+- `one` — exactly one record covers this region; verifies body CRC and xattr match
+- `none` — uncovered region; fails if non-zero bytes are present
+- `many` — overlapping records; always a failure
+- `contended` — lock held; skipped
+
+Prints anomalies always; clean spans only with `--verbose`.
+
+### `dump.go`
+
+Opens a single data file, reads all xattr records, sorts by offset, prints
+each block's full header (kind, worker, cycle, node, timestamp, seed, CRC)
+and a `VerifyBlock` verdict. Useful for hand-inspecting specific files.
+
+---
+
+## Framework workloads
+
+### `bench.go`
+
+Bandwidth benchmark. Multiple workers write fixed-size files; reports MiB/s.
+Implements `StatusFormatter` to show live bandwidth in the status table.
+Has a companion standalone `bench verify` subcommand.
+
+### `soak.go`
+
+Long-running integrity stress test. Workers write and re-write blocks to
+overlapping and non-overlapping files using the xattrstore integrity stack.
+Verifies global file locks are configured when running cross-node. Uses zap
+for IO tracing. The canonical tool for finding silent corruption or torn
+writes under sustained load.
+
+**Relationship to `verifyio/cmd/iotest-soak`:** these are two independent
+implementations, not one wrapping the other -- `iotest-soak` is `package
+main` (a standalone binary), so this package cannot import it as a library.
+Both are consumers of the same underlying integrity machinery
+(`verifyio/block`, `xattrstore`, `fileops`, `verifier`); the worker-spawning,
+op-selection, and file-pool logic is separately implemented in each rather
+than shared.
+
+The one behavioral difference that isn't incidental: `iotest-soak` opens its
+stores via `xattrstore.OpenStore` (`LockModeOFD`, single-node only), while
+this file's `soakOpenStores` uses `xattrstore.OpenStoreMultiNode`
+(`LockModePOSIX`). That follows directly from what each tool is for --
+`iotest-soak` is the original, simpler tool for direct single-node testing
+of the library (see `verifyio/README.md`), while `SoakTool` here exists
+specifically to run across a real multi-node BeeGFS cluster via the
+framework's SSH fan-out, which is why it needs the cross-node lock mode
+(and therefore `tuneUseGlobalFileLocks=true` -- see `soakCheckGlobalFileLocks`)
+in the first place.
+
+### `inval.go`
+
+Measures cache invalidation latency between nodes. Leader/follower roles are
+claimed via `O_EXCL` on a lock file on `cfg.Path` (a one-time, not
+per-round, rendezvous). The leader mutates the shared test file each round
+and the follower measures how long BeeGFS takes to propagate the
+invalidation. Writes a structured log file per node with per-round stats.
+
+Per-round coordination (the ready handshake, round announcements, and
+observation reports) goes over a plain TCP connection to the leader
+(`invalControlPort`), not through files on `cfg.Path`. It used to: a round
+file's mere existence is itself subject to the same dentry/ENOENT-cache TTL
+being probed, so a follower's single revalidation of the test directory
+could refresh both the round file and the test file's mutated attribute in
+one round-trip — silently absorbing real invalidation latency into the
+(unmeasured) round-file wait and reporting near-zero latency for a case that
+was actually slow. This is a well-known failure mode in coordination-channel
+design generally, and inval.go's fix follows the standard principle:
+coordination must not ride the same cache/TTL regime as the thing being
+measured. Only the actual test-file mutations (and the one-time leader lock)
+still live on `cfg.Path`.
+
+The `chmod` op encodes the expected mode as `0600 | (round % 64)` rather
+than a fixed `^0077` toggle. XOR-with-a-constant is its own inverse, so it
+used to flip between exactly two mode values with period 2 — a follower
+reading a one-round-stale cached mode would see it match the *current*
+round's expected value, reporting a false "instant visibility" for what
+could be a real caching regression. `os.FileMode.Perm()` is only 9 bits, so
+a fully non-repeating encoding isn't possible across `invalDefaultRounds`
+(1000) rounds; varying the low 6 (group+other) bits raises the alias period
+from 2 rounds to 64, adopting the standard "N mod K, K large" fallback
+for permission-based signals when true monotonicity isn't available. The owner `rw` bits (`0600`) are held fixed:
+leader and follower run as the same uid, and an owner-unreadable or
+-unwritable mode would break `setxattr`/`getxattr` the next time
+`invalOpXattr` is picked for the same file.
+
+---
+
+## File naming conventions
+
+| Pattern | Purpose |
+|---------|---------|
+| `.iotest-<workload>-<node>.json` | Per-node workload status |
+| `.iotest-<workload>-<node>.log` | SSH stdout/stderr capture (framework) or explicit log (inval) |
+| `.iotest-invocation.json` | Full `os.Args` + start time of the invoking command |
+| `.iotest.stop` | Stop signal; presence triggers all workloads to exit |
+| `iotest-soak-*` | Soak data files (no leading dot; subject to `--fresh` cleanup) |
+
+---
+
+## Future investigation (soak cross-node anomalies)
+
+Cross-node soak runs surface `verdict=BODY_CORRUPT` anomalies that are cache
+coherence effects, not corruption. The verdict distinguishes them: `BODY_CORRUPT`
+means the block passed its own in-data stripe CRCs (internally consistent) but
+does not match the seed in the current xattr header — a coherent *older* version,
+i.e. a stale read. Genuine corruption would be `BODY_CRC_MISMATCH`. Two open
+items, deliberately deferred past the first check-in:
+
+1. **Fail-vs-warn split keyed on `fsynced`.** Soak currently treats every
+   `BODY_CORRUPT` as fatal. But the writer syncs and stamps `TagFsynced` in the
+   xattr *before* releasing its exclusive lock (see `xattrstore.Writer.WriteBlock`),
+   so the two cases differ:
+   - `fsynced=true` + stale body → a durably-committed write came back stale.
+     This is the real coherence red flag → keep as **fail**.
+   - `fsynced=false` + stale body → the reader observed a not-yet-committed
+     (intent-phase) block → should probably be a **warn/counter**, not a hard
+     failure.
+
+2. **Why is `fsynced=false` ever visible to a reader?** Under the intended lock
+   protocol it should be impossible: the writer flips `fsynced`→true and re-puts
+   the xattr while holding the exclusive lock, and a reader must take a conflicting
+   shared lock. Observing the transient intent state implies either (a) the
+   reader's `getxattr` is served from a stale client metadata cache (POSIX lock
+   acquisition does not invalidate it), or (b) a cross-node lock-exclusivity gap
+   (shared lock granted while the writer holds exclusive). Both are reader-side
+   and distinct from the data-page-cache staleness. A disambiguating diagnostic
+   (on mismatch, immediately re-read the xattr and note whether the shared-lock
+   acquisition contended) would tell (a) from (b). The writer's fsync-before-unlock
+   is already correct — no writer change is implied.

--- a/ctl/internal/cmd/iotest/bench.go
+++ b/ctl/internal/cmd/iotest/bench.go
@@ -1,0 +1,323 @@
+package iotest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/thinkparq/beegfs-go/verifyio/bench/posixbench"
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+)
+
+// benchExtraStatus is written into workloadStatus.ExtraData after a bench run
+// completes. It captures the full per-node throughput snapshot so that
+// "beegfs iotest status" can display bandwidth numbers alongside the summary
+// table without re-reading any data files.
+type benchExtraStatus struct {
+	WriteMBps      float64 `json:"writeMBps"`
+	WriteMiBps     float64 `json:"writeMiBps"`
+	WriteIOPS      float64 `json:"writeIOPS"`
+	MinMBps        float64 `json:"minMBps"`
+	MaxMBps        float64 `json:"maxMBps"`
+	StdDevMBps     float64 `json:"stdDevMBps"`
+	ReadMBps       float64 `json:"readMBps"`
+	ReadMiBps      float64 `json:"readMiBps"`
+	ReadIOPS       float64 `json:"readIOPS"`
+	ReadMinMBps    float64 `json:"readMinMBps"`
+	ReadMaxMBps    float64 `json:"readMaxMBps"`
+	ReadStdDevMBps float64 `json:"readStdDevMBps"`
+}
+
+// FormatExtraStatus implements StatusFormatter. It decodes benchExtraStatus and
+// returns one or two lines (write + optional read) formatted for status output.
+func (b *BenchTool) FormatExtraStatus(node string, data json.RawMessage) string {
+	var s benchExtraStatus
+	if err := json.Unmarshal(data, &s); err != nil {
+		return ""
+	}
+	write := fmt.Sprintf("  %-20s  write: %8.2f MB/s  %8.2f MiB/s  %8.0f IOPS  [min=%.2f max=%.2f stddev=%.2f]",
+		node, s.WriteMBps, s.WriteMiBps, s.WriteIOPS, s.MinMBps, s.MaxMBps, s.StdDevMBps)
+	if s.ReadMBps == 0 {
+		return write
+	}
+	read := fmt.Sprintf("  %-20s  read:  %8.2f MB/s  %8.2f MiB/s  %8.0f IOPS  [min=%.2f max=%.2f stddev=%.2f]",
+		"", s.ReadMBps, s.ReadMiBps, s.ReadIOPS, s.ReadMinMBps, s.ReadMaxMBps, s.ReadStdDevMBps)
+	return write + "\n" + read
+}
+
+const (
+	benchDefaultThreads   = 4
+	benchDefaultBlockSize = 128 * 1024       // 128 KiB
+	benchDefaultFileSize  = 10 * 1024 * 1024 // 10 MiB per worker
+)
+
+// BenchTool implements Tool. It runs a write-once POSIX IO benchmark and
+// reports bandwidth. A posixbench.json manifest is written for later
+// verification with 'beegfs iotest bench verify'.
+type BenchTool struct {
+	noXattr bool
+}
+
+func (b *BenchTool) Name() string { return "bench" }
+func (b *BenchTool) Description() string {
+	return "write-once POSIX IO benchmark with manifest-based verification"
+}
+
+func (b *BenchTool) RegisterFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&b.noXattr, "no-xattr", false,
+		"write per-stripe ECC into data files instead of xattrs; blocksize is encoded in filenames; verification is ECC-only")
+}
+
+func (b *BenchTool) Run(ctx context.Context, cfg RunConfig) error {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("get hostname: %w", err)
+	}
+
+	bc := posixbench.DefaultConfig()
+	bc.Path = cfg.Path
+	bc.Hostname = hostname
+	bc.Threads = benchDefaultThreads
+	if cfg.Threads > 0 {
+		bc.Threads = cfg.Threads
+	}
+	// --blocksize (RunConfig.BlockSize) overrides the transfer/block size; 0
+	// means use bench's default. posixbench validates it divides FileSize.
+	bc.BlockSize = benchDefaultBlockSize
+	if cfg.BlockSize > 0 {
+		bc.BlockSize = cfg.BlockSize
+	}
+	bc.FileSize = benchDefaultFileSize
+	bc.NoXattr = b.noXattr
+	bc.EnsureSeed()
+	if err := bc.Validate(); err != nil {
+		return err
+	}
+
+	totalData := int64(bc.Threads) * bc.FileSize
+	fmt.Printf("posixbench run\n")
+	fmt.Printf("  path=%s  threads=%d  layout=%s  kind=%s  seed=%d\n",
+		bc.Path, bc.Threads, bc.Layout, bc.Kind, bc.Seed)
+	fmt.Printf("  blockSize=%s  fileSize=%s/worker  totalData=%s\n",
+		iotestHumanSize(int64(bc.BlockSize)), iotestHumanSize(bc.FileSize), iotestHumanSize(totalData))
+	fmt.Println()
+
+	r, err := posixbench.NewRunner(bc)
+	if err != nil {
+		return fmt.Errorf("bench: %w", err)
+	}
+
+	start := time.Now()
+	res, err := r.Run(true)
+	if err != nil {
+		return fmt.Errorf("bench: %w", err)
+	}
+	elapsed := time.Since(start)
+
+	writeIOPS := float64(res.TotalWritten) / float64(bc.BlockSize) / res.WriteElapsed.Seconds()
+	writeMiBps := float64(res.TotalWritten) / (1024 * 1024) / res.WriteElapsed.Seconds()
+	readIOPS := float64(res.TotalRead) / float64(bc.BlockSize) / res.ReadElapsed.Seconds()
+	readMiBps := float64(res.TotalRead) / (1024 * 1024) / res.ReadElapsed.Seconds()
+	ws := res.WriteStats()
+	rs := res.ReadStats()
+
+	fmt.Printf("%-10s  %10s  %10s  %10s  %10s  %10s  %10s  %12s\n",
+		"access", "bw(MB/s)", "bw(MiB/s)", "IOPS", "min(MB/s)", "max(MB/s)", "stddev", "elapsed")
+	fmt.Printf("%-10s  %10s  %10s  %10s  %10s  %10s  %10s  %12s\n",
+		"------", "--------", "---------", "----", "---------", "---------", "------", "-------")
+	fmt.Printf("%-10s  %10.2f  %10.2f  %10.0f  %10.2f  %10.2f  %10.2f  %12s\n",
+		"write", res.WriteMBps(), writeMiBps, writeIOPS,
+		ws.MinMBps, ws.MaxMBps, ws.StdDevMBps,
+		res.WriteElapsed.Round(time.Millisecond))
+	fmt.Printf("%-10s  %10.2f  %10.2f  %10.0f  %10.2f  %10.2f  %10.2f  %12s\n",
+		"read", res.ReadMBps(), readMiBps, readIOPS,
+		rs.MinMBps, rs.MaxMBps, rs.StdDevMBps,
+		res.ReadElapsed.Round(time.Millisecond))
+	fmt.Println()
+	fmt.Printf("Elapsed: %s\n", elapsed.Round(time.Millisecond))
+	fmt.Printf("Manifest: %s\n", posixbench.ManifestPath(bc.Path, bc.Hostname))
+
+	cfg.TotalOps.Add(res.TotalWritten/int64(bc.BlockSize) + res.TotalRead/int64(bc.BlockSize))
+
+	if cfg.SetExtraStatus != nil {
+		cfg.SetExtraStatus(benchExtraStatus{
+			WriteMBps:      res.WriteMBps(),
+			WriteMiBps:     writeMiBps,
+			WriteIOPS:      writeIOPS,
+			MinMBps:        ws.MinMBps,
+			MaxMBps:        ws.MaxMBps,
+			StdDevMBps:     ws.StdDevMBps,
+			ReadMBps:       res.ReadMBps(),
+			ReadMiBps:      readMiBps,
+			ReadIOPS:       readIOPS,
+			ReadMinMBps:    rs.MinMBps,
+			ReadMaxMBps:    rs.MaxMBps,
+			ReadStdDevMBps: rs.StdDevMBps,
+		})
+	}
+	return nil
+}
+
+func newBenchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bench",
+		Short: "Write-once POSIX IO benchmark with manifest-based verification",
+		Long: `Write-once POSIX IO benchmark with manifest-based verification.
+
+  run     write data files (+ optional read phase) and report bandwidth
+  verify  check data files against the manifest written by run`,
+	}
+	cmd.AddCommand(newBenchRunCmd(), newBenchVerifyCmd())
+	return cmd
+}
+
+func newBenchRunCmd() *cobra.Command {
+	cfg := posixbench.DefaultConfig()
+	var (
+		kindStr string
+		doRead  bool
+		noXattr bool
+	)
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Write data files and report bandwidth",
+		Long: `Write data files to a directory and report write (and optionally read) bandwidth.
+A posixbench.json manifest is written alongside the data for later verification.`,
+		Annotations: map[string]string{"authorization.AllowAllUsers": ""},
+		Args:        cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if helpIfNoFlags(cmd) {
+				return nil
+			}
+			if cfg.Path == "" {
+				return fmt.Errorf("required flag \"path\" not set")
+			}
+			k, err := block.KindFromString(kindStr)
+			if err != nil {
+				return fmt.Errorf("run: %w", err)
+			}
+			cfg.Kind = k
+			cfg.NoXattr = noXattr
+			cfg.EnsureSeed()
+			if err := cfg.Validate(); err != nil {
+				return fmt.Errorf("run: %w", err)
+			}
+
+			r, err := posixbench.NewRunner(cfg)
+			if err != nil {
+				return fmt.Errorf("run: %w", err)
+			}
+
+			totalData := int64(cfg.Threads) * int64(cfg.FilesPerWorker) * cfg.FileSize
+			if cfg.Layout == posixbench.LayoutNto1 {
+				totalData = int64(cfg.Threads) * cfg.FileSize
+			}
+
+			fmt.Printf("posixbench run\n")
+			fmt.Printf("  path=%s threads=%d layout=%s kind=%s seed=%d\n",
+				cfg.Path, cfg.Threads, cfg.Layout, cfg.Kind, cfg.Seed)
+			fmt.Printf("  blockSize=%s fileSize=%s totalData=%s\n",
+				iotestHumanSize(int64(cfg.BlockSize)), iotestHumanSize(cfg.FileSize), iotestHumanSize(totalData))
+			fmt.Println()
+
+			start := time.Now()
+			res, err := r.Run(doRead)
+			if err != nil {
+				return fmt.Errorf("run: %w", err)
+			}
+			elapsed := time.Since(start)
+
+			fmt.Printf("Write:  %7.1f MB/s  %s in %s\n",
+				res.WriteMBps(),
+				iotestHumanSize(res.TotalWritten),
+				res.WriteElapsed.Round(time.Millisecond))
+			if doRead {
+				fmt.Printf("Read:   %7.1f MB/s  %s in %s\n",
+					res.ReadMBps(),
+					iotestHumanSize(res.TotalRead),
+					res.ReadElapsed.Round(time.Millisecond))
+			}
+			fmt.Printf("Elapsed: %s\n", elapsed.Round(time.Millisecond))
+			fmt.Printf("Manifest: %s/posixbench.json\n", cfg.Path)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&cfg.Path, "path", "", "target directory (required)")
+	cmd.Flags().IntVar(&cfg.Threads, "threads", cfg.Threads, "worker goroutines")
+	cmd.Flags().IntVar(&cfg.BlockSize, "block-size", cfg.BlockSize, "IO transfer size in bytes")
+	cmd.Flags().Int64Var(&cfg.FileSize, "file-size", cfg.FileSize, "per-worker data size in bytes")
+	cmd.Flags().IntVar(&cfg.FilesPerWorker, "files-per-worker", cfg.FilesPerWorker, "files per worker (1-to-1 layout only)")
+	cmd.Flags().StringVar((*string)(&cfg.Layout), "layout", string(cfg.Layout), "file distribution: 1-to-1 or n-to-1")
+	cmd.Flags().StringVar(&kindStr, "kind", "decimal", "data pattern: decimal|prng|zeros|ones|countup|repeat")
+	cmd.Flags().Uint64Var(&cfg.Seed, "seed", 0, "pattern seed (0 = random, recorded in manifest)")
+	cmd.Flags().BoolVar(&doRead, "read", false, "run a sequential read phase after writing")
+	cmd.Flags().BoolVar(&noXattr, "no-xattr", false,
+		"write per-stripe ECC into data files instead of xattrs; blocksize is encoded in filenames; verification is ECC-only")
+	return cmd
+}
+
+func newBenchVerifyCmd() *cobra.Command {
+	var (
+		path     string
+		hostname string
+		verbose  bool
+	)
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Check data files against the posixbench.json manifest written by run",
+		Long: `Verify data files against the posixbench.json manifest written by 'bench run'.
+
+When verifying files written by 'beegfs iotest start bench' on a shared path,
+pass --hostname to select the per-node manifest (posixbench-{hostname}.json).`,
+		Annotations: map[string]string{"authorization.AllowAllUsers": ""},
+		Args:        cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if helpIfNoFlags(cmd) {
+				return nil
+			}
+			if path == "" {
+				return fmt.Errorf("required flag \"path\" not set")
+			}
+			cfg, err := posixbench.ReadManifestHost(path, hostname)
+			if err != nil {
+				return fmt.Errorf("verify: %w", err)
+			}
+
+			v, err := posixbench.NewVerifier(cfg)
+			if err != nil {
+				return fmt.Errorf("verify: %w", err)
+			}
+
+			fmt.Printf("posixbench verify\n")
+			fmt.Printf("  path=%s seed=%d kind=%s blockSize=%s\n",
+				path, cfg.Seed, cfg.Kind, iotestHumanSize(int64(cfg.BlockSize)))
+			fmt.Println()
+
+			start := time.Now()
+			n, err := v.Verify(func(a posixbench.Anomaly) error {
+				if verbose {
+					fmt.Printf("  MISMATCH  file=%s fileIndex=%d blockIndex=%d offset=%d\n",
+						a.File, a.FileIndex, a.BlockIndex, a.Offset)
+				}
+				return nil
+			})
+			if err != nil {
+				return fmt.Errorf("verify: %w", err)
+			}
+
+			fmt.Printf("Elapsed: %s\n", time.Since(start).Round(time.Millisecond))
+			if n == 0 {
+				fmt.Println("PASS")
+				return nil
+			}
+			return fmt.Errorf("FAIL: %d block(s) mismatched", n)
+		},
+	}
+	cmd.Flags().StringVar(&path, "path", "", "directory containing the manifest (required)")
+	cmd.Flags().StringVar(&hostname, "hostname", "", "verify files for this hostname (reads posixbench-{hostname}.json)")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "print all mismatched blocks")
+	return cmd
+}

--- a/ctl/internal/cmd/iotest/dump.go
+++ b/ctl/internal/cmd/iotest/dump.go
@@ -1,0 +1,96 @@
+package iotest
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+)
+
+func newDumpCmd() *cobra.Command {
+	var path string
+	cmd := &cobra.Command{
+		Use:   "dump",
+		Short: "Print every block stored in a verifyio data file",
+		Long: `Print every block stored in a verifyio data file.
+Reads xattrs to discover records, verifies each block, and prints a summary in offset order.`,
+		Annotations: map[string]string{"authorization.AllowAllUsers": ""},
+		Args:        cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if helpIfNoFlags(cmd) {
+				return nil
+			}
+			if path == "" {
+				return fmt.Errorf("required flag \"path\" not set")
+			}
+			f, err := os.Open(path)
+			if err != nil {
+				return fmt.Errorf("open: %w", err)
+			}
+			defer f.Close()
+
+			store, err := xattrstore.OpenStore(path)
+			if err != nil {
+				return fmt.Errorf("OpenStore: %w", err)
+			}
+
+			type entry struct {
+				offset, length int64
+				header         []byte
+			}
+			var entries []entry
+			if err := store.ForEachEntry(func(offset, length int64, header []byte) error {
+				h := make([]byte, len(header))
+				copy(h, header)
+				entries = append(entries, entry{offset, length, h})
+				return nil
+			}); err != nil {
+				return fmt.Errorf("ForEachEntry: %w", err)
+			}
+
+			sort.Slice(entries, func(i, j int) bool {
+				return entries[i].offset < entries[j].offset
+			})
+
+			fmt.Printf("%s: %d block(s)\n\n", path, len(entries))
+
+			scratch := make([]byte, 4096)
+			for _, e := range entries {
+				h, err := block.UnmarshalHeader(e.header)
+				if err != nil {
+					fmt.Printf("offset=%-8d length=%-6d  header parse error: %v\n\n", e.offset, e.length, err)
+					continue
+				}
+
+				buf := make([]byte, e.length)
+				_, readErr := f.ReadAt(buf, e.offset)
+
+				var verdictStr string
+				if readErr != nil {
+					verdictStr = fmt.Sprintf("READ_ERROR(%v)", readErr)
+				} else {
+					if int(h.BodyLen) > len(scratch) {
+						scratch = make([]byte, h.BodyLen)
+					}
+					v, _ := block.VerifyBlock(buf, &h, scratch)
+					verdictStr = v.String()
+				}
+
+				ts := time.Unix(0, h.TimeNs).UTC().Format(time.RFC3339Nano)
+				fmt.Printf("offset=%-8d length=%-6d  verdict=%s\n", e.offset, e.length, verdictStr)
+				fmt.Printf("  kind=%-10s worker=%-4d cycle=%-6d node=%s tid=%d\n",
+					h.Kind, h.WorkerID, h.Cycle, block.NodeNameString(h.NodeName), h.TID)
+				fmt.Printf("  time=%s\n", ts)
+				fmt.Printf("  bodyLen=%-6d seed=0x%016x bodyCRC=0x%08x\n\n",
+					h.BodyLen, h.Seed, h.BodyCRC)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&path, "path", "", "data file to inspect")
+	return cmd
+}

--- a/ctl/internal/cmd/iotest/framework.go
+++ b/ctl/internal/cmd/iotest/framework.go
@@ -1,0 +1,885 @@
+package iotest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+	"github.com/thinkparq/beegfs-go/ctl/internal/util"
+	"golang.org/x/term"
+)
+
+// Tool is implemented by each iotest workload. The framework handles SSH
+// fan-out, coordination files, and the start/status/stop lifecycle.
+// Tools only need to run work and respect the stop signal.
+type Tool interface {
+	Name() string
+	Run(ctx context.Context, cfg RunConfig) error
+}
+
+// FlagProvider is an optional interface tools can implement to register
+// their own flags on the 'start' command. RegisterFlags is called once
+// during command construction; flags registered here are forwarded to
+// remote nodes verbatim via the SSH fan-out mechanism.
+type FlagProvider interface {
+	RegisterFlags(cmd *cobra.Command)
+}
+
+// CompletionHinter is an optional interface tools can implement to print
+// post-run guidance after all workloads finish. The framework calls it once
+// per unique tool type after a successful start --wait/--watch completes.
+type CompletionHinter interface {
+	CompletionHint(path string) string
+}
+
+// StatusFormatter is an optional interface tools can implement to render
+// their ExtraData field in beegfs iotest status output.
+type StatusFormatter interface {
+	FormatExtraStatus(node string, data json.RawMessage) string
+}
+
+// StatusFootnote is an optional interface tools can implement to print a
+// one-time explanatory footer after all per-node FormatExtraStatus blocks.
+type StatusFootnote interface {
+	FormatStatusFootnote() string
+}
+
+// Describer is an optional interface tools can implement to provide a one-line
+// description shown in 'beegfs iotest start' help text.
+type Describer interface {
+	Description() string
+}
+
+// RunConfig is passed to Tool.Run by the framework.
+type RunConfig struct {
+	Path           string
+	NodeName       string        // this node's identity for cross-node coordination; falls back to os.Hostname() when empty. On multi-node runs this is the --nodes name the operator typed (and is therefore resolvable by the other participating nodes), NOT necessarily os.Hostname()'s value.
+	BlockSize      int           // bytes per verifiable block; 0 = the tool's own default
+	Threads        int           // worker/thread count; 0 = the tool's own default
+	TotalOps       *atomic.Int64 // increment on each completed operation
+	StopSignal     *atomic.Bool  // poll this; return nil when true
+	SetExtraStatus func(v any)   // write tool-specific data into the status file
+}
+
+// workloadStatus is the on-disk format of a coordination status file
+// (.iotest-<workload>-<hostname>.json).  It is written periodically while
+// a tool runs and once more with the final status on completion.
+// ExtraData carries tool-specific JSON that StatusFormatter implementations
+// decode for display; the framework treats it as an opaque blob.
+type workloadStatus struct {
+	Node      string          `json:"node"`
+	Workload  string          `json:"workload"`
+	Status    string          `json:"status"` // "running" | "done" | "failed"
+	StartTime time.Time       `json:"startTime"`
+	EndTime   *time.Time      `json:"endTime,omitempty"`
+	TotalOps  int64           `json:"totalOps"`
+	Error     string          `json:"error,omitempty"`
+	ExtraData json.RawMessage `json:"extraData,omitempty"`
+}
+
+type frameworkCfg struct {
+	path            string
+	nodes           string
+	nodeName        string // overrides os.Hostname() for status file naming; injected by startMultiNode
+	wait            bool
+	watch           bool
+	refreshInterval time.Duration
+	fresh           bool
+	blockSize       int // --blocksize; bytes per verifiable block, 0 = each tool's default
+	threads         int // --threads; worker count, 0 = each tool's default
+}
+
+// NewFrameworkCmds returns the start/status/stop cobra commands for
+// the given tools. Add the returned commands to the iotest parent command.
+func NewFrameworkCmds(tools ...Tool) []*cobra.Command {
+	cfg := &frameworkCfg{}
+
+	toolMap := make(map[string]Tool, len(tools))
+	for _, t := range tools {
+		toolMap[t.Name()] = t
+	}
+
+	addPathFlag := func(cmd *cobra.Command) {
+		cmd.Flags().StringVar(&cfg.path, "path", "/tmp/beegfs-iotest",
+			"directory for coordination and data files (use a shared BeeGFS path for multi-node runs)")
+	}
+	addWaitWatch := func(cmd *cobra.Command) {
+		cmd.Flags().DurationVar(&cfg.refreshInterval, "wait", 0,
+			"block and poll for completion at this interval, printing final status when done (e.g. --wait=5s)")
+		cmd.Flags().DurationVarP(&cfg.refreshInterval, "watch", "w", 0,
+			"continuously refresh and display status at this interval until all workloads complete (e.g. --watch=5s)")
+		cmd.MarkFlagsMutuallyExclusive("wait", "watch")
+	}
+
+	return []*cobra.Command{
+		newFrameworkStartCmd(cfg, toolMap, addPathFlag, addWaitWatch),
+		newFrameworkStatusCmd(cfg, toolMap, addPathFlag, addWaitWatch),
+		newFrameworkStopCmd(cfg, addPathFlag),
+	}
+}
+
+// ── Commands ──────────────────────────────────────────────────────────────────
+
+// helpWidth returns the terminal width to wrap help text to. It mirrors the
+// clamp used by the help renderer (getTermWidthForHelp in root.go: min 80,
+// max 150, fallback 80 when stdout is not a terminal) so that our pre-wrapped
+// lines already fit and the renderer's own wrapping pass leaves them unchanged.
+func helpWidth() int {
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w <= 0 {
+		return 80
+	}
+	return min(150, max(80, w))
+}
+
+// wrapWithHangingIndent word-wraps s so that each line fits within width,
+// indenting every line after the first by indent spaces. The first line is
+// returned without leading indent so the caller can place it after a label
+// (e.g. a padded workload name), producing a hanging-indent layout. It wraps
+// two columns short of the available width so the help renderer's own wrapping
+// pass (which subtracts one and re-adds indentation) does not re-break lines.
+func wrapWithHangingIndent(s string, indent, width int) string {
+	avail := max(width-indent-2, 20) // 20 = sane floor for very narrow terminals
+	words := strings.Fields(s)
+	if len(words) == 0 {
+		return ""
+	}
+	pad := strings.Repeat(" ", indent)
+	var b strings.Builder
+	b.WriteString(words[0])
+	lineLen := len(words[0])
+	for _, w := range words[1:] {
+		if lineLen+1+len(w) > avail {
+			b.WriteString("\n")
+			b.WriteString(pad)
+			b.WriteString(w)
+			lineLen = len(w)
+		} else {
+			b.WriteString(" ")
+			b.WriteString(w)
+			lineLen += 1 + len(w)
+		}
+	}
+	return b.String()
+}
+
+func newFrameworkStartCmd(cfg *frameworkCfg, tools map[string]Tool, addPathFlag, addWaitWatch func(*cobra.Command)) *cobra.Command {
+	names := make([]string, 0, len(tools))
+	for n := range tools {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	var longBuf strings.Builder
+	// The blank line after the header matters: the help renderer (see
+	// wrapHelpText in root.go) collapses a ":"-terminated header block into a
+	// single line, but preserves an indented paragraph verbatim as a code
+	// block. Emitting the list as its own indented paragraph keeps our
+	// hanging-indent wrapping intact.
+	longBuf.WriteString("Start one or more iotest workloads locally or across multiple nodes via SSH.\n\nAvailable workloads:\n\n")
+	const descCol = 12 // "  " + %-8s name + "  "
+	width := helpWidth()
+	for _, n := range names {
+		desc := ""
+		if d, ok := tools[n].(Describer); ok {
+			desc = d.Description()
+		}
+		fmt.Fprintf(&longBuf, "  %-8s  %s\n", n, wrapWithHangingIndent(desc, descCol, width))
+	}
+
+	cmd := &cobra.Command{
+		Use:   "start [workload...]",
+		Short: "Start one or more iotest workloads",
+		Long:  longBuf.String(),
+		Example: `  # Run soak on the local node
+  beegfs iotest start soak --path /mnt/beegfs/testdir
+
+  # Run soak across two nodes and watch until complete
+  beegfs iotest start soak --nodes test-r9-01,test-r9-02 --path /mnt/beegfs/testdir --watch=5s
+
+  # Run soak and inval simultaneously across two nodes
+  beegfs iotest start soak inval --nodes test-r9-01,test-r9-02 --path /mnt/beegfs/testdir`,
+		Annotations: map[string]string{"authorization.AllowAllUsers": ""},
+		Args:        cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				_ = cmd.Help()
+				return nil
+			}
+			if cmd.Flags().Changed("watch") {
+				cfg.watch = true
+			} else if cmd.Flags().Changed("wait") {
+				cfg.wait = true
+			}
+
+			selected := make([]Tool, 0, len(args))
+			for _, name := range args {
+				t, ok := tools[name]
+				if !ok {
+					names := make([]string, 0, len(tools))
+					for n := range tools {
+						names = append(names, n)
+					}
+					return fmt.Errorf("unknown workload %q (available: %s)", name, strings.Join(names, ", "))
+				}
+				selected = append(selected, t)
+			}
+
+			if cfg.fresh {
+				resolvedPath, err := freshCheckPath(cfg.path)
+				if err != nil {
+					return err
+				}
+				if err := freshDelete(resolvedPath); err != nil {
+					return err
+				}
+			}
+
+			_ = os.MkdirAll(cfg.path, 0755)
+			// Only the invoking node records the invocation. Remote fan-out nodes
+			// (launched with --iotest-node) share this BeeGFS path and would
+			// otherwise overwrite the file with their per-node args (--iotest-node,
+			// -N stripped), hiding the real multi-node command from `status`.
+			if cfg.nodeName == "" {
+				saveInvocation(cfg.path)
+			}
+
+			if cfg.nodes != "" {
+				nodes, err := parseNodes(cfg.nodes)
+				if err != nil {
+					return err
+				}
+				if err := startMultiNode(cmd.Context(), cfg, selected, nodes); err != nil {
+					return err
+				}
+				if !cfg.wait && !cfg.watch {
+					fmt.Printf("beegfs iotest status --path %s  # %d node(s) started\n",
+						cfg.path, len(nodes))
+					return nil
+				}
+				if err := waitOrWatch(cmd.Context(), cfg, tools); err != nil {
+					return err
+				}
+				printCompletionHints(cfg.path, selected)
+				return nil
+			}
+			if err := startLocal(cmd.Context(), cfg, selected); err != nil {
+				return err
+			}
+			printCompletionHints(cfg.path, selected)
+			return nil
+		},
+	}
+	addPathFlag(cmd)
+	addWaitWatch(cmd)
+	cmd.Flags().StringVarP(&cfg.nodes, "nodes", "N", "", "comma-separated node names or path to a nodes file")
+	cmd.Flags().BoolVar(&cfg.fresh, "fresh", false, "remove iotest data and coordination files from --path before starting")
+	cmd.Flags().IntVar(&cfg.blockSize, "blocksize", 0, "bytes per verifiable block for tools that write blocks (soak, bench); 0 = each tool's own default")
+	cmd.Flags().IntVar(&cfg.threads, "threads", 0, "worker/thread count for tools that support it (soak, bench); 0 = each tool's own default")
+	cmd.Flags().StringVar(&cfg.nodeName, "iotest-node", "", "override the node name used in status files (injected by multi-node SSH invocations)")
+	_ = cmd.Flags().MarkHidden("iotest-node")
+	for _, t := range tools {
+		if fp, ok := t.(FlagProvider); ok {
+			fp.RegisterFlags(cmd)
+		}
+	}
+	return cmd
+}
+
+func newFrameworkStatusCmd(cfg *frameworkCfg, tools map[string]Tool, addPathFlag, addWaitWatch func(*cobra.Command)) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "status",
+		Short:       "Show the status of active or recent iotest workloads",
+		Annotations: map[string]string{"authorization.AllowAllUsers": ""},
+		Args:        cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("watch") {
+				cfg.watch = true
+			} else if cmd.Flags().Changed("wait") {
+				cfg.wait = true
+			}
+
+			if cfg.wait || cfg.watch {
+				return waitOrWatch(cmd.Context(), cfg, tools)
+			}
+
+			statuses, err := readStatuses(cfg.path)
+			if err != nil {
+				return err
+			}
+			if len(statuses) == 0 {
+				fmt.Printf("No iotest status files found at %s\n", cfg.path)
+				return nil
+			}
+			printStatusTable(cfg.path, statuses, tools)
+			return nil
+		},
+	}
+	addPathFlag(cmd)
+	addWaitWatch(cmd)
+	return cmd
+}
+
+func newFrameworkStopCmd(cfg *frameworkCfg, addPathFlag func(*cobra.Command)) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:         "stop",
+		Short:       "Signal all running iotest workloads to stop",
+		Annotations: map[string]string{"authorization.AllowAllUsers": ""},
+		Args:        cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			f, err := os.Create(stopPath(cfg.path))
+			if err != nil {
+				return fmt.Errorf("write stop signal: %w", err)
+			}
+			// watchStopSignal polls for this file's existence, not any content
+			// written to it -- but if Close fails the create may not be durably
+			// visible yet, and running workloads would never see the signal
+			// while this command reports success.
+			if err := f.Close(); err != nil {
+				return fmt.Errorf("write stop signal: %w", err)
+			}
+			fmt.Println("Stop signal written. Workloads will exit at the next poll interval.")
+			return nil
+		},
+	}
+	addPathFlag(cmd)
+	_ = cmd.MarkFlagRequired("path")
+	return cmd
+}
+
+// ── Local execution ───────────────────────────────────────────────────────────
+
+func startLocal(ctx context.Context, cfg *frameworkCfg, tools []Tool) error {
+	hostname := cfg.nodeName
+	if hostname == "" {
+		h, err := os.Hostname()
+		if err != nil {
+			return fmt.Errorf("get hostname: %w", err)
+		}
+		hostname = h
+	}
+
+	if err := os.MkdirAll(cfg.path, 0755); err != nil {
+		return fmt.Errorf("create path %s: %w", cfg.path, err)
+	}
+
+	// Refuse to start if the same workload type is already running on this node.
+	// Only check workloads being started here — different workload types are
+	// expected to run concurrently (each gets its own SSH session and stop-signal
+	// goroutine). Only check the local hostname; other nodes' status files are
+	// visible on a shared path and must not block this node from starting.
+	starting := make(map[string]bool, len(tools))
+	for _, t := range tools {
+		starting[t.Name()] = true
+	}
+	if existing, _ := readStatuses(cfg.path); len(existing) > 0 {
+		for _, s := range existing {
+			if s.Status == "running" && s.Node == hostname && starting[s.Workload] {
+				return fmt.Errorf("workload %q is still running on this node at %s; "+
+					"wait for it to finish or remove the coordination files with 'rm %s/.iotest-*'",
+					s.Workload, cfg.path, cfg.path)
+			}
+		}
+	}
+	_ = os.Remove(stopPath(cfg.path)) // clear any stale stop signal from a previous run
+
+	stopSig := &atomic.Bool{}
+	stopCtx, cancelStop := context.WithCancel(ctx)
+	defer cancelStop()
+	go watchStopSignal(stopCtx, cfg.path, stopSig)
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var failures []string
+
+	for _, tool := range tools {
+		tool := tool
+		startTime := time.Now()
+		spath := statusPath(cfg.path, tool.Name(), hostname)
+		ops := &atomic.Int64{}
+
+		var extraStatus atomic.Value
+
+		_ = writeStatus(workloadStatus{
+			Node: hostname, Workload: tool.Name(),
+			Status: "running", StartTime: startTime,
+		}, spath)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			setExtra := func(v any) {
+				if data, err := json.Marshal(v); err == nil {
+					extraStatus.Store(json.RawMessage(data))
+				}
+			}
+			getExtra := func() json.RawMessage {
+				raw, _ := extraStatus.Load().(json.RawMessage)
+				return raw
+			}
+
+			updateCtx, cancelUpdate := context.WithCancel(ctx)
+			defer cancelUpdate() // safety net for early returns
+			updateDone := make(chan struct{})
+			go func() {
+				defer close(updateDone)
+				t := time.NewTicker(5 * time.Second)
+				defer t.Stop()
+				for {
+					select {
+					case <-t.C:
+						_ = writeStatus(workloadStatus{
+							Node: hostname, Workload: tool.Name(),
+							Status: "running", StartTime: startTime,
+							TotalOps: ops.Load(), ExtraData: getExtra(),
+						}, spath)
+					case <-updateCtx.Done():
+						return
+					}
+				}
+			}()
+
+			runErr := tool.Run(ctx, RunConfig{
+				Path: cfg.path, NodeName: cfg.nodeName, BlockSize: cfg.blockSize, Threads: cfg.threads, TotalOps: ops, StopSignal: stopSig,
+				SetExtraStatus: setExtra,
+			})
+
+			// Stop the update goroutine and wait for it to exit before writing
+			// the final status, so the ticker cannot overwrite "done"/"failed".
+			cancelUpdate()
+			<-updateDone
+
+			now := time.Now()
+			status, errStr := "done", ""
+			if runErr != nil {
+				status = "failed"
+				errStr = runErr.Error()
+				mu.Lock()
+				failures = append(failures, fmt.Sprintf("%s: %s", tool.Name(), errStr))
+				mu.Unlock()
+			}
+			_ = writeStatus(workloadStatus{
+				Node: hostname, Workload: tool.Name(),
+				Status: status, StartTime: startTime, EndTime: &now,
+				TotalOps: ops.Load(), Error: errStr, ExtraData: getExtra(),
+			}, spath)
+		}()
+	}
+
+	wg.Wait()
+
+	if len(failures) > 0 {
+		return fmt.Errorf("workload(s) failed:\n  %s", strings.Join(failures, "\n  "))
+	}
+	return nil
+}
+
+// ── Multi-node execution ──────────────────────────────────────────────────────
+
+// startMultiNode launches one SSH session per (tool, node) pair so each
+// workload gets its own log file named .iotest-<workload>-<node>.log.
+func startMultiNode(ctx context.Context, cfg *frameworkCfg, tools []Tool, nodes []NodeSpec) error {
+	if err := os.MkdirAll(cfg.path, 0755); err != nil {
+		return fmt.Errorf("create path %s: %w", cfg.path, err)
+	}
+
+	allNames := make([]string, len(tools))
+	for i, t := range tools {
+		allNames[i] = t.Name()
+	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var failures []string
+
+	for _, tool := range tools {
+		for _, node := range nodes {
+			tool, node := tool, node
+			remoteArgs := append(buildRemoteArgsForWorkload(os.Args, allNames, tool.Name()),
+				"--iotest-node", node.Name)
+			lPath := filepath.Join(cfg.path, fmt.Sprintf(".iotest-%s-%s.log", tool.Name(), node.Name))
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := sshStartBackground(ctx, node, remoteArgs, lPath); err != nil {
+					mu.Lock()
+					failures = append(failures, err.Error())
+					mu.Unlock()
+				}
+			}()
+		}
+	}
+
+	wg.Wait()
+
+	if len(failures) > 0 {
+		return fmt.Errorf("failed to start on node(s):\n  %s", strings.Join(failures, "\n  "))
+	}
+	return nil
+}
+
+// ── Wait / Watch ──────────────────────────────────────────────────────────────
+
+func waitOrWatch(ctx context.Context, cfg *frameworkCfg, tools map[string]Tool) error {
+	if cfg.refreshInterval == 0 {
+		cfg.refreshInterval = 5 * time.Second
+	}
+	ticker := time.NewTicker(cfg.refreshInterval)
+	defer ticker.Stop()
+
+	for {
+		statuses, err := readStatuses(cfg.path)
+		if err != nil {
+			return err
+		}
+
+		if cfg.watch && len(statuses) > 0 {
+			r := util.TermRefresher{}
+			if err := r.StartRefresh(); err != nil {
+				return err
+			}
+			printStatusTable(cfg.path, statuses, tools)
+			_ = r.FinishRefresh(util.WithTermFooter(fmt.Sprintf(
+				"Refreshing every %s (last: %s). Ctrl+C to stop watching.",
+				cfg.refreshInterval, time.Now().Format(time.TimeOnly),
+			)))
+		}
+
+		if len(statuses) > 0 && allTerminated(statuses) {
+			if cfg.wait {
+				printStatusTable(cfg.path, statuses, tools)
+			}
+			util.TerminalAlert()
+			return terminationError(statuses)
+		}
+
+		select {
+		case <-ctx.Done():
+			// Return any failures that already completed rather than hiding them.
+			statuses, _ = readStatuses(cfg.path)
+			return terminationError(statuses)
+		case <-ticker.C:
+		}
+	}
+}
+
+// ── File helpers ──────────────────────────────────────────────────────────────
+
+func statusPath(dir, workload, hostname string) string {
+	return filepath.Join(dir, fmt.Sprintf(".iotest-%s-%s.json", workload, hostname))
+}
+
+func stopPath(dir string) string {
+	return filepath.Join(dir, ".iotest.stop")
+}
+
+func invocationPath(dir string) string {
+	return filepath.Join(dir, ".iotest-invocation.json")
+}
+
+type invocationRecord struct {
+	Args      []string  `json:"args"`
+	StartTime time.Time `json:"startTime"`
+}
+
+func saveInvocation(dir string) {
+	rec := invocationRecord{Args: os.Args, StartTime: time.Now()}
+	if data, err := json.Marshal(rec); err == nil {
+		_ = os.WriteFile(invocationPath(dir), data, 0644)
+	}
+}
+
+func readInvocation(dir string) *invocationRecord {
+	data, err := os.ReadFile(invocationPath(dir))
+	if err != nil {
+		return nil
+	}
+	var rec invocationRecord
+	if json.Unmarshal(data, &rec) != nil {
+		return nil
+	}
+	return &rec
+}
+
+func writeStatus(s workloadStatus, path string) error {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+func readStatuses(dir string) ([]workloadStatus, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, ".iotest-*.json"))
+	if err != nil {
+		return nil, fmt.Errorf("glob %s: %w", dir, err)
+	}
+	invPath := invocationPath(dir)
+	statuses := make([]workloadStatus, 0, len(matches))
+	for _, m := range matches {
+		if m == invPath {
+			continue
+		}
+		data, err := os.ReadFile(m)
+		if err != nil {
+			continue
+		}
+		var s workloadStatus
+		if err := json.Unmarshal(data, &s); err != nil {
+			continue
+		}
+		statuses = append(statuses, s)
+	}
+	return statuses, nil
+}
+
+// watchStopSignal polls for the stop file every second and sets sig when found.
+// Runs in a goroutine; exits when ctx is cancelled or the stop file appears.
+func watchStopSignal(ctx context.Context, dir string, sig *atomic.Bool) {
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			if _, err := os.Stat(stopPath(dir)); err == nil {
+				sig.Store(true)
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// ── Output ────────────────────────────────────────────────────────────────────
+
+// printStatusTable renders all workload statuses as a table, then appends any
+// tool-specific extra lines from StatusFormatter implementors below the table.
+// If any workload has failed, it also prints debugging hints pointing to the
+// SSH log for each failed node.
+func printStatusTable(path string, statuses []workloadStatus, tools map[string]Tool) {
+	if inv := readInvocation(path); inv != nil {
+		fmt.Printf("[%s] %s\n", inv.StartTime.Format(time.DateTime), strings.Join(inv.Args, " "))
+	}
+
+	t := table.NewWriter()
+	t.AppendHeader(table.Row{"WORKLOAD", "NODE", "STATUS", "OPS", "ELAPSED", "ERROR"})
+	for _, s := range statuses {
+		elapsed := "-"
+		if !s.StartTime.IsZero() {
+			end := time.Now()
+			if s.EndTime != nil {
+				end = *s.EndTime
+			}
+			elapsed = end.Sub(s.StartTime).Round(time.Second).String()
+		}
+		t.AppendRow(table.Row{s.Workload, s.Node, s.Status, s.TotalOps, elapsed, s.Error})
+	}
+	fmt.Println(t.Render())
+
+	// Print tool-specific extra data for any status that has it.
+	for _, s := range statuses {
+		if len(s.ExtraData) == 0 {
+			continue
+		}
+		tool, ok := tools[s.Workload]
+		if !ok {
+			continue
+		}
+		sf, ok := tool.(StatusFormatter)
+		if !ok {
+			continue
+		}
+		if line := sf.FormatExtraStatus(s.Node, s.ExtraData); line != "" {
+			fmt.Println(line)
+		}
+	}
+
+	// Print a one-time footer for any tool that implements StatusFootnote.
+	seenFootnote := map[string]bool{}
+	for _, s := range statuses {
+		if seenFootnote[s.Workload] {
+			continue
+		}
+		tool, ok := tools[s.Workload]
+		if !ok {
+			continue
+		}
+		if fn, ok := tool.(StatusFootnote); ok {
+			if footer := fn.FormatStatusFootnote(); footer != "" {
+				fmt.Println(footer)
+			}
+		}
+		seenFootnote[s.Workload] = true
+	}
+
+	// Print debug hints for any failed workloads. Each workload on each node
+	// has its own SSH log file named .iotest-<workload>-<node>.log.
+	var failed []workloadStatus
+	for _, s := range statuses {
+		if s.Status == "failed" {
+			failed = append(failed, s)
+		}
+	}
+	if len(failed) > 0 {
+		fmt.Println("# To investigate failures, check the SSH log for each failed workload:")
+		for _, s := range failed {
+			logFile := filepath.Join(path, fmt.Sprintf(".iotest-%s-%s.log", s.Workload, s.Node))
+			fmt.Printf("cat %s\n", logFile)
+		}
+	}
+}
+
+// printCompletionHints calls CompletionHint once per unique tool type.
+func printCompletionHints(path string, tools []Tool) {
+	seen := map[string]bool{}
+	for _, t := range tools {
+		if seen[t.Name()] {
+			continue
+		}
+		seen[t.Name()] = true
+		if h, ok := t.(CompletionHinter); ok {
+			if hint := h.CompletionHint(path); hint != "" {
+				fmt.Println(hint)
+			}
+		}
+	}
+}
+
+func allTerminated(statuses []workloadStatus) bool {
+	for _, s := range statuses {
+		if s.Status == "running" {
+			return false
+		}
+	}
+	return true
+}
+
+// iotestHumanSize formats n as a human-readable IEC size string (KiB/MiB/GiB).
+func iotestHumanSize(n int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case n >= gib:
+		return fmt.Sprintf("%.2f GiB", float64(n)/gib)
+	case n >= mib:
+		return fmt.Sprintf("%.2f MiB", float64(n)/mib)
+	case n >= kib:
+		return fmt.Sprintf("%.2f KiB", float64(n)/kib)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
+// ── Fresh-start helpers ───────────────────────────────────────────────────────
+
+// freshBlocklist contains absolute paths that --fresh refuses to clean.
+// These are the standard Linux/Unix directories where deleting iotest-*
+// files would be surprising at best and destructive at worst.
+var freshBlocklist = map[string]bool{
+	"/":      true,
+	"/bin":   true,
+	"/boot":  true,
+	"/dev":   true,
+	"/etc":   true,
+	"/home":  true,
+	"/lib":   true,
+	"/lib32": true,
+	"/lib64": true,
+	"/opt":   true,
+	"/proc":  true,
+	"/root":  true,
+	"/run":   true,
+	"/sbin":  true,
+	"/srv":   true,
+	"/sys":   true,
+	"/tmp":   true,
+	"/usr":   true,
+	"/var":   true,
+}
+
+// freshCheckPath returns the resolved, symlink-free absolute form of path,
+// or an error if that resolves to a blocklisted directory. Callers must
+// pass the returned path to freshDelete rather than the original path --
+// checking the lexical path but deleting through the original would let a
+// symlinked --path whose target is a blocklisted directory bypass the
+// check entirely (the check would see the symlink's own path, not where it
+// points, while the OS transparently follows the symlink during the
+// delete).
+func freshCheckPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("--fresh: resolve path %q: %w", path, err)
+	}
+	// EvalSymlinks fails if the path doesn't exist yet -- the common case on
+	// a first run, before the MkdirAll below creates it. A nonexistent path
+	// can't be a symlink to anywhere, so fall back to the unresolved
+	// absolute path rather than treating that as an error.
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("--fresh: resolve symlinks in %q: %w", path, err)
+		}
+		resolved = abs
+	}
+	if freshBlocklist[resolved] {
+		return "", fmt.Errorf("--fresh: refusing to clean %q (system directory); use a dedicated test path", resolved)
+	}
+	return resolved, nil
+}
+
+// freshDelete removes iotest data and coordination files from dir.
+// Files matching iotest-* (data files) and .iotest-* (status, log, stop
+// signal) are deleted. Non-matching files are left untouched.
+func freshDelete(dir string) error {
+	var deleted int
+	for _, pat := range []string{"iotest-*", ".iotest-*"} {
+		matches, err := filepath.Glob(filepath.Join(dir, pat))
+		if err != nil {
+			return fmt.Errorf("--fresh: glob %q: %w", pat, err)
+		}
+		for _, m := range matches {
+			if err := os.Remove(m); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("--fresh: remove %q: %w", m, err)
+			}
+			deleted++
+		}
+	}
+	if deleted > 0 {
+		fmt.Printf("--fresh: removed %d file(s) from %s\n", deleted, dir)
+	}
+	return nil
+}
+
+// terminationError returns nil if every workload succeeded, or an error listing
+// all failed workloads. Workloads still in "running" state are ignored — callers
+// that reach this only do so after allTerminated returns true.
+func terminationError(statuses []workloadStatus) error {
+	var failed []string
+	for _, s := range statuses {
+		if s.Status == "failed" {
+			msg := s.Workload + " on " + s.Node
+			if s.Error != "" {
+				msg += ": " + s.Error
+			}
+			failed = append(failed, msg)
+		}
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("workload(s) failed:\n  %s", strings.Join(failed, "\n  "))
+	}
+	return nil
+}

--- a/ctl/internal/cmd/iotest/framework_test.go
+++ b/ctl/internal/cmd/iotest/framework_test.go
@@ -1,0 +1,70 @@
+// This is a unit test.
+//
+// Coverage: freshCheckPath's blocklist resolution -- an ordinary path
+// passes and returns its absolute form; a nonexistent path (the common
+// first-run case, before start's MkdirAll creates it) also passes rather
+// than erroring on a missing target; and a symlink whose target is a
+// blocklisted directory is rejected, a regression test for the resolved
+// vs. lexical path bug found by review (the check used to compare the
+// symlink's own path against the blocklist, never the directory it
+// actually pointed to).
+package iotest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFreshCheckPathOrdinaryDir(t *testing.T) {
+	dir := t.TempDir()
+	got, err := freshCheckPath(dir)
+	if err != nil {
+		t.Fatalf("freshCheckPath: %v", err)
+	}
+	wantAbs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	// On macOS /tmp is itself a symlink to /private/tmp, so allow either the
+	// absolute form or its symlink-resolved form.
+	resolvedWant, err := filepath.EvalSymlinks(wantAbs)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", wantAbs, err)
+	}
+	if got != wantAbs && got != resolvedWant {
+		t.Errorf("got %q, want %q or %q", got, wantAbs, resolvedWant)
+	}
+}
+
+func TestFreshCheckPathNonexistentDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does-not-exist-yet")
+	got, err := freshCheckPath(dir)
+	if err != nil {
+		t.Fatalf("freshCheckPath on a not-yet-created path (the normal first-run case): %v", err)
+	}
+	wantAbs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	if got != wantAbs {
+		t.Errorf("got %q, want %q", got, wantAbs)
+	}
+}
+
+// TestFreshCheckPathSymlinkToBlocklistedDirRejected is a regression test:
+// --fresh's blocklist must reject a symlinked --path whose target is a
+// blocklisted directory, not just a --path that is lexically one of the
+// blocklisted strings itself.
+func TestFreshCheckPathSymlinkToBlocklistedDirRejected(t *testing.T) {
+	if _, err := os.Stat("/tmp"); err != nil {
+		t.Skipf("/tmp not present on this system: %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "escape-link")
+	if err := os.Symlink("/tmp", link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if _, err := freshCheckPath(link); err == nil {
+		t.Errorf("freshCheckPath(symlink to /tmp): got nil error, want a blocklist rejection")
+	}
+}

--- a/ctl/internal/cmd/iotest/inval.go
+++ b/ctl/internal/cmd/iotest/inval.go
@@ -1,0 +1,1054 @@
+//go:build linux
+
+package iotest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/thinkparq/beegfs-go/verifyio/xattr"
+)
+
+const (
+	invalDefaultRounds       = 1000
+	invalDefaultRoundTimeout = 10 * time.Second
+	invalDefaultReadyTimeout = 30 * time.Second
+	invalDefaultBlockSize    = int64(4096)
+
+	// invalControlPort carries all per-round leader/follower coordination
+	// (ready handshake, round announcements, observation reports) over a
+	// plain TCP connection instead of files on cfg.Path. Round-signal files
+	// used to live on the mount under test, which meant raising a cache TTL
+	// to probe for a regression also made the coordination signal itself go
+	// stale by the same amount: a follower's single revalidation of that
+	// directory could refresh both the round file's existence AND the test
+	// file's mutated attribute in one round-trip, absorbing the real
+	// invalidation delay into the (unmeasured) round-file wait and reporting
+	// near-zero latency for a case that was actually slow. This is a
+	// well-known failure mode in coordination-channel design generally:
+	// coordination must not ride the same cache/TTL regime as the thing
+	// being measured.
+	//
+	// Deliberately above 60999: Linux's default ephemeral/outgoing port
+	// range (net.ipv4.ip_local_port_range) commonly runs 32768-60999, and a
+	// fixed listener port inside that range can transiently collide with an
+	// unrelated outgoing connection's source port under connection churn.
+	// 61999 sits in IANA's dynamic/private range (49152-65535) reserved for
+	// exactly this kind of ephemeral-but-not-OS-assigned use.
+	invalControlPort = 61999
+
+	invalLockFile    = ".inval-leader.lock"
+	invalTestFile    = "inval-test"
+	invalRenameFileA = "inval-rename-a"
+	invalRenameFileB = "inval-rename-b"
+	invalUnlinkFile  = "inval-unlink-test"
+	invalXattrName   = "user.inval_marker"
+	invalLogFileFmt  = "inval-log-%s-%s.txt" // role (leader/follower), hostname
+)
+
+// invalOp identifies the kind of metadata mutation applied in a round.
+type invalOp string
+
+const (
+	invalOpSize   invalOp = "size"
+	invalOpChmod  invalOp = "chmod"
+	invalOpMtime  invalOp = "mtime"
+	invalOpRename invalOp = "rename"
+	invalOpUnlink invalOp = "unlink"
+	invalOpXattr  invalOp = "xattr"
+)
+
+// invalAllOps lists every operation type. The leader picks one at random
+// each round; invalPrintSummary iterates this slice for the per-op breakdown.
+var invalAllOps = []invalOp{invalOpSize, invalOpChmod, invalOpMtime, invalOpRename, invalOpUnlink, invalOpXattr}
+
+// errStopped is returned by invalWaitForFile when the stop signal fires,
+// allowing callers to distinguish a clean stop from a real timeout.
+var errStopped = errors.New("stop signal received")
+
+// InvalTool implements Tool. It tests metadata cache invalidation by electing
+// a leader to mutate a file's metadata across multiple rounds, while followers
+// measure how quickly they observe each mutation via stat().
+type InvalTool struct{}
+
+func (t *InvalTool) Name() string { return "inval" }
+func (t *InvalTool) Description() string {
+	return "metadata cache-invalidation test; measures observation latency per node"
+}
+
+func (t *InvalTool) Run(ctx context.Context, cfg RunConfig) (err error) {
+	hostname, err := invalNodeName(cfg)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(cfg.Path, 0755); err != nil {
+		return fmt.Errorf("create path %s: %w", cfg.Path, err)
+	}
+
+	isLeader, leaderHost, err := invalElectLeader(cfg.Path, hostname)
+	if err != nil {
+		return err
+	}
+	if isLeader {
+		// invalElectLeader already created the O_CREATE|O_EXCL lock file by
+		// the time it returns isLeader=true. defer here -- rather than a
+		// bare call at the end of invalRunLeader's round loop -- so a
+		// mid-run error on any round, or even a failure to create the
+		// per-node log file just below, doesn't leave a stale lock file
+		// behind. A stale lock blocks every future run on this path: the
+		// next invocation's O_CREATE|O_EXCL would see a "leader" that
+		// already won and every node would wait forever as a follower.
+		defer invalCleanup(cfg.Path)
+	}
+
+	role := "follower"
+	if isLeader {
+		role = "leader"
+	}
+	logPath := filepath.Join(cfg.Path, fmt.Sprintf(invalLogFileFmt, role, hostname))
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return fmt.Errorf("create log file: %w", err)
+	}
+	// The per-node results log (round-by-round latency stats) is this test's
+	// actual diagnostic output -- losing the tail of it to an unflushed
+	// Close silently would defeat the point of running inval at all.
+	defer func() {
+		if closeErr := logFile.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+	fmt.Printf("inval: writing results to %s\n", logPath)
+
+	if isLeader {
+		return invalRunLeader(ctx, cfg, leaderHost, logFile)
+	}
+	return invalRunFollower(ctx, cfg, leaderHost, logFile)
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+// invalCacheStats mirrors the counters in /proc/fs/beegfs/*/inode_cache_stats.
+// Read before and after polling so each round can report the delta invalidation count.
+type invalCacheStats struct {
+	Hits          uint64
+	Misses        uint64
+	Invalidations uint64
+}
+
+// invalReady is sent once by each follower immediately after connecting to
+// the leader's control-channel listener, identifying itself by hostname.
+type invalReady struct {
+	Node string `json:"node"`
+}
+
+// invalRound is sent by the leader over each follower's control connection
+// immediately after it mutates the test file. Followers decode this to learn
+// which operation was applied, the expected post-mutation state, and the
+// timestamp of the mutation. Only the field(s) relevant to Op are populated.
+type invalRound struct {
+	Round             int       `json:"round"`
+	Op                invalOp   `json:"op"`
+	ExpectedSize      int64     `json:"expectedSize,omitempty"`
+	ExpectedMode      uint32    `json:"expectedMode,omitempty"`
+	ExpectedMtime     time.Time `json:"expectedMtime,omitempty"`
+	OldName           string    `json:"oldName,omitempty"`
+	ExpectedName      string    `json:"expectedName,omitempty"`
+	ExpectedExists    bool      `json:"expectedExists,omitempty"` // invalOpUnlink only
+	ExpectedXattr     string    `json:"expectedXattr,omitempty"`  // invalOpXattr only
+	MutatedAt         time.Time `json:"mutatedAt"`
+	ExpectedFollowers int       `json:"expectedFollowers"`
+}
+
+// invalObservation is sent back by each follower over its control connection
+// once it detects the expected post-mutation state via stat(). The leader
+// decodes these to compute per-round latency and detect followers that
+// timed out.
+type invalObservation struct {
+	Round      int       `json:"round"`
+	Op         invalOp   `json:"op"`
+	Node       string    `json:"node"`
+	ObservedAt time.Time `json:"observedAt,omitempty"`
+	LatencyMs  int64     `json:"latencyMs"`
+	Timeout    bool      `json:"timeout,omitempty"`
+}
+
+// invalRoundResult aggregates all observations the leader collected for a single
+// round. Missed lists follower hostnames that did not respond within the timeout.
+type invalRoundResult struct {
+	Round        int
+	Op           invalOp
+	Observations []invalObservation
+	Missed       []string
+}
+
+func (r invalRoundResult) summary() string {
+	if len(r.Missed) > 0 {
+		return fmt.Sprintf("%d observed, %d missed: %s", len(r.Observations), len(r.Missed), strings.Join(r.Missed, ", "))
+	}
+	if len(r.Observations) == 0 {
+		return "no observations"
+	}
+	var lats []int64
+	for _, o := range r.Observations {
+		lats = append(lats, o.LatencyMs)
+	}
+	sort.Slice(lats, func(i, j int) bool { return lats[i] < lats[j] })
+	return fmt.Sprintf("%d observed, min=%dms max=%dms", len(r.Observations), lats[0], lats[len(lats)-1])
+}
+
+// ── Leader election ───────────────────────────────────────────────────────────
+
+// invalNodeName returns this node's identity for leader/follower
+// coordination: cfg.NodeName if the framework set one (multi-node runs,
+// where it's the --nodes name the operator typed and is therefore
+// resolvable by the other participating nodes), otherwise os.Hostname().
+// Raw os.Hostname() is not guaranteed resolvable by other nodes -- e.g. a
+// VM's real hostname can differ from the DNS/hosts alias other nodes know
+// it by -- so anything dialed over invalControlPort must use this, not
+// os.Hostname() directly.
+func invalNodeName(cfg RunConfig) (string, error) {
+	if cfg.NodeName != "" {
+		return cfg.NodeName, nil
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("get hostname: %w", err)
+	}
+	return hostname, nil
+}
+
+// invalElectLeader attempts to become leader via O_CREATE|O_EXCL on the lock
+// file. Returns (true, hostname, nil) for the leader; (false, leaderHostname,
+// nil) for followers. Includes paranoia checks on both sides.
+func invalElectLeader(path, hostname string) (isLeader bool, leaderHost string, err error) {
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return false, "", fmt.Errorf("create path %s: %w", path, err)
+	}
+
+	lockPath := filepath.Join(path, invalLockFile)
+
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err == nil {
+		_, writeErr := fmt.Fprint(f, hostname)
+		closeErr := f.Close()
+		if writeErr != nil || closeErr != nil {
+			// If the remove also fails, a stray lock file would block every
+			// future leader election on this path until someone notices and
+			// removes it by hand -- fold that into the returned error rather
+			// than losing it.
+			removeErr := os.Remove(lockPath)
+			return false, "", fmt.Errorf("write leader lock: %w", errors.Join(writeErr, closeErr, removeErr))
+		}
+		// Paranoia: read back and verify our hostname is there.
+		data, err := os.ReadFile(lockPath)
+		if err != nil {
+			removeErr := os.Remove(lockPath)
+			return false, "", fmt.Errorf("verify leader lock: %w", errors.Join(err, removeErr))
+		}
+		if got := strings.TrimSpace(string(data)); got != hostname {
+			removeErr := os.Remove(lockPath)
+			return false, "", errors.Join(fmt.Errorf("leader lock verification failed: wrote %q, read back %q", hostname, got), removeErr)
+		}
+		return true, hostname, nil
+	}
+
+	if !os.IsExist(err) {
+		return false, "", fmt.Errorf("create leader lock: %w", err)
+	}
+
+	// We're a follower. Poll until the lock file is written (brief window).
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		data, err := os.ReadFile(lockPath)
+		if err == nil {
+			if h := strings.TrimSpace(string(data)); h != "" {
+				leaderHost = h
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			return false, "", fmt.Errorf("timeout waiting for leader lock to be populated")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Paranoia: the lock file must not contain our hostname.
+	if leaderHost == hostname {
+		return false, "", fmt.Errorf("leader lock contains our own hostname %q but we did not create it — filesystem consistency error", hostname)
+	}
+
+	return false, leaderHost, nil
+}
+
+func invalVerifyLock(path, expectedHostname string) error {
+	data, err := os.ReadFile(filepath.Join(path, invalLockFile))
+	if err != nil {
+		return fmt.Errorf("leader lock read failed: %w", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != expectedHostname {
+		return fmt.Errorf("leader lock now contains %q (expected %q) — leadership conflict", got, expectedHostname)
+	}
+	return nil
+}
+
+// ── Leader ────────────────────────────────────────────────────────────────────
+
+func invalRunLeader(ctx context.Context, cfg RunConfig, hostname string, log io.Writer) error {
+	testFile := filepath.Join(cfg.Path, invalTestFile)
+	renameFile := filepath.Join(cfg.Path, invalRenameFileA)
+
+	// Create test files for followers to stat. invalRenameFileA is the
+	// initial name of the rename-test file; rename rounds toggle it between
+	// invalRenameFileA and invalRenameFileB.
+	if err := os.WriteFile(testFile, []byte{}, 0644); err != nil {
+		return fmt.Errorf("create test file: %w", err)
+	}
+	if err := os.WriteFile(renameFile, []byte{}, 0644); err != nil {
+		return fmt.Errorf("create rename test file: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg.Path, invalUnlinkFile), []byte{}, 0644); err != nil {
+		return fmt.Errorf("create unlink test file: %w", err)
+	}
+
+	// Probe for user-extended-attribute support. If unsupported, drop
+	// invalOpXattr from this run's op set — otherwise xattr.Set below would
+	// abort the whole run on the first xattr round.
+	ops := invalAllOps
+	if err := xattr.Set(testFile, invalXattrName, []byte("0"), 0); err != nil {
+		fmt.Fprintf(log, "[leader:%s] user xattrs not supported (%v); skipping %q op\n", hostname, err, invalOpXattr)
+		ops = make([]invalOp, 0, len(invalAllOps)-1)
+		for _, o := range invalAllOps {
+			if o != invalOpXattr {
+				ops = append(ops, o)
+			}
+		}
+	} else {
+		_ = xattr.Remove(testFile, invalXattrName)
+	}
+
+	// Open the off-mount control channel and wait for followers to connect.
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", invalControlPort))
+	if err != nil {
+		return fmt.Errorf("listen on control port %d: %w", invalControlPort, err)
+	}
+	defer ln.Close()
+
+	fmt.Fprintf(log, "[leader:%s] waiting up to %s for followers on port %d...\n", hostname, invalDefaultReadyTimeout, invalControlPort)
+	followers := invalAcceptFollowers(ctx, ln, cfg.StopSignal)
+	if cfg.StopSignal != nil && cfg.StopSignal.Load() {
+		return nil
+	}
+	if len(followers) == 0 {
+		return fmt.Errorf("[leader] no followers registered — cannot run inval test")
+	}
+	defer func() {
+		for _, fc := range followers {
+			fc.conn.Close()
+		}
+	}()
+	names := make([]string, 0, len(followers))
+	for n := range followers {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	fmt.Fprintf(log, "[leader:%s] %d follower(s): %s\n", hostname, len(followers), strings.Join(names, ", "))
+
+	var results []invalRoundResult
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	renameToB := false   // tracks current name of the rename-test file
+	unlinkExists := true // tracks whether the unlink-test file currently exists
+
+	for round := 1; round <= invalDefaultRounds; round++ {
+		if ctx.Err() != nil || (cfg.StopSignal != nil && cfg.StopSignal.Load()) {
+			break
+		}
+
+		if err := invalVerifyLock(cfg.Path, hostname); err != nil {
+			return err
+		}
+
+		op := ops[rng.Intn(len(ops))]
+		rd := invalRound{Round: round, Op: op, ExpectedFollowers: len(followers)}
+
+		switch op {
+		case invalOpSize:
+			info, err := os.Stat(testFile)
+			if err != nil {
+				return fmt.Errorf("round %d: stat before truncate: %w", round, err)
+			}
+			cur := info.Size()
+			delta := int64(rng.Intn(3)+1) * invalDefaultBlockSize // 1-3 blocks
+			if cur > 0 && rng.Intn(2) == 0 {
+				if delta > cur {
+					delta = cur
+				}
+				rd.ExpectedSize = cur - delta
+			} else {
+				rd.ExpectedSize = cur + delta
+			}
+			if err := os.Truncate(testFile, rd.ExpectedSize); err != nil {
+				return fmt.Errorf("round %d: truncate: %w", round, err)
+			}
+		case invalOpChmod:
+			// 0600 | round%64 rather than toggling a fixed XOR mask: XOR
+			// with a constant is its own inverse, so it used to flip between
+			// exactly two mode values with period 2 — a follower whose
+			// cached mode was just one round stale would see it match the
+			// CURRENT round's expected value, reporting a false "instant
+			// visibility" for a real caching regression. Perm() is only 9
+			// bits, so this can't be made fully monotone across an
+			// unbounded run, but round%64 in the low 6 (group+other) bits
+			// raises the alias period from 2 rounds to 64 — far beyond any
+			// real cache-staleness window — matching the standard "encode N
+			// mod K, K large" fallback for permission-based signals. The
+			// owner rw bits (0600) are held
+			// fixed rather than folded into the varying range: leader and
+			// follower run as the same uid here, and an owner-unreadable or
+			// -unwritable mode would break this round's own setxattr/getxattr
+			// once invalOpXattr is picked in a later round on the same file.
+			rd.ExpectedMode = 0600 | uint32(round%64)
+			if err := os.Chmod(testFile, os.FileMode(rd.ExpectedMode)); err != nil {
+				return fmt.Errorf("round %d: chmod: %w", round, err)
+			}
+		case invalOpMtime:
+			info, err := os.Stat(testFile)
+			if err != nil {
+				return fmt.Errorf("round %d: stat before chtimes: %w", round, err)
+			}
+			rd.ExpectedMtime = info.ModTime().Truncate(time.Second).Add(time.Second)
+			if err := os.Chtimes(testFile, rd.ExpectedMtime, rd.ExpectedMtime); err != nil {
+				return fmt.Errorf("round %d: chtimes: %w", round, err)
+			}
+		case invalOpRename:
+			oldName, newName := invalRenameFileA, invalRenameFileB
+			if renameToB {
+				oldName, newName = invalRenameFileB, invalRenameFileA
+			}
+			renameToB = !renameToB
+			if err := os.Rename(filepath.Join(cfg.Path, oldName), filepath.Join(cfg.Path, newName)); err != nil {
+				return fmt.Errorf("round %d: rename: %w", round, err)
+			}
+			rd.OldName = oldName
+			rd.ExpectedName = newName
+		case invalOpUnlink:
+			unlinkPath := filepath.Join(cfg.Path, invalUnlinkFile)
+			if unlinkExists {
+				if err := os.Remove(unlinkPath); err != nil {
+					return fmt.Errorf("round %d: unlink: %w", round, err)
+				}
+				rd.ExpectedExists = false
+			} else {
+				if err := os.WriteFile(unlinkPath, []byte{}, 0644); err != nil {
+					return fmt.Errorf("round %d: recreate unlink test file: %w", round, err)
+				}
+				rd.ExpectedExists = true
+			}
+			unlinkExists = !unlinkExists
+		case invalOpXattr:
+			rd.ExpectedXattr = strconv.Itoa(round)
+			if err := xattr.Set(testFile, invalXattrName, []byte(rd.ExpectedXattr), 0); err != nil {
+				return fmt.Errorf("round %d: setxattr: %w", round, err)
+			}
+		}
+		rd.MutatedAt = time.Now()
+
+		result := invalBroadcastRound(followers, round, rd, invalDefaultRoundTimeout, log)
+		result.Op = op
+		results = append(results, result)
+		cfg.TotalOps.Add(1)
+
+		fmt.Fprintf(log, "[leader:%s] round %d (%s): %s\n", hostname, round, op, result.summary())
+	}
+
+	invalPrintSummary(log, len(followers), results)
+	return nil
+}
+
+// invalCleanup removes the leader lock left behind by a run so a
+// subsequent run starts from a clean directory. Called via defer in Run
+// (covering every exit path, not just clean completion of the round loop)
+// as soon as election confirms this node is the leader and the lock file
+// therefore already exists. Best-effort: errors go to stderr (the run's own
+// log file may already be closed or never created, depending on which exit
+// path got here) but never fail the run. Test data files (inval-test,
+// inval-rename-*, and the per-node log files) are left in place. Round,
+// observation, and ready signaling no longer touch cfg.Path at all (see
+// invalControlPort), so there is nothing else to clean up here.
+func invalCleanup(path string) {
+	if err := os.Remove(filepath.Join(path, invalLockFile)); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "[leader] cleanup: remove %s: %v\n", invalLockFile, err)
+	}
+}
+
+// invalFollowerConn is the leader's handle to one follower's control
+// connection: a persistent TCP connection, held open for the life of the
+// run, carrying round announcements out and observation reports back.
+type invalFollowerConn struct {
+	conn net.Conn
+	enc  *json.Encoder
+	dec  *json.Decoder
+}
+
+// invalAcceptFollowers accepts control-channel connections for up to
+// invalDefaultReadyTimeout, enforcing a 5-second minimum wait so that
+// followers racing the leader still have time to connect. Each connection's
+// first message must be an invalReady identifying the follower's hostname.
+func invalAcceptFollowers(ctx context.Context, ln net.Listener, stopSig *atomic.Bool) map[string]*invalFollowerConn {
+	followers := make(map[string]*invalFollowerConn)
+	deadline := time.Now().Add(invalDefaultReadyTimeout)
+	minWait := time.Now().Add(5 * time.Second)
+
+	type accepted struct {
+		conn net.Conn
+		err  error
+	}
+	acceptCh := make(chan accepted)
+	go func() {
+		for {
+			c, err := ln.Accept()
+			acceptCh <- accepted{c, err}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if ctx.Err() != nil || (stopSig != nil && stopSig.Load()) {
+			return followers
+		}
+		if time.Now().After(deadline) {
+			return followers
+		}
+		select {
+		case a := <-acceptCh:
+			if a.err != nil {
+				continue
+			}
+			node, fc, err := invalHandshakeFollower(a.conn)
+			if err != nil {
+				a.conn.Close()
+				continue
+			}
+			followers[node] = fc
+		case <-ticker.C:
+			if len(followers) > 0 && time.Now().After(minWait) {
+				return followers
+			}
+		}
+	}
+}
+
+// invalHandshakeFollower reads the connecting follower's invalReady message
+// off conn, bounding the read so a misbehaving client can't hang the leader.
+func invalHandshakeFollower(conn net.Conn) (string, *invalFollowerConn, error) {
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		return "", nil, err
+	}
+	dec := json.NewDecoder(conn)
+	var ready invalReady
+	if err := dec.Decode(&ready); err != nil {
+		return "", nil, err
+	}
+	if ready.Node == "" {
+		return "", nil, fmt.Errorf("empty hostname in ready handshake")
+	}
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		return "", nil, err
+	}
+	return ready.Node, &invalFollowerConn{conn: conn, enc: json.NewEncoder(conn), dec: dec}, nil
+}
+
+// invalBroadcastRound sends rd to every follower over its control
+// connection, then collects an invalObservation back from each within
+// timeout. Followers whose connection errors or that don't respond in time
+// are recorded in result.Missed; one follower's failure does not block or
+// abort collection from the others.
+func invalBroadcastRound(followers map[string]*invalFollowerConn, round int, rd invalRound, timeout time.Duration, log io.Writer) invalRoundResult {
+	result := invalRoundResult{Round: round}
+
+	type res struct {
+		node string
+		obs  invalObservation
+		err  error
+	}
+	ch := make(chan res, len(followers))
+
+	for node, fc := range followers {
+		node, fc := node, fc
+		go func() {
+			if err := fc.enc.Encode(rd); err != nil {
+				ch <- res{node: node, err: err}
+				return
+			}
+			_ = fc.conn.SetReadDeadline(time.Now().Add(timeout + 2*time.Second))
+			var obs invalObservation
+			err := fc.dec.Decode(&obs)
+			_ = fc.conn.SetReadDeadline(time.Time{})
+			ch <- res{node: node, obs: obs, err: err}
+		}()
+	}
+
+	for i := 0; i < len(followers); i++ {
+		r := <-ch
+		if r.err != nil {
+			result.Missed = append(result.Missed, r.node)
+			continue
+		}
+		if r.obs.Round != round {
+			// A stale response for an earlier round -- left unread on the
+			// connection after that round's own read deadline gave up
+			// waiting for it (the timeout+2s margin above) -- was consumed
+			// by this round's Decode call instead of a fresh response.
+			// There's no cheap way to resync mid-stream (no per-message
+			// framing beyond JSON object boundaries), so this is recorded
+			// as missed for THIS round rather than silently misattributing
+			// stale latency/timestamp data to it. This follower will likely
+			// keep showing as missed for the rest of the run -- a visible,
+			// honest failure mode instead of silently wrong numbers.
+			fmt.Fprintf(log, "[leader] round %d: %s sent a stale response for round %d -- connection desynced, treating as missed\n",
+				round, r.node, r.obs.Round)
+			result.Missed = append(result.Missed, r.node)
+			continue
+		}
+		result.Observations = append(result.Observations, r.obs)
+	}
+	sort.Strings(result.Missed)
+	return result
+}
+
+// ── Follower ──────────────────────────────────────────────────────────────────
+
+func invalRunFollower(ctx context.Context, cfg RunConfig, leaderHost string, log io.Writer) error {
+	hostname, err := invalNodeName(cfg)
+	if err != nil {
+		return err
+	}
+	testFile := filepath.Join(cfg.Path, invalTestFile)
+
+	fmt.Fprintf(log, "[follower:%s] leader is %s\n", hostname, leaderHost)
+
+	// Wait for the test file to appear (leader creates it before opening its
+	// control-channel listener).
+	if err := invalWaitForFile(ctx, testFile, 30*time.Second, cfg.StopSignal); err != nil {
+		if errors.Is(err, errStopped) {
+			return nil
+		}
+		return fmt.Errorf("test file never appeared: %w", err)
+	}
+
+	// Stat the files to populate the inode/dentry caches.
+	if _, err := os.Stat(testFile); err != nil {
+		return fmt.Errorf("initial stat: %w", err)
+	}
+	if _, err := os.Stat(filepath.Join(cfg.Path, invalRenameFileA)); err != nil {
+		return fmt.Errorf("initial stat of rename file: %w", err)
+	}
+	if _, err := os.Stat(filepath.Join(cfg.Path, invalUnlinkFile)); err != nil {
+		return fmt.Errorf("initial stat of unlink file: %w", err)
+	}
+
+	// Connect to the leader's off-mount control channel and register ready.
+	// The listener may not be up the instant testFile appears, so retry
+	// briefly rather than treating an immediate connection failure as fatal.
+	conn, err := invalDialLeader(ctx, leaderHost, cfg.StopSignal)
+	if err != nil {
+		if errors.Is(err, errStopped) {
+			return nil
+		}
+		return fmt.Errorf("connect to leader control channel: %w", err)
+	}
+	defer conn.Close()
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+	if err := enc.Encode(invalReady{Node: hostname}); err != nil {
+		return fmt.Errorf("send ready: %w", err)
+	}
+	fmt.Fprintf(log, "[follower:%s] ready\n", hostname)
+
+	for round := 1; round <= invalDefaultRounds; round++ {
+		if ctx.Err() != nil || (cfg.StopSignal != nil && cfg.StopSignal.Load()) {
+			return nil
+		}
+
+		// Wait for the round announcement from the leader.
+		if err := conn.SetReadDeadline(time.Now().Add(invalDefaultRoundTimeout + 15*time.Second)); err != nil {
+			return fmt.Errorf("round %d: set read deadline: %w", round, err)
+		}
+		var rd invalRound
+		if err := dec.Decode(&rd); err != nil {
+			return fmt.Errorf("round %d: read round announcement: %w", round, err)
+		}
+		if err := conn.SetReadDeadline(time.Time{}); err != nil {
+			return fmt.Errorf("round %d: clear read deadline: %w", round, err)
+		}
+
+		// Snapshot procfs before polling.
+		before, _ := invalReadCacheStats()
+
+		// Poll until we observe the mutation, using the predicate appropriate
+		// for this round's operation type.
+		var observedAt time.Time
+		switch rd.Op {
+		case invalOpSize:
+			observedAt, err = invalPollForSize(ctx, testFile, rd.ExpectedSize, invalDefaultRoundTimeout)
+		case invalOpChmod:
+			observedAt, err = invalPollForMode(ctx, testFile, os.FileMode(rd.ExpectedMode), invalDefaultRoundTimeout)
+		case invalOpMtime:
+			observedAt, err = invalPollForMtime(ctx, testFile, rd.ExpectedMtime, invalDefaultRoundTimeout)
+		case invalOpRename:
+			// The interesting cache-invalidation signal is the old name
+			// becoming ENOENT, since this node has a stale positive dentry
+			// for it (from initial setup or a prior round's priming below).
+			observedAt, err = invalPollForGone(ctx, filepath.Join(cfg.Path, rd.OldName), invalDefaultRoundTimeout)
+			// Prime the cache for the new name (now the live name of the
+			// rename-test file) so the next rename round, which will treat
+			// this path as its OldName, has a stale positive dentry to
+			// invalidate.
+			_, _ = os.Stat(filepath.Join(cfg.Path, rd.ExpectedName))
+		case invalOpUnlink:
+			unlinkPath := filepath.Join(cfg.Path, invalUnlinkFile)
+			if rd.ExpectedExists {
+				observedAt, err = invalPollForExists(ctx, unlinkPath, invalDefaultRoundTimeout)
+			} else {
+				observedAt, err = invalPollForGone(ctx, unlinkPath, invalDefaultRoundTimeout)
+			}
+		case invalOpXattr:
+			observedAt, err = invalPollForXattr(ctx, testFile, invalXattrName, rd.ExpectedXattr, invalDefaultRoundTimeout)
+		default:
+			err = fmt.Errorf("unknown op %q", rd.Op)
+		}
+
+		// Snapshot procfs after.
+		after, _ := invalReadCacheStats()
+		invalDelta := after.Invalidations - before.Invalidations
+
+		obs := invalObservation{Round: round, Op: rd.Op, Node: hostname}
+		if err != nil {
+			obs.Timeout = true
+			fmt.Fprintf(log, "[follower:%s] round %d (%s): TIMEOUT (invals=%d)\n", hostname, round, rd.Op, invalDelta)
+		} else {
+			obs.ObservedAt = observedAt
+			// LatencyMs is a cross-node delta: the follower's observe time minus the
+			// leader's mutate time. It therefore REQUIRES NTP-synchronized clocks
+			// (inval does no clock-offset estimation). A negative value is physically
+			// impossible — an observation cannot precede its cause — so it means the
+			// follower's clock is behind the leader's; clamp to 0 and warn rather than
+			// let clock skew poison the min/p50 summary.
+			latency := observedAt.Sub(rd.MutatedAt)
+			if latency < 0 {
+				fmt.Fprintf(log, "[follower:%s] round %d (%s): WARNING negative latency %dms — clock skew; ensure NTP is synced across nodes\n",
+					hostname, round, rd.Op, latency.Milliseconds())
+				latency = 0
+			}
+			obs.LatencyMs = latency.Milliseconds()
+			fmt.Fprintf(log, "[follower:%s] round %d (%s): %dms (invals=%d)\n", hostname, round, rd.Op, obs.LatencyMs, invalDelta)
+		}
+
+		if err := enc.Encode(obs); err != nil {
+			return fmt.Errorf("round %d: send observation: %w", round, err)
+		}
+		cfg.TotalOps.Add(1)
+	}
+
+	return nil
+}
+
+// invalDialLeader connects to the leader's control-channel listener,
+// retrying briefly since the listener may not be up the instant the
+// follower observes testFile.
+func invalDialLeader(ctx context.Context, leaderHost string, stopSig *atomic.Bool) (net.Conn, error) {
+	addr := net.JoinHostPort(leaderHost, strconv.Itoa(invalControlPort))
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if stopSig != nil && stopSig.Load() {
+			return nil, errStopped
+		}
+		conn, err := net.DialTimeout("tcp", addr, 3*time.Second)
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timeout connecting to %s: %w", addr, lastErr)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// ── Procfs ────────────────────────────────────────────────────────────────────
+
+// invalReadCacheStats reads inode_cache_stats from the first BeeGFS client
+// entry under /proc/fs/beegfs/. Returns a zero struct if not available.
+func invalReadCacheStats() (invalCacheStats, error) {
+	matches, err := filepath.Glob("/proc/fs/beegfs/*/inode_cache_stats")
+	if err != nil || len(matches) == 0 {
+		return invalCacheStats{}, fmt.Errorf("inode_cache_stats not found (client mounted with tuneCacheInvalidationInodeWatch?)")
+	}
+	data, err := os.ReadFile(matches[0])
+	if err != nil {
+		return invalCacheStats{}, fmt.Errorf("read %s: %w", matches[0], err)
+	}
+	var s invalCacheStats
+	for _, line := range strings.Split(string(data), "\n") {
+		parts := strings.SplitN(strings.TrimSpace(line), ": ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		val, err := strconv.ParseUint(strings.TrimSpace(parts[1]), 10, 64)
+		if err != nil {
+			continue
+		}
+		switch parts[0] {
+		case "inodeCacheHits":
+			s.Hits = val
+		case "inodeCacheMisses":
+			s.Misses = val
+		case "inodeCacheInvalidations":
+			s.Invalidations = val
+		}
+	}
+	return s, nil
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func invalWaitForFile(ctx context.Context, path string, timeout time.Duration, stopSig *atomic.Bool) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if stopSig != nil && stopSig.Load() {
+			return errStopped
+		}
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for %s", filepath.Base(path))
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func invalPollForSize(ctx context.Context, path string, expectedSize int64, timeout time.Duration) (time.Time, error) {
+	deadline := time.Now().Add(timeout)
+	var lastSize int64 = -1
+	for {
+		if ctx.Err() != nil {
+			return time.Time{}, ctx.Err()
+		}
+		info, err := os.Stat(path)
+		if err == nil {
+			lastSize = info.Size()
+			if lastSize == expectedSize {
+				return time.Now(), nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return time.Time{}, fmt.Errorf("timeout waiting for size %d (last observed: %d)", expectedSize, lastSize)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func invalPollForMode(ctx context.Context, path string, expectedMode os.FileMode, timeout time.Duration) (time.Time, error) {
+	deadline := time.Now().Add(timeout)
+	var lastMode os.FileMode
+	for {
+		if ctx.Err() != nil {
+			return time.Time{}, ctx.Err()
+		}
+		info, err := os.Stat(path)
+		if err == nil {
+			lastMode = info.Mode().Perm()
+			if lastMode == expectedMode.Perm() {
+				return time.Now(), nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return time.Time{}, fmt.Errorf("timeout waiting for mode %v (last observed: %v)", expectedMode.Perm(), lastMode)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// invalPollForMtime polls until the file's mtime, truncated to second
+// precision, matches expectedMtime (which is itself second-truncated by the
+// leader). Second precision is used because not all filesystems preserve
+// finer-grained mtimes through stat().
+func invalPollForMtime(ctx context.Context, path string, expectedMtime time.Time, timeout time.Duration) (time.Time, error) {
+	deadline := time.Now().Add(timeout)
+	var lastMtime time.Time
+	for {
+		if ctx.Err() != nil {
+			return time.Time{}, ctx.Err()
+		}
+		info, err := os.Stat(path)
+		if err == nil {
+			lastMtime = info.ModTime().Truncate(time.Second)
+			if lastMtime.Equal(expectedMtime) {
+				return time.Now(), nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return time.Time{}, fmt.Errorf("timeout waiting for mtime %s (last observed: %s)", expectedMtime, lastMtime)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// invalPollForGone polls until path no longer exists, used to detect a
+// rename's old name being invalidated from a stale positive dentry cache.
+func invalPollForGone(ctx context.Context, path string, timeout time.Duration) (time.Time, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		if ctx.Err() != nil {
+			return time.Time{}, ctx.Err()
+		}
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return time.Now(), nil
+		}
+		if time.Now().After(deadline) {
+			return time.Time{}, fmt.Errorf("timeout waiting for %s to be removed", filepath.Base(path))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// invalPollForExists polls until path exists, used to detect a previously
+// removed file's recreation invalidating a stale negative dentry cache.
+func invalPollForExists(ctx context.Context, path string, timeout time.Duration) (time.Time, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		if ctx.Err() != nil {
+			return time.Time{}, ctx.Err()
+		}
+		if _, err := os.Stat(path); err == nil {
+			return time.Now(), nil
+		}
+		if time.Now().After(deadline) {
+			return time.Time{}, fmt.Errorf("timeout waiting for %s to exist", filepath.Base(path))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// invalPollForXattr polls until the named extended attribute on path equals
+// expected.
+func invalPollForXattr(ctx context.Context, path, name, expected string, timeout time.Duration) (time.Time, error) {
+	deadline := time.Now().Add(timeout)
+	var last string
+	for {
+		if ctx.Err() != nil {
+			return time.Time{}, ctx.Err()
+		}
+		if val, err := xattr.Get(path, name); err == nil {
+			last = string(val)
+			if last == expected {
+				return time.Now(), nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return time.Time{}, fmt.Errorf("timeout waiting for xattr %s=%q (last observed: %q)", name, expected, last)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+func invalPrintSummary(log io.Writer, followerCount int, results []invalRoundResult) {
+	var latencies []int64
+	missed, total := 0, 0
+
+	for _, r := range results {
+		total += followerCount
+		missed += len(r.Missed)
+		for _, obs := range r.Observations {
+			if obs.Timeout {
+				missed++
+			} else {
+				latencies = append(latencies, obs.LatencyMs)
+			}
+		}
+	}
+
+	fmt.Fprintf(log, "\nSummary (%d follower(s), %d rounds):\n", followerCount, len(results))
+	fmt.Fprintf(log, "  (latencies are cross-node deltas; meaningful only with NTP-synced clocks)\n")
+	if len(latencies) > 0 {
+		sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+		fmt.Fprintf(log, "  min=%dms  p50=%dms  p95=%dms  p99=%dms  max=%dms\n",
+			latencies[0],
+			invalPercentile(latencies, 50),
+			invalPercentile(latencies, 95),
+			invalPercentile(latencies, 99),
+			latencies[len(latencies)-1],
+		)
+	}
+	fmt.Fprintf(log, "  Missed invalidations: %d/%d\n", missed, total)
+
+	// Per-operation breakdown.
+	perOpLatencies := make(map[invalOp][]int64)
+	perOpMissed := make(map[invalOp]int)
+	perOpTotal := make(map[invalOp]int)
+	for _, r := range results {
+		perOpTotal[r.Op] += followerCount
+		perOpMissed[r.Op] += len(r.Missed)
+		for _, obs := range r.Observations {
+			if obs.Timeout {
+				perOpMissed[r.Op]++
+			} else {
+				perOpLatencies[r.Op] = append(perOpLatencies[r.Op], obs.LatencyMs)
+			}
+		}
+	}
+
+	fmt.Fprintf(log, "\nPer-operation breakdown:\n")
+	for _, op := range invalAllOps {
+		lats := perOpLatencies[op]
+		if len(lats) == 0 {
+			fmt.Fprintf(log, "  %-7s no observations  missed=%d/%d\n", op, perOpMissed[op], perOpTotal[op])
+			continue
+		}
+		sort.Slice(lats, func(i, j int) bool { return lats[i] < lats[j] })
+		fmt.Fprintf(log, "  %-7s min=%dms  p50=%dms  p95=%dms  p99=%dms  max=%dms  missed=%d/%d\n",
+			op,
+			lats[0],
+			invalPercentile(lats, 50),
+			invalPercentile(lats, 95),
+			invalPercentile(lats, 99),
+			lats[len(lats)-1],
+			perOpMissed[op], perOpTotal[op],
+		)
+	}
+}
+
+func invalPercentile(sorted []int64, p int) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	return sorted[(len(sorted)-1)*p/100]
+}

--- a/ctl/internal/cmd/iotest/inval_test.go
+++ b/ctl/internal/cmd/iotest/inval_test.go
@@ -1,0 +1,105 @@
+//go:build linux
+
+// This is a unit test.
+//
+// Coverage: invalBroadcastRound's round-number correlation check -- a
+// follower's stale response for an earlier round (left over from a
+// previous round's expired read deadline) must be recorded as missed for
+// the current round, not silently misattributed as a real observation.
+package iotest
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newFakeFollowerConn returns an invalFollowerConn backed by one end of an
+// in-memory net.Pipe, plus the other end for the test to act as the
+// follower. json.Encoder/Decoder wrap the leader-side end exactly as
+// invalAcceptFollowers does for a real connection.
+func newFakeFollowerConn(t *testing.T) (*invalFollowerConn, net.Conn) {
+	t.Helper()
+	leaderSide, followerSide := net.Pipe()
+	t.Cleanup(func() {
+		_ = leaderSide.Close()
+		_ = followerSide.Close()
+	})
+	fc := &invalFollowerConn{
+		conn: leaderSide,
+		enc:  json.NewEncoder(leaderSide),
+		dec:  json.NewDecoder(leaderSide),
+	}
+	return fc, followerSide
+}
+
+func TestInvalBroadcastRoundFreshResponse(t *testing.T) {
+	fc, followerSide := newFakeFollowerConn(t)
+	go func() {
+		var rd invalRound
+		if err := json.NewDecoder(followerSide).Decode(&rd); err != nil {
+			return
+		}
+		_ = json.NewEncoder(followerSide).Encode(invalObservation{Round: rd.Round, Node: "f1", LatencyMs: 42})
+	}()
+
+	followers := map[string]*invalFollowerConn{"f1": fc}
+	var log strings.Builder
+	result := invalBroadcastRound(followers, 5, invalRound{Round: 5}, time.Second, &log)
+
+	if len(result.Missed) != 0 {
+		t.Errorf("Missed = %v, want empty", result.Missed)
+	}
+	if len(result.Observations) != 1 || result.Observations[0].LatencyMs != 42 {
+		t.Errorf("Observations = %v, want one observation with LatencyMs=42", result.Observations)
+	}
+}
+
+// TestInvalBroadcastRoundStaleResponseTreatedAsMissed is a regression test
+// for the round-desync bug: a response carrying an earlier round number
+// than the one just broadcast -- exactly what a connection stuck with an
+// unread backlog produces -- must not be attributed to the current round.
+func TestInvalBroadcastRoundStaleResponseTreatedAsMissed(t *testing.T) {
+	fc, followerSide := newFakeFollowerConn(t)
+	go func() {
+		var rd invalRound
+		if err := json.NewDecoder(followerSide).Decode(&rd); err != nil {
+			return
+		}
+		// Simulate a stale response for an earlier round arriving during
+		// this round's broadcast.
+		_ = json.NewEncoder(followerSide).Encode(invalObservation{Round: rd.Round - 1, Node: "f1", LatencyMs: 999})
+	}()
+
+	followers := map[string]*invalFollowerConn{"f1": fc}
+	var log strings.Builder
+	result := invalBroadcastRound(followers, 5, invalRound{Round: 5}, time.Second, &log)
+
+	if len(result.Observations) != 0 {
+		t.Errorf("Observations = %v, want empty -- the stale round-4 response must not be attributed to round 5", result.Observations)
+	}
+	if len(result.Missed) != 1 || result.Missed[0] != "f1" {
+		t.Errorf("Missed = %v, want [f1]", result.Missed)
+	}
+	if !strings.Contains(log.String(), "desynced") {
+		t.Errorf("log output = %q, want a mention of the desync", log.String())
+	}
+}
+
+func TestInvalBroadcastRoundConnectionError(t *testing.T) {
+	fc, followerSide := newFakeFollowerConn(t)
+	_ = followerSide.Close() // force the leader's Decode to fail immediately
+
+	followers := map[string]*invalFollowerConn{"f1": fc}
+	var log strings.Builder
+	result := invalBroadcastRound(followers, 1, invalRound{Round: 1}, time.Second, &log)
+
+	if len(result.Observations) != 0 {
+		t.Errorf("Observations = %v, want empty", result.Observations)
+	}
+	if len(result.Missed) != 1 || result.Missed[0] != "f1" {
+		t.Errorf("Missed = %v, want [f1]", result.Missed)
+	}
+}

--- a/ctl/internal/cmd/iotest/iotest.go
+++ b/ctl/internal/cmd/iotest/iotest.go
@@ -1,0 +1,55 @@
+// Package iotest implements the "beegfs iotest" subcommand family.
+//
+// There are two groups of commands:
+//
+//   - Standalone tools: smoke, verify, dump, bench run/verify.
+//     These operate on a single node without coordination files.
+//
+//   - Framework-managed workloads: soak, bench (via "beegfs iotest start"),
+//     inval.  The framework handles SSH fan-out, per-node status files,
+//     stop-signal propagation, and the start/status/stop lifecycle.
+//     Each workload implements the Tool interface; the framework knows nothing
+//     about what the tool actually does.
+//
+// Coordination files live under --path (default /tmp/beegfs-iotest) and use
+// the naming convention .iotest-<workload>-<hostname>.json for status and
+// .iotest.stop for the stop signal.  Using a shared BeeGFS path allows every
+// node's status to be visible from any single node via "beegfs iotest status".
+package iotest
+
+import "github.com/spf13/cobra"
+
+// helpIfNoFlags prints help and returns true when the command was invoked
+// with no flags, signalling RunE to return immediately.
+func helpIfNoFlags(cmd *cobra.Command) bool {
+	if cmd.Flags().NFlag() == 0 {
+		_ = cmd.Help()
+		return true
+	}
+	return false
+}
+
+// NewIotestCmd returns the "beegfs iotest" command, with every standalone
+// tool and framework-managed workload already registered as a subcommand.
+func NewIotestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "iotest",
+		Short: "Verifiable IO testing tools for BeeGFS filesystems",
+		Long: `Verifiable IO testing tools for BeeGFS filesystems.
+
+Each write produces a block body that is deterministically generated from a
+seed and self-checked via per-stripe CRC32C checksums; the block carries no
+descriptive header. Instead, the header (seed, kind, node, offset, etc.) is
+stored exclusively in an xattr on the same inode, never embedded in the
+block data. A subsequent verify sweep can detect silent corruption, torn
+writes, and stale data.`,
+	}
+	cmd.AddCommand(
+		newSmokeCmd(),
+		newVerifyCmd(),
+		newDumpCmd(),
+		newBenchCmd(),
+	)
+	cmd.AddCommand(NewFrameworkCmds(&SoakTool{}, &BenchTool{}, &InvalTool{})...)
+	return cmd
+}

--- a/ctl/internal/cmd/iotest/nodes.go
+++ b/ctl/internal/cmd/iotest/nodes.go
@@ -1,0 +1,164 @@
+package iotest
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// NodeSpec identifies a remote node. ExtraArgs is reserved for future per-node
+// flag overrides and is always empty in the current implementation.
+type NodeSpec struct {
+	Name      string
+	ExtraArgs []string
+}
+
+// parseNodes parses a -N value into a slice of NodeSpecs. The value is treated
+// as a file path if a file exists at that path; otherwise it is parsed as a
+// comma-separated list of node names. File format: node names separated by
+// newlines and/or commas; everything from a # to the end of the line is a
+// comment, whether the line starts with # or the # follows one or more node
+// names (e.g. "node1   # rack 9").
+func parseNodes(value string) ([]NodeSpec, error) {
+	if _, err := os.Stat(value); err == nil {
+		return parseNodesFile(value)
+	}
+	return parseNodesInline(value)
+}
+
+func parseNodesFile(path string) ([]NodeSpec, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open nodes file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var nodes []NodeSpec
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if idx := strings.IndexByte(line, '#'); idx >= 0 {
+			line = line[:idx]
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		for _, name := range strings.Split(line, ",") {
+			if name = strings.TrimSpace(name); name != "" {
+				nodes = append(nodes, NodeSpec{Name: name})
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read nodes file %s: %w", path, err)
+	}
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("no node names found in %s", path)
+	}
+	return nodes, nil
+}
+
+func parseNodesInline(value string) ([]NodeSpec, error) {
+	var nodes []NodeSpec
+	for _, name := range strings.Split(value, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			nodes = append(nodes, NodeSpec{Name: name})
+		}
+	}
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("no node names found in %q", value)
+	}
+	return nodes, nil
+}
+
+// buildRemoteArgs returns os.Args[1:] with flags that must not be forwarded to
+// remote nodes stripped:
+//
+//   - -N/--nodes: stripped so remote nodes do not recurse into multi-node mode.
+//   - --fresh: stripped because the primary invocation already cleaned the shared
+//     path before launching remote nodes; re-running it remotely would race with
+//     the primary node's own setup and delete its data and log files.
+func buildRemoteArgs(osArgs []string) []string {
+	result := make([]string, 0, len(osArgs))
+	skip := false
+	for _, arg := range osArgs[1:] {
+		if skip {
+			skip = false
+			continue
+		}
+		if arg == "-N" || arg == "--nodes" {
+			skip = true
+			continue
+		}
+		if strings.HasPrefix(arg, "-N=") || strings.HasPrefix(arg, "--nodes=") {
+			continue
+		}
+		if arg == "--fresh" || strings.HasPrefix(arg, "--fresh=") {
+			continue
+		}
+		result = append(result, arg)
+	}
+	return result
+}
+
+// buildRemoteArgsForWorkload is like buildRemoteArgs but also strips all
+// workload names from the positional args except target. This produces a
+// single-workload invocation when multiple workloads were given on the
+// command line (e.g. "start soak bench" → "start soak" for target=soak).
+func buildRemoteArgsForWorkload(osArgs []string, allWorkloads []string, target string) []string {
+	others := make(map[string]bool, len(allWorkloads))
+	for _, n := range allWorkloads {
+		if n != target {
+			others[n] = true
+		}
+	}
+	base := buildRemoteArgs(osArgs)
+	result := make([]string, 0, len(base))
+	// Workload names are always leading positional args, before any flag --
+	// see "Usage: beegfs iotest start [workload...] [flags]". Only strip
+	// matches from that leading run. Once a flag-looking token ("-...")
+	// appears, every remaining token is a flag or a flag's value and must
+	// be passed through verbatim, even if a value happens to equal another
+	// workload's name (e.g. a hypothetical --tag=soak on some other flag).
+	inLeadingPositionals := true
+	for _, arg := range base {
+		if inLeadingPositionals {
+			if strings.HasPrefix(arg, "-") {
+				inLeadingPositionals = false
+			} else if others[arg] {
+				continue
+			}
+		}
+		result = append(result, arg)
+	}
+	return result
+}
+
+// sshStartBackground starts `beegfs <remoteArgs>` on node via SSH as a
+// background process, redirecting output to logPath on the remote host.
+// Returns as soon as the background process is launched.
+func sshStartBackground(ctx context.Context, node NodeSpec, remoteArgs []string, logPath string) error {
+	// Quote logPath too (not just the args): it derives from the user's --path,
+	// so an unquoted redirect target would break or inject on a path containing
+	// spaces or shell metacharacters.
+	remote := fmt.Sprintf("nohup beegfs %s > %s 2>&1 &", shellJoin(remoteArgs), shellJoin([]string{logPath}))
+	cmd := exec.CommandContext(ctx, "ssh", "-o", "BatchMode=yes", node.Name, remote)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("ssh %s: %w\n%s", node.Name, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// shellJoin produces a space-separated string of single-quoted arguments,
+// safe for interpolation into a remote shell command.
+func shellJoin(args []string) string {
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		quoted[i] = "'" + strings.ReplaceAll(arg, "'", `'\''`) + "'"
+	}
+	return strings.Join(quoted, " ")
+}

--- a/ctl/internal/cmd/iotest/nodes_test.go
+++ b/ctl/internal/cmd/iotest/nodes_test.go
@@ -1,0 +1,91 @@
+// This is a unit test.
+//
+// Coverage: parseNodesFile's inline-comment stripping -- a regression test
+// for a line like "node1   # rack 9" becoming the literal bogus hostname
+// "node1   # rack 9" instead of just "node1" -- plus whole-line comments,
+// blank lines, and comma-separated names on one line, all combined in one
+// file; and buildRemoteArgsForWorkload's leading-positional-only stripping
+// -- a regression test for a flag value that happens to equal another
+// workload's name being silently dropped, since the old implementation
+// matched by value anywhere in the arg list rather than by position.
+package iotest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func nodeNames(specs []NodeSpec) []string {
+	names := make([]string, len(specs))
+	for i, s := range specs {
+		names[i] = s.Name
+	}
+	return names
+}
+
+func TestParseNodesFileInlineComments(t *testing.T) {
+	content := "node1   # rack 9\n" +
+		"# a whole-line comment\n" +
+		"\n" +
+		"node2,node3  # both in rack 10\n" +
+		"node4#no space before the hash\n"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nodes.txt")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := parseNodesFile(path)
+	if err != nil {
+		t.Fatalf("parseNodesFile: %v", err)
+	}
+	want := []string{"node1", "node2", "node3", "node4"}
+	names := nodeNames(got)
+	if len(names) != len(want) {
+		t.Fatalf("got %v, want %v", names, want)
+	}
+	for i, w := range want {
+		if names[i] != w {
+			t.Errorf("node %d: got %q, want %q", i, names[i], w)
+		}
+	}
+}
+
+// TestBuildRemoteArgsForWorkloadValueNotConfusedWithWorkloadName is a
+// regression test: a flag value that happens to equal another selected
+// workload's name must be passed through untouched, since it appears after
+// a flag token and is therefore not a positional workload-name arg.
+func TestBuildRemoteArgsForWorkloadValueNotConfusedWithWorkloadName(t *testing.T) {
+	osArgs := []string{
+		"beegfs", "iotest", "start", "soak", "bench",
+		"--path", "/mnt/x",
+		"--iolog-file", "bench", // a flag value that happens to equal a workload name
+	}
+	got := buildRemoteArgsForWorkload(osArgs, []string{"soak", "bench"}, "soak")
+
+	want := []string{"iotest", "start", "soak", "--path", "/mnt/x", "--iolog-file", "bench"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("arg %d: got %q, want %q (full: %v)", i, got[i], w, got)
+		}
+	}
+}
+
+func TestBuildRemoteArgsForWorkloadStripsLeadingWorkloadNames(t *testing.T) {
+	osArgs := []string{"beegfs", "iotest", "start", "soak", "bench", "--path", "/mnt/x"}
+	got := buildRemoteArgsForWorkload(osArgs, []string{"soak", "bench"}, "bench")
+
+	want := []string{"iotest", "start", "bench", "--path", "/mnt/x"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("arg %d: got %q, want %q (full: %v)", i, got[i], w, got)
+		}
+	}
+}

--- a/ctl/internal/cmd/iotest/smoke.go
+++ b/ctl/internal/cmd/iotest/smoke.go
@@ -1,0 +1,148 @@
+package iotest
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/fileops"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+)
+
+var allVerdicts = []block.Verdict{
+	block.VerdictOK,
+	block.VerdictBodyCorrupt,
+	block.VerdictBodyCRCMismatch,
+	block.VerdictHeadBadCRC,
+	block.VerdictHeadBadMagic,
+	block.VerdictHeadBadFormat,
+	block.VerdictTruncated,
+}
+
+func newSmokeCmd() *cobra.Command {
+	var (
+		path      string
+		records   int
+		blocksize int
+		kind      string
+		iotrace   int
+		iologfile string
+	)
+	cmd := &cobra.Command{
+		Use:   "smoke",
+		Short: "Write N blocks to a file, storing each block's header in an xattr, then verify",
+		Long: `Write N blocks to a file, storing each block's header in an xattr, then read back and verify.
+The file is truncated on every run. Single-threaded and deterministic.`,
+		Annotations: map[string]string{"authorization.AllowAllUsers": ""},
+		Args:        cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			if helpIfNoFlags(cmd) {
+				return nil
+			}
+			if records <= 0 {
+				return fmt.Errorf("blocks must be > 0")
+			}
+			// blocksize is the exact number of bytes written per block; the body
+			// fills it minus the in-data stripe CRCs. block.BodyLen rejects sizes
+			// that can't be partitioned cleanly (rather than silently rounding).
+			if _, err := block.BodyLen(blocksize); err != nil {
+				return fmt.Errorf("invalid --blocksize: %w", err)
+			}
+			bodyKind, err := block.KindFromString(kind)
+			if err != nil {
+				return err
+			}
+
+			ioLog, cleanup, err := newIOTraceLogger(iotrace, iologfile)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			f, err := fileops.Open(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
+			if err != nil {
+				return fmt.Errorf("open %s: %w", path, err)
+			}
+			// A silent Close failure here is exactly the class of bug this tool
+			// exists to catch -- don't let it slip past unchecked in smoke itself.
+			defer func() {
+				if closeErr := f.Close(); closeErr != nil && err == nil {
+					err = closeErr
+				}
+			}()
+
+			store, err := xattrstore.OpenStore(path)
+			if err != nil {
+				return fmt.Errorf("OpenStore: %w", err)
+			}
+
+			w, err := xattrstore.NewWriter(f, store, 0, bodyKind, blocksize, ioLog)
+			if err != nil {
+				return fmt.Errorf("NewWriter: %w", err)
+			}
+
+			// Write phase
+			fmt.Printf("Writing %d blocks (%d bytes each, kind=%s) to %s\n", records, blocksize, bodyKind, path)
+			writeStart := time.Now()
+			for i := 0; i < records; i++ {
+				if err := w.WriteBlock(int64(i)*int64(blocksize), fileops.IOTypeBuffered, false); err != nil {
+					return fmt.Errorf("WriteBlock at i=%d: %w", i, err)
+				}
+			}
+			if err := f.Sync(); err != nil {
+				return fmt.Errorf("fsync: %w", err)
+			}
+			fmt.Printf("Wrote %d blocks (%d bytes) in %s\n",
+				records, int64(records)*int64(blocksize), time.Since(writeStart).Round(time.Millisecond))
+
+			// Verify phase
+			fmt.Println("Verifying ...")
+			buf := make([]byte, blocksize)
+			counts := make(map[block.Verdict]int, len(allVerdicts))
+			scratch := make([]byte, blocksize)
+			verifyStart := time.Now()
+			for i := 0; i < records; i++ {
+				offset := int64(i) * int64(blocksize)
+				if _, err := f.ReadAt(buf, offset); err != nil {
+					return fmt.Errorf("ReadAt at i=%d: %w", i, err)
+				}
+				hdrBytes, getErr := store.Get(offset, int64(blocksize))
+				if getErr != nil {
+					counts[block.VerdictHeadBadMagic]++
+					continue
+				}
+				h, hdrErr := block.UnmarshalHeader(hdrBytes)
+				if hdrErr != nil {
+					counts[block.VerdictHeadBadCRC]++
+					continue
+				}
+				v, _ := block.VerifyBlock(buf, &h, scratch)
+				counts[v]++
+			}
+			verifyElapsed := time.Since(verifyStart).Round(time.Millisecond)
+
+			fmt.Println("Results:")
+			for _, v := range allVerdicts {
+				if c := counts[v]; c > 0 {
+					fmt.Printf("  %-18s %d\n", v.String()+":", c)
+				}
+			}
+			fmt.Printf("Verify took %s\n", verifyElapsed)
+
+			if counts[block.VerdictOK] == records {
+				fmt.Println("PASS")
+				return nil
+			}
+			return fmt.Errorf("FAIL")
+		},
+	}
+	cmd.Flags().StringVar(&path, "path", "/tmp/iotest-smoke.dat", "data file path")
+	cmd.Flags().IntVar(&records, "blocks", 1000, "number of blocks to write")
+	cmd.Flags().IntVar(&blocksize, "blocksize", 4096, "total bytes written per block on disk (the exact write size; use a power of two)")
+	cmd.Flags().StringVar(&kind, "kind", "decimal", "body pattern: decimal | prng | repeat | countup | zeros | ones")
+	cmd.Flags().IntVar(&iotrace, "iotrace", 0, "IO trace level (0=off, 1=error, 2=warn, 3=info, 4/5=debug)")
+	cmd.Flags().StringVar(&iologfile, "iologfile", "", "IO trace destination file (default stderr)")
+	return cmd
+}

--- a/ctl/internal/cmd/iotest/soak.go
+++ b/ctl/internal/cmd/iotest/soak.go
@@ -1,0 +1,549 @@
+//go:build linux
+
+package iotest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+
+	"github.com/thinkparq/beegfs-go/common/filesystem"
+	"github.com/thinkparq/beegfs-go/common/logger"
+	"github.com/thinkparq/beegfs-go/ctl/pkg/ctl/procfs"
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/fileops"
+	"github.com/thinkparq/beegfs-go/verifyio/verifier"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+	"go.uber.org/zap"
+)
+
+const (
+	soakDefaultThreads    = 4
+	soakDefaultDuration   = 5 * time.Minute
+	soakDefaultBlockSize  = 1024
+	soakDefaultFileBlocks = 64
+)
+
+// SoakTool implements Tool. It runs a multi-threaded soak test that
+// continuously writes and verifies blocks with OFD locking.
+type SoakTool struct {
+	logLevel    int
+	logFile     string
+	lockTimeout time.Duration
+	duration    time.Duration
+}
+
+func (s *SoakTool) Name() string { return "soak" }
+func (s *SoakTool) Description() string {
+	return "continuous write-verify loop; detects corruption, torn writes, and stale cache"
+}
+
+func (s *SoakTool) RegisterFlags(cmd *cobra.Command) {
+	cmd.Flags().IntVar(&s.logLevel, "iolog-level", 0, "IO log level (0=off, 1=error, 2=warn, 3=info, 4/5=debug)")
+	cmd.Flags().StringVar(&s.logFile, "iolog-file", "", "IO log destination file (default stderr)")
+	cmd.Flags().DurationVar(&s.lockTimeout, "lock-timeout", 30*time.Second,
+		"give up on a stuck POSIX lock/xattr syscall after this long and fail (0 = wait indefinitely)")
+	cmd.Flags().DurationVar(&s.duration, "duration", soakDefaultDuration,
+		"how long to run (0 = until stopped or an anomaly)")
+}
+
+func (s *SoakTool) CompletionHint(path string) string {
+	files, _ := filepath.Glob(filepath.Join(path, "iotest-soak-*"))
+	if len(files) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("Soak data files:\n")
+	const maxShow = 5
+	for i, f := range files {
+		if i >= maxShow {
+			fmt.Fprintf(&sb, "  ... and %d more\n", len(files)-maxShow)
+			break
+		}
+		info, err := os.Stat(f)
+		if err != nil {
+			continue
+		}
+		fmt.Fprintf(&sb, "  %8s  %s\n", iotestHumanSize(info.Size()), filepath.Base(f))
+	}
+	sb.WriteString("\nTo verify:\n")
+	for i, f := range files {
+		if i >= maxShow {
+			break
+		}
+		fmt.Fprintf(&sb, "  beegfs iotest verify --path %s\n", f)
+	}
+	return sb.String()
+}
+
+func (s *SoakTool) Run(ctx context.Context, cfg RunConfig) error {
+	ioLog, cleanup, err := newIOTraceLogger(s.logLevel, s.logFile)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	var localNode string
+	if hostname, err := os.Hostname(); err == nil {
+		localNode = hostname
+		ioLog = ioLog.With(zap.String("node", hostname))
+	}
+
+	// --threads (RunConfig.Threads) overrides the worker count; 0 = soak default.
+	threads := cfg.Threads
+	if threads <= 0 {
+		threads = soakDefaultThreads
+	}
+	dur := s.duration // --duration; 0 = run until stopped or an anomaly
+
+	if err := soakCheckGlobalFileLocks(ctx, cfg.Path, ioLog); err != nil {
+		return err
+	}
+
+	noOverlapPaths, sharedPaths, err := soakResolveFiles(cfg.Path, threads)
+	if err != nil {
+		return err
+	}
+	soakPrintPlan(threads, noOverlapPaths, sharedPaths, dur)
+
+	// Open one Store per file before spawning workers. Workers operating on the
+	// same file share a Store so the intra-process mutex inside each Store
+	// serialises all goroutines on this node (POSIX F_SETLK only provides
+	// inter-process exclusivity, not inter-goroutine).
+	noOverlapStores, err := soakOpenStores(noOverlapPaths, s.lockTimeout)
+	if err != nil {
+		return err
+	}
+	sharedStores, err := soakOpenStores(sharedPaths, s.lockTimeout)
+	if err != nil {
+		return err
+	}
+
+	baseCtx, cancelCause := context.WithCancelCause(ctx)
+	defer cancelCause(nil)
+	// dur == 0 means run until the stop signal or an anomaly cancels baseCtx.
+	var runCtx context.Context
+	var stop context.CancelFunc
+	if dur > 0 {
+		runCtx, stop = context.WithTimeout(baseCtx, dur)
+	} else {
+		runCtx, stop = context.WithCancel(baseCtx)
+	}
+	defer stop()
+
+	// --blocksize (RunConfig.BlockSize) overrides the per-block size; 0 means
+	// use soak's default.
+	bs := cfg.BlockSize
+	if bs <= 0 {
+		bs = soakDefaultBlockSize
+	}
+	ops := []soakOp{
+		soakWriteBufferedOp(),
+		soakVerifyRangeOp(bs, localNode),
+	}
+	nBlocks := int64(soakDefaultFileBlocks)
+
+	var (
+		wg       sync.WaitGroup
+		failures atomic.Int64
+	)
+	start := time.Now()
+
+	go soakProgressLoop(runCtx, start, cfg.TotalOps)
+	go soakStopWatchLogger(runCtx, cfg.StopSignal, ioLog)
+
+	plan := soakPlan{ops: ops, nBlocks: nBlocks, blockSize: bs}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		wc := soakWorkerCtx{ctx: runCtx, cancelCause: cancelCause, workerID: 0, totalOps: cfg.TotalOps, stopSig: cfg.StopSignal, log: ioLog}
+		if err := soakSpawnWorker(wc, noOverlapPaths, noOverlapStores, plan); err != nil {
+			failures.Add(1)
+		}
+	}()
+
+	for i := 1; i < threads; i++ {
+		wg.Add(1)
+		workerID := i
+		go func() {
+			defer wg.Done()
+			wc := soakWorkerCtx{ctx: runCtx, cancelCause: cancelCause, workerID: workerID, totalOps: cfg.TotalOps, stopSig: cfg.StopSignal, log: ioLog}
+			if err := soakSpawnWorker(wc, sharedPaths, sharedStores, plan); err != nil {
+				failures.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	elapsed := time.Since(start).Round(time.Millisecond)
+	fmt.Printf("elapsed=%s ops=%d\n", elapsed, cfg.TotalOps.Load())
+
+	if cfg.StopSignal != nil && cfg.StopSignal.Load() {
+		fmt.Println("STOPPED (stop signal received)")
+		return nil
+	}
+	cause := context.Cause(baseCtx)
+	workerFailure := cause != nil && cause != context.DeadlineExceeded && cause != context.Canceled
+	if failures.Load() > 0 || workerFailure {
+		// The failing worker already printed the full anomaly inline (see
+		// soakRunWorker); don't echo the same multi-line cause again here.
+		return fmt.Errorf("FAIL")
+	}
+	fmt.Println("PASS")
+	return nil
+}
+
+// ── Op types ──────────────────────────────────────────────────────────────────
+
+// soakOp is a single atomic operation applied to one block within a soak file.
+// Implementations must be safe to call concurrently on different handles.
+type soakOp func(ctx context.Context, h *soakFileHandle, offset int64) error
+
+// soakFileHandle bundles the open file, its xattr store, and a Writer for a
+// single soak data file. Workers hold one handle per file they operate on.
+type soakFileHandle struct {
+	path   string
+	file   *fileops.File
+	store  *xattrstore.Store
+	writer *xattrstore.Writer
+}
+
+func (h *soakFileHandle) close() error { return h.file.Close() }
+
+func soakWriteBufferedOp() soakOp {
+	return func(_ context.Context, h *soakFileHandle, offset int64) error {
+		err := h.writer.WriteBlock(offset, fileops.IOTypeBuffered, true)
+		if errors.Is(err, xattrstore.ErrLockBusy) || errors.Is(err, xattrstore.ErrSetChanged) {
+			return nil
+		}
+		return err
+	}
+}
+
+func soakVerifyRangeOp(blockSize int, localNode string) soakOp {
+	return func(_ context.Context, h *soakFileHandle, offset int64) error {
+		lease, err := h.store.TryAcquireShared(h.file.LockFd(), offset, int64(blockSize))
+		if err != nil {
+			if errors.Is(err, xattrstore.ErrLockBusy) {
+				return nil
+			}
+			return err
+		}
+		defer func() { _ = lease.Release() }()
+		// LockNone: the lease above already covers [offset, offset+blockSize).
+		// VerifyFile's default per-span locking would re-acquire a shared lock
+		// on the same Store, which self-deadlocks in LockModePOSIX (the
+		// in-process mutex is not reentrant).
+		return verifier.VerifyFile(h.store, h.file, verifier.Options{
+			Range:    &verifier.ByteRange{Offset: offset, Length: int64(blockSize)},
+			LockMode: verifier.LockNone,
+		}, func(span verifier.Span) error {
+			if !soakSpanIsAnomaly(span) {
+				return nil
+			}
+			var ino uint64
+			var st unix.Stat_t
+			if unix.Fstat(int(h.file.LockFd().Fd()), &st) == nil {
+				ino = st.Ino
+			}
+			msg := fmt.Sprintf("anomaly at [%d,%d): file=%s inode=%d coverage=%s verdict=%s xattrMatch=%v",
+				span.Offset, span.Offset+span.Length, h.path, ino, span.Coverage, span.Verdict, span.XattrMatch)
+			if span.Header != nil {
+				// TimeNs is stamped by the writer at the time of the write. If
+				// the clocks on both nodes are NTP-synchronised this gives the
+				// true age of the written block at the moment the anomaly is
+				// detected. A large write_age for BODY_CORRUPT indicates stale
+				// data in the local page cache — the writer flushed long ago but
+				// this node has not yet seen the updated bytes from the storage
+				// servers.
+				writeAge := time.Since(time.Unix(0, span.Header.TimeNs)).Round(time.Millisecond)
+				writerNode := block.NodeNameString(span.Header.NodeName)
+				fsynced := span.Header.Tag&block.TagFsynced != 0
+				msg += fmt.Sprintf(" writer=%s reader=%s write_age=%s fsynced=%v seed=0x%016x cycle=%d",
+					writerNode, localNode, writeAge, fsynced, span.Header.Seed, span.Header.Cycle)
+				if span.Diag != nil {
+					stripeState := fmt.Sprintf("OK(%d/%d)",
+						span.Diag.StripesTotal-span.Diag.StripesFailed, span.Diag.StripesTotal)
+					if span.Diag.StripesFailed > 0 {
+						stripeState = fmt.Sprintf("FAILED(%d/%d)",
+							span.Diag.StripesFailed, span.Diag.StripesTotal)
+					}
+					msg += fmt.Sprintf(" bodyCRC(hdr)=0x%08x bodyCRC(read)=0x%08x stripeCRC=%s",
+						span.Header.BodyCRC, span.Diag.ReadBodyCRC, stripeState)
+				}
+			}
+			// The verdict codes are terse; add a plain-English line so the log is
+			// self-explanatory (e.g. that BODY_CORRUPT is valid-but-wrong-version
+			// data, not necessarily corruption). Only meaningful for CoverageOne,
+			// where Verdict is populated.
+			if span.Coverage == verifier.CoverageOne {
+				msg += "\n  meaning: " + span.Verdict.Explanation()
+			}
+			return fmt.Errorf("%s", msg)
+		})
+	}
+}
+
+func soakSpanIsAnomaly(s verifier.Span) bool {
+	switch s.Coverage {
+	case verifier.CoverageMany:
+		return true
+	case verifier.CoverageOne:
+		return s.Verdict != block.VerdictOK
+	default:
+		return false
+	}
+}
+
+// ── Op runner ─────────────────────────────────────────────────────────────────
+
+type soakOpRunner struct {
+	handles   []*soakFileHandle
+	ops       []soakOp
+	rng       *rand.Rand
+	nBlocks   int64
+	blockSize int
+}
+
+func newSoakOpRunner(handles []*soakFileHandle, ops []soakOp, seed int64, nBlocks int64, blockSize int) *soakOpRunner {
+	return &soakOpRunner{
+		handles:   handles,
+		ops:       ops,
+		rng:       rand.New(rand.NewSource(seed)),
+		nBlocks:   nBlocks,
+		blockSize: blockSize,
+	}
+}
+
+func (r *soakOpRunner) runOnce(ctx context.Context) error {
+	h := r.handles[r.rng.Intn(len(r.handles))]
+	op := r.ops[r.rng.Intn(len(r.ops))]
+	offset := r.rng.Int63n(r.nBlocks) * int64(r.blockSize)
+	return op(ctx, h, offset)
+}
+
+// ── Workers ───────────────────────────────────────────────────────────────────
+
+// soakWorkerCtx bundles the per-worker execution environment: everything a
+// worker needs to report progress, signal a fatal anomaly to its siblings,
+// and know when to stop. It's identical across every worker started by one
+// Run call except workerID.
+type soakWorkerCtx struct {
+	ctx         context.Context
+	cancelCause context.CancelCauseFunc
+	workerID    int
+	totalOps    *atomic.Int64
+	stopSig     *atomic.Bool
+	log         *zap.Logger
+}
+
+// soakPlan bundles the run configuration every worker operates under: which
+// ops to sample from and the block layout. Identical across every worker
+// started by one Run call.
+type soakPlan struct {
+	ops       []soakOp
+	nBlocks   int64
+	blockSize int
+}
+
+func soakSpawnWorker(wc soakWorkerCtx, paths []string, stores map[string]*xattrstore.Store, plan soakPlan) error {
+	handles, err := soakOpenHandles(paths, stores, wc.workerID, plan.blockSize, wc.log)
+	if err != nil {
+		err = fmt.Errorf("worker %d: open handles: %w", wc.workerID, err)
+		fmt.Fprintln(os.Stderr, err)
+		wc.cancelCause(err)
+		return err
+	}
+	defer soakCloseHandles(handles)
+
+	r := newSoakOpRunner(handles, plan.ops, int64(wc.workerID), plan.nBlocks, plan.blockSize)
+	return soakRunWorker(wc, r)
+}
+
+func soakRunWorker(wc soakWorkerCtx, r *soakOpRunner) error {
+	for {
+		select {
+		case <-wc.ctx.Done():
+			return nil
+		default:
+		}
+		if wc.stopSig != nil && wc.stopSig.Load() {
+			return nil
+		}
+		if err := r.runOnce(wc.ctx); err != nil {
+			err = fmt.Errorf("worker %d: %w", wc.workerID, err)
+			fmt.Fprintln(os.Stderr, err)
+			wc.cancelCause(err)
+			return err
+		}
+		wc.totalOps.Add(1)
+	}
+}
+
+func soakStopWatchLogger(ctx context.Context, stopSig *atomic.Bool, log *zap.Logger) {
+	t := time.NewTicker(20 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			if stopSig != nil && stopSig.Load() {
+				log.Info("stop signal detected; waiting for workers to finish")
+				return
+			}
+			log.Info("running; no stop signal detected")
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func soakProgressLoop(ctx context.Context, start time.Time, totalOps *atomic.Int64) {
+	t := time.NewTicker(5 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			fmt.Printf("[%s] ops=%d\n", time.Since(start).Round(time.Second), totalOps.Load())
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// soakCheckGlobalFileLocks verifies the BeeGFS client mount backing path has
+// tuneUseGlobalFileLocks enabled. soakOpenStores relies on
+// xattrstore.OpenStoreMultiNode's cross-node POSIX locking (LockModePOSIX),
+// which silently degrades to local-only locking if the client does not
+// propagate flock/fcntl locks across nodes, breaking soak's correctness
+// guarantees when multiple nodes share the same files.
+func soakCheckGlobalFileLocks(ctx context.Context, path string, log *zap.Logger) error {
+	fs, err := filesystem.NewFromPath(path)
+	if err != nil {
+		log.Warn("unable to determine BeeGFS mount point for path (skipping cross-node lock check)", zap.String("path", path), zap.Error(err))
+		return nil
+	}
+	mountPath := fs.GetMountPath()
+
+	clients, err := procfs.GetBeeGFSClients(ctx, procfs.GetBeeGFSClientsConfig{FilterByMounts: []string{mountPath}}, &logger.Logger{Logger: log})
+	if err != nil {
+		log.Warn("unable to verify BeeGFS client configuration: unable to fetch configuration from /proc/fs/beegfs (ignoring)", zap.Error(err))
+		return nil
+	}
+	if len(clients) != 1 {
+		log.Warn("unable to verify BeeGFS client configuration: expected exactly one entry in /proc/fs/beegfs for this mount point (ignoring)", zap.String("mountPoint", mountPath))
+		return nil
+	}
+
+	val, ok := clients[0].Config["tuneUseGlobalFileLocks"]
+	if !ok {
+		log.Warn("the BeeGFS client version does not appear to support 'tuneUseGlobalFileLocks': cannot verify cross-node locking is enabled (ignoring)")
+		return nil
+	}
+	if val != "1" {
+		return fmt.Errorf("soak relies on cross-node POSIX file locking, but the BeeGFS mount %s has 'tuneUseGlobalFileLocks = %s': "+
+			"set 'tuneUseGlobalFileLocks = true' in beegfs-client.conf on every node running soak against this mount", mountPath, val)
+	}
+	return nil
+}
+
+// ── File management ───────────────────────────────────────────────────────────
+
+func soakResolveFiles(dir string, threads int) (noOverlapPaths, sharedPaths []string, err error) {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, nil, fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	noOverlapPaths = []string{filepath.Join(dir, "iotest-soak-0.noOverlap")}
+	nShared := threads - 1
+	if nShared <= 0 {
+		return noOverlapPaths, nil, nil
+	}
+	nFiles := nShared / 2
+	if nFiles == 0 {
+		nFiles = 1
+	}
+	sharedPaths = make([]string, nFiles)
+	for i := range sharedPaths {
+		sharedPaths[i] = filepath.Join(dir, fmt.Sprintf("iotest-soak-%d.shared", i))
+	}
+	return noOverlapPaths, sharedPaths, nil
+}
+
+// soakOpenStores ensures each path exists and opens one Store per path.
+// Callers pass the resulting map to soakOpenHandles so all workers that share
+// a file use the same Store instance and its intra-process mutex.
+func soakOpenStores(paths []string, lockTimeout time.Duration) (map[string]*xattrstore.Store, error) {
+	m := make(map[string]*xattrstore.Store, len(paths))
+	for _, p := range paths {
+		f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0644)
+		if err != nil {
+			return nil, fmt.Errorf("create %s: %w", p, err)
+		}
+		if err := f.Close(); err != nil {
+			return nil, fmt.Errorf("close %s: %w", p, err)
+		}
+		store, err := xattrstore.OpenStoreMultiNode(p, lockTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("OpenStore %s: %w", p, err)
+		}
+		m[p] = store
+	}
+	return m, nil
+}
+
+func soakOpenHandles(paths []string, stores map[string]*xattrstore.Store, workerID, blockSize int, log *zap.Logger) ([]*soakFileHandle, error) {
+	handles := make([]*soakFileHandle, 0, len(paths))
+	for _, p := range paths {
+		h, err := soakOpenHandle(p, stores[p], workerID, blockSize, log)
+		if err != nil {
+			soakCloseHandles(handles)
+			return nil, err
+		}
+		handles = append(handles, h)
+	}
+	return handles, nil
+}
+
+func soakOpenHandle(path string, store *xattrstore.Store, workerID, blockSize int, log *zap.Logger) (*soakFileHandle, error) {
+	f, err := fileops.Open(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	w, err := xattrstore.NewWriter(f, store, workerID, block.KindDecimal, blockSize, log)
+	if err != nil {
+		closeErr := f.Close()
+		return nil, fmt.Errorf("NewWriter %s: %w", path, errors.Join(err, closeErr))
+	}
+	return &soakFileHandle{path: path, file: f, store: store, writer: w}, nil
+}
+
+func soakCloseHandles(handles []*soakFileHandle) {
+	for _, h := range handles {
+		if err := h.close(); err != nil {
+			fmt.Fprintf(os.Stderr, "close %s: %v\n", h.path, err)
+		}
+	}
+}
+
+func soakPrintPlan(threads int, noOverlapPaths, sharedPaths []string, duration time.Duration) {
+	fmt.Printf("Starting soak: %d thread(s)", threads)
+	if duration > 0 {
+		fmt.Printf(" for %s", duration)
+	}
+	fmt.Println()
+	fmt.Printf("  noOverlap: %s\n", noOverlapPaths[0])
+	for _, p := range sharedPaths {
+		fmt.Printf("  shared:    %s\n", p)
+	}
+}

--- a/ctl/internal/cmd/iotest/trace.go
+++ b/ctl/internal/cmd/iotest/trace.go
@@ -1,0 +1,58 @@
+package iotest
+
+import (
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// newIOTraceLogger builds a zap logger for IO-level tracing. level 0 returns a no-op logger.
+// Levels 1–5 follow the BeeGFS log scale: 1=Error, 2=Warn, 3=Info, 4/5=Debug.
+// logFile is the output path; empty means stderr.
+func newIOTraceLogger(level int, logFile string) (*zap.Logger, func(), error) {
+	if level <= 0 {
+		return zap.NewNop(), func() {}, nil
+	}
+
+	encCfg := zapcore.EncoderConfig{
+		TimeKey:     "T",
+		LevelKey:    "L",
+		MessageKey:  "M",
+		EncodeTime:  zapcore.ISO8601TimeEncoder,
+		EncodeLevel: zapcore.CapitalLevelEncoder,
+	}
+	enc := zapcore.NewConsoleEncoder(encCfg)
+
+	var sink zapcore.WriteSyncer
+	cleanup := func() {}
+	if logFile != "" {
+		f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			return nil, nil, fmt.Errorf("trace: open %s: %w", logFile, err)
+		}
+		sink = zapcore.AddSync(f)
+		cleanup = func() { _ = f.Close() }
+	} else {
+		sink = zapcore.AddSync(os.Stderr)
+	}
+
+	zapLevel := traceToZapLevel(level)
+	core := zapcore.NewCore(enc, sink, zap.NewAtomicLevelAt(zapLevel))
+	log := zap.New(core)
+	return log, func() { _ = log.Sync(); cleanup() }, nil
+}
+
+func traceToZapLevel(level int) zapcore.Level {
+	switch level {
+	case 1:
+		return zapcore.ErrorLevel
+	case 2:
+		return zapcore.WarnLevel
+	case 3:
+		return zapcore.InfoLevel
+	default:
+		return zapcore.DebugLevel
+	}
+}

--- a/ctl/internal/cmd/iotest/verify.go
+++ b/ctl/internal/cmd/iotest/verify.go
@@ -1,0 +1,193 @@
+package iotest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/spf13/cobra"
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/fileops"
+	"github.com/thinkparq/beegfs-go/verifyio/verifier"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+)
+
+func newVerifyCmd() *cobra.Command {
+	var (
+		path    string
+		verbose bool
+	)
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Verify a data file written by smoke or soak",
+		Long: `Verify a data file written by smoke or soak.
+Every byte range is classified by coverage and checked against its stored xattr header.
+Anomalies are always printed; --verbose prints all spans including clean ones.
+
+If --path is a directory, every iotest-soak-* data file in it (as produced
+by 'beegfs iotest start soak --path <dir>') is verified in turn.`,
+		Annotations: map[string]string{"authorization.AllowAllUsers": ""},
+		Args:        cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if helpIfNoFlags(cmd) {
+				return nil
+			}
+			if path == "" {
+				return fmt.Errorf("required flag \"path\" not set")
+			}
+
+			info, err := os.Stat(path)
+			if err != nil {
+				return fmt.Errorf("stat: %w", err)
+			}
+
+			files := []string{path}
+			if info.IsDir() {
+				files, err = filepath.Glob(filepath.Join(path, "iotest-soak-*"))
+				if err != nil {
+					return fmt.Errorf("glob: %w", err)
+				}
+				if len(files) == 0 {
+					return fmt.Errorf("%s: no iotest-soak-* data files found", path)
+				}
+				sort.Strings(files)
+			}
+
+			totalAnomalies := 0
+			for _, f := range files {
+				anomalies, _, err := verifyOneFile(f, verbose)
+				if err != nil {
+					return err
+				}
+				totalAnomalies += anomalies
+			}
+			if totalAnomalies > 0 {
+				return fmt.Errorf("FAIL: %d anomaly(s)", totalAnomalies)
+			}
+			fmt.Println("PASS")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&path, "path", "", "data file or soak directory to verify")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "print all spans, not just anomalies")
+	return cmd
+}
+
+// verifyOneFile verifies a single data file, printing per-span output and a
+// summary line. It returns the number of anomalous spans found.
+func verifyOneFile(path string, verbose bool) (anomalies, total int, err error) {
+	f, err := fileops.Open(path, os.O_RDONLY, 0)
+	if err != nil {
+		return 0, 0, fmt.Errorf("open: %w", err)
+	}
+	defer f.Close()
+
+	store, err := xattrstore.OpenStore(path)
+	if err != nil {
+		return 0, 0, fmt.Errorf("OpenStore: %w", err)
+	}
+
+	if err := verifyCheckXattrPresence(path, store); err != nil {
+		return 0, 0, err
+	}
+
+	err = verifier.VerifyFile(store, f, verifier.Options{}, func(span verifier.Span) error {
+		total++
+		ok, line, detail := verifySummariseSpan(span)
+		if !ok {
+			anomalies++
+		}
+		if verbose || !ok {
+			fmt.Print(line)
+			if detail != "" {
+				fmt.Print(detail)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return anomalies, total, fmt.Errorf("verify %s: %w", path, err)
+	}
+
+	fmt.Printf("\n%s: %d span(s) checked", path, total)
+	if anomalies > 0 {
+		fmt.Printf(", %d anomaly(s)\n", anomalies)
+	} else {
+		fmt.Println(", 0 anomalies")
+	}
+	return anomalies, total, nil
+}
+
+func verifyCheckXattrPresence(path string, store *xattrstore.Store) error {
+	info, err := os.Stat(path)
+	if err != nil || info.Size() == 0 {
+		return nil
+	}
+	n := 0
+	if err := store.ForEachEntry(func(_, _ int64, _ []byte) error {
+		n++
+		return nil
+	}); err != nil {
+		// A listxattr failure (permissions, the file vanishing mid-check, ...)
+		// is a different problem than "genuinely zero xattr records" -- don't
+		// let it get misdiagnosed as missing xattr support below.
+		return fmt.Errorf("%s: listing xattrs: %w", path, err)
+	}
+	if n == 0 {
+		return fmt.Errorf("%s: no iotest xattr records found on a non-empty file\n"+
+			"Possible causes:\n"+
+			"  - Filesystem does not support user xattrs\n"+
+			"    BeeGFS: add 'client_extra_mount_options = user_xattr' to beegfs-client.conf\n"+
+			"  - File was copied without preserving xattrs (use 'cp --preserve=xattr')\n"+
+			"  - File was not written by verifyio", path)
+	}
+	return nil
+}
+
+func verifySummariseSpan(s verifier.Span) (ok bool, line, detail string) {
+	switch s.Coverage {
+	case verifier.CoverageOne:
+		clean := s.Verdict == block.VerdictOK && s.XattrMatch
+		xattrStr := "match"
+		if !s.XattrMatch {
+			xattrStr = "MISMATCH"
+		}
+		status := "ok"
+		if !clean {
+			status = "FAIL"
+		}
+		line = fmt.Sprintf("offset=%-10d length=%-8d coverage=one      verdict=%-18s xattr=%-8s %s\n",
+			s.Offset, s.Length, s.Verdict, xattrStr, status)
+		if s.Header != nil {
+			detail = fmt.Sprintf("  kind=%-10s worker=%-4d cycle=%-6d node=%s\n",
+				s.Header.Kind, s.Header.WorkerID, s.Header.Cycle,
+				block.NodeNameString(s.Header.NodeName))
+		}
+		return clean, line, detail
+
+	case verifier.CoverageNone:
+		status := "ok"
+		if !s.AllZero {
+			status = "FAIL (non-zero bytes in uncovered region)"
+		}
+		line = fmt.Sprintf("offset=%-10d length=%-8d coverage=none     allzero=%-5v %s\n",
+			s.Offset, s.Length, s.AllZero, status)
+		return s.AllZero, line, ""
+
+	case verifier.CoverageMany:
+		line = fmt.Sprintf("offset=%-10d length=%-8d coverage=many     FAIL (%d overlapping records)\n",
+			s.Offset, s.Length, len(s.Entries))
+		return false, line, ""
+
+	case verifier.CoverageContended:
+		line = fmt.Sprintf("offset=%-10d length=%-8d coverage=contended (lock busy; skipped)\n",
+			s.Offset, s.Length)
+		return true, line, ""
+
+	default:
+		line = fmt.Sprintf("offset=%-10d length=%-8d coverage=unknown(%d)\n",
+			s.Offset, s.Length, int(s.Coverage))
+		return false, line, ""
+	}
+}

--- a/ctl/internal/cmd/root.go
+++ b/ctl/internal/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/entry"
 	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/health"
 	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/index"
+	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/iotest"
 	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/license"
 	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/node"
 	"github.com/thinkparq/beegfs-go/ctl/internal/cmd/pool"
@@ -110,6 +111,7 @@ Thank you for using BeeGFS and supporting its ongoing development! 🐝
 	cmd.AddCommand(quota.NewCmd())
 	cmd.AddCommand(health.NewHealthCmd())
 	cmd.AddCommand(benchmark.NewBenchmarkCmd())
+	cmd.AddCommand(iotest.NewIotestCmd())
 	cmd.AddCommand(index.NewCmd())
 	cmd.AddCommand(copy.NewCopyCmd())
 	cmd.AddCommand(debug.NewCmd())

--- a/verifyio/README.md
+++ b/verifyio/README.md
@@ -1,0 +1,251 @@
+# verifyio
+
+`verifyio` is a Go library for verifiable filesystem IO testing, imported as
+`github.com/thinkparq/beegfs-go/verifyio`. Every write produces a block body
+that is deterministically generated from a seed and self-checked via
+per-stripe CRC32C checksums appended after it — the block itself carries no
+descriptive header. Instead, the header (seed, kind, node, offset,
+timestamps, etc.) is stored exclusively in an xattr on the same inode, never
+embedded in the block data. A verifier can later sweep the file, read back
+each block's xattr header and data under a shared OFD lock, check the stripe
+CRCs for internal consistency, then regenerate the body from the xattr's
+seed and compare — catching silent corruption, torn writes, and stale data.
+It backs the standalone `iotest-*` tools documented below and the
+`beegfs iotest` CLI command.
+
+Not every tool needs real xattr support: `iotest-posixbench` (below) never
+calls setxattr/getxattr at all. It verifies purely through a run-level
+manifest file instead of a per-block xattr, and can optionally embed
+per-stripe CRC32C checksums directly in the data (trading verification
+depth — no protection against misdirected, torn, or stale writes — for
+write throughput). Useful on filesystems without xattr support, or when
+benchmarking raw throughput without any per-block metadata overhead.
+
+## How it works
+
+1. **Write**: `xattrstore.Writer.WriteBlock` acquires an exclusive OFD range
+   lock, writes the block header into an xattr (`user.verifyio.<offset>-<length>`),
+   then writes the block data — deterministic body + per-stripe CRC32C
+   checksums, no embedded header — to the data file before releasing the
+   lock (intent-before-data ordering).
+
+2. **Verify**: `verifier.VerifyFile` snapshots all xattrs, builds a sweep-line
+   over the file, then for each covered range acquires a shared OFD lock and
+   reads the block back. It classifies every byte range as `CoverageOne` (one
+   record, body verified), `CoverageNone` (unwritten), `CoverageMany` (two
+   records overlap — a bug), or `CoverageContended` (lock was busy; skipped).
+
+3. **Locking**: OFD locks (`F_OFD_SETLK`) are per-open-file-description, so
+   two goroutines each holding their own `*os.File` to the same path serialize
+   against each other — the same as two separate processes.
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| `block` | Deterministic body + per-stripe CRC32C checksums (the on-disk block); a separate 90-byte header describing it is marshaled here but stored by `xattrstore`, never embedded in the block itself. `MakeBlock`, `VerifyBlock`, body kinds (decimal, PRNG, countup, zeros, ones, repeat). |
+| `xattr` | Thin wrappers around `listxattr`/`getxattr`/`setxattr`/`removexattr` with ERANGE-retry loops. |
+| `xattrstore` | Per-offset header storage as xattrs. `Store` (Put/Get/ForEachEntry/Overlapping/ReplaceRange), `Writer` (WriteBlock with OFD locking), OFD lock primitives (`TryAcquireExclusive`, `TryAcquireShared`, `Lease`). |
+| `fileops` | `File` type that manages IO handles per `IOType`. `IOTypeBuffered` implemented; `IOTypeODirect`, `IOTypeMmap`, `IOTypePwritev` are stubs. |
+| `verifier` | Sweep-line file verifier. `VerifyFile` with `Options` (ByteRange, LockMode, Log). |
+| `internal/trace` | Structured zap logger setup for IO tracing (internal to verifyio). |
+| `bench/posixbench` | Write-once POSIX IO benchmark with manifest-based verification. |
+
+## Building
+
+Commands below are relative to the `verifyio/` directory (from the repo root,
+prefix with `verifyio/`, e.g. `go build ./verifyio/cmd/...`).
+
+Build all tools into `./bin/`:
+
+```sh
+go build -o ./bin/ ./cmd/...
+```
+
+Build a specific tool into the current directory:
+
+```sh
+go build ./cmd/iotest-soak/
+go build ./cmd/iotest-smoke/
+go build ./cmd/iotest-verify/
+go build ./cmd/iotest-dump/
+go build ./cmd/iotest-posixbench/
+```
+
+Install to `$GOBIN` (or `~/go/bin` if `$GOBIN` is unset):
+
+```sh
+go install ./cmd/...
+```
+
+Run directly without a build step:
+
+```sh
+go run ./cmd/iotest-soak/ -path /tmp/soak -threads 8 -duration 30s
+```
+
+Run tests and benchmarks:
+
+```sh
+go test ./...
+go test -bench=. ./...
+```
+
+## Tools
+
+### iotest-smoke
+
+Single-threaded end-to-end smoke test. Writes N blocks to a file, storing
+each block's header in an xattr, reads everything back, and verifies. Useful as a quick
+sanity check and as a copy-paste starter for new consumers of the library.
+The file is truncated and rewritten on every run.
+
+```
+iotest-smoke -path /tmp/iotest-smoke.dat -blocks 1000
+iotest-smoke -path /tmp/iotest-smoke.dat -blocks 100 -blocksize 8192 -kind prng
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-path` | `/tmp/iotest-smoke.dat` | Data file path |
+| `-blocks` | `1000` | Number of blocks to write |
+| `-blocksize` | `4096` | Total bytes per block on disk (use a power of two); must satisfy `block.BodyLen`'s body/stripe-CRC split — no header-size floor, since the header lives in the xattr, not the block |
+| `-kind` | `decimal` | Body pattern: `decimal`, `prng`, `repeat`, `countup`, `zeros`, `ones` |
+| `-iotrace` | `0` | IO trace level (0=off … 5=debug) |
+| `-iologfile` | stderr | IO trace destination file |
+
+---
+
+### iotest-soak
+
+Multi-threaded long-running stress test. Thread 0 operates exclusively on a
+`.noOverlap` file; the remaining N−1 threads share a pool of ⌊(N−1)/2⌋
+`.shared` files (clamped to at least one whenever there is a shared worker, so
+`-threads 2` uses a single shared file). Each worker loops for the requested duration, randomly
+picking a file from its pool, an operation (write or range-verify), and a
+block-aligned offset, then executing it. OFD locking handles contention on
+shared files. The run aborts immediately if body corruption (`CoverageMany`
+or `Verdict != OK`) is detected.
+
+```
+iotest-soak -path /tmp/soak -threads 8 -duration 5m
+iotest-soak -path /tmp/soak -threads 16 -duration 1h -blocksize 4096 -file-blocks 256
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-path` | `/tmp/iotest-soak` | Directory for soak data files (created if absent) |
+| `-threads` | `4` | Number of concurrent worker goroutines |
+| `-duration` | `30s` | How long to run (`0` = until anomaly) |
+| `-blocksize` | `1024` | Bytes per block (use a power of two); must satisfy `block.BodyLen`'s body/stripe-CRC split |
+| `-file-blocks` | `64` | Number of blocks per file (file size = blocksize × file-blocks) |
+| `-iotrace` | `0` | IO trace level (0=off … 5=debug) |
+| `-iologfile` | stderr | IO trace destination file |
+
+File layout for `-threads 8`:
+
+```
+/tmp/soak/iotest-soak-0.noOverlap   ← thread 0 only
+/tmp/soak/iotest-soak-0.shared      ← shared by threads 1–7
+/tmp/soak/iotest-soak-1.shared
+/tmp/soak/iotest-soak-2.shared
+```
+
+---
+
+### iotest-verify
+
+Verifies all blocks in a file written by `iotest-smoke` or `iotest-soak`.
+By default prints only anomalous spans; `-verbose` prints every span.
+Exits 1 if any anomaly is found.
+
+```
+iotest-verify -path /tmp/iotest-smoke.dat
+iotest-verify -path /tmp/soak/iotest-soak-0.noOverlap -verbose
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-path` | (required) | Data file to verify |
+| `-verbose` | false | Print all spans, not just anomalies |
+
+---
+
+### iotest-dump
+
+Dumps the xattr index of a data file in human-readable form. Lists every
+stored record sorted by offset, with offset, length, worker ID, cycle,
+body-pattern kind, timestamp, and verification verdict.
+
+```
+iotest-dump -path /tmp/iotest-smoke.dat
+iotest-dump -path /tmp/soak/iotest-soak-0.shared
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-path` | (required) | Data file to inspect |
+
+---
+
+### iotest-posixbench
+
+Write-once POSIX IO benchmark with manifest-based post-run verification.
+Does not use xattrs; records a `posixbench.json` manifest alongside the
+data so the verify subcommand can check body integrity later.
+
+```sh
+# Write 1 GiB per worker across 8 threads, then read back:
+iotest-posixbench run -path /mnt/testdir -threads 8 -read
+
+# Verify after the fact (reads posixbench.json from the same directory):
+iotest-posixbench verify -path /mnt/testdir
+```
+
+**`run` flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-path` | (required) | Target directory |
+| `-threads` | `4` | Worker goroutines |
+| `-block-size` | `4194304` (4 MiB) | IO transfer size in bytes |
+| `-file-size` | `1073741824` (1 GiB) | Per-worker data size in bytes (bytes, not a size suffix) |
+| `-files-per-worker` | `1` | Files per worker; ignored when `-layout n-to-1` (all workers share the one file regardless) |
+| `-layout` | `1-to-1` | `1-to-1` (one file per worker) or `n-to-1` (all workers share one file) |
+| `-kind` | `decimal` | Body pattern: `decimal`, `prng`, `zeros`, `ones`, `countup`, `repeat` |
+| `-seed` | `0` | Pattern seed (0 = random, recorded in manifest) |
+| `-read` | false | Run a sequential read phase after writing |
+
+**`verify` flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-path` | (required) | Directory containing `posixbench.json` |
+| `-verbose` | false | Print all anomalies (default: summary only) |
+
+---
+
+## Design notes
+
+**Intent-before-data**: the xattr is always written before the data block.
+After a crash, a verifier may see an xattr with no matching data (recoverable)
+but never data without a matching xattr.
+
+**Fixed-size writes with `Put`**: `Writer.WriteBlock` uses `store.Put` rather
+than `store.ReplaceRange`. With fixed block sizes at block-aligned offsets,
+each new write to the same position uses the same xattr name
+(`user.verifyio.<offset>-<blocksize>`) and `setxattr` replaces it in place — no
+orphaned xattrs accumulate.
+
+**Verifier races under concurrent writes**: `verifier.VerifyFile` snapshots the
+set of xattr entries (offset/length) before acquiring per-span locks, but
+**re-reads each header under the shared lock** before verifying. Because a writer
+holds an exclusive lock across both the xattr write and the data write, a verifier
+holding the shared lock always sees a mutually consistent header/body pair — so a
+block reseeded after the snapshot is verified against its new header and passes,
+rather than being falsely reported as `BODY_CORRUPT`. Two races remain benign and
+are not anomalies: (1) a write completing entirely after the snapshot produces
+apparent data with no xattr claim (`CoverageNone, AllZero=false`); (2) an entry
+removed or replaced between the snapshot and the per-span lock is reported
+`CoverageContended` (its header was gone when the lock was held). The soak test
+only flags `CoverageMany` and `Verdict != VerdictOK` as real anomalies.

--- a/verifyio/TODO.md
+++ b/verifyio/TODO.md
@@ -1,0 +1,112 @@
+# verifyio — work in progress
+
+## Background
+
+The verifyio library was migrated into `beegfs-go` from a standalone project
+and now lives at the top-level `verifyio/` package, consumed by the standalone
+`iotest-*` tools and the `beegfs iotest` CLI.
+
+### What's done
+
+- `verifyio/{block,verifier,xattr,xattrstore,fileops}/` — xattr-backed block writer/verifier, OFD locking, sweep-line verifier
+- `verifyio/bench/posixbench/` — sequential POSIX write/read benchmark with manifest
+- `verifyio/internal/trace/` — zap IO trace logger
+- `verifyio/cmd/` — CLI tools: iotest-smoke, iotest-soak, iotest-verify, iotest-dump, iotest-posixbench, iotest-util
+- All tools show usage+examples when invoked without arguments
+- `iotest-verify` gives a clear error when a file has no xattr records (catches BeeGFS missing `user_xattr`)
+- `iotest-soak` redesigned: two file pools (noOverlap + shared), OFD locking, extensible op system, duration-controlled loop
+- All tools already participate in `go test ./...`, `go vet ./...`, staticcheck via `make test`
+- No Makefile targets added — consistent with the `watch/cmd/test-*` precedent (dev tools use `go install` directly)
+
+---
+
+## Next: new `beegfs iotest` subcommand
+
+> **Status: implemented.** The `beegfs iotest` command now exists
+> (`ctl/internal/cmd/iotest`, see its `DESIGN.md`). The notes below are retained
+> for the original design rationale.
+
+The goal is a new subcommand under the `beegfs` CLI that exposes iotest
+functionality to users running against a live BeeGFS mount.
+
+### Open design questions
+
+1. **Client-side or server-side IO?** ✅ DECIDED: client-side.
+   The CLI process does IO via POSIX through the BeeGFS mount, exercising the full path
+   (client module → network → storage). No new daemon-side handlers needed.
+
+2. **Relationship to `beegfs benchmark`**
+   - New sibling subcommand (e.g. `beegfs iotest`) — separate concern, different flags?
+   - Or extend `beegfs benchmark` with a client-side mode?
+
+3. **Which iotest mode first?**
+   - Integrity mode (`iotest-soak` style) — write+verify with xattrs, detects silent corruption
+   - Benchmark mode (`iotest-posixbench` style) — sequential write/read, reports MB/s
+   - Or both under the same subcommand with subcommands like `beegfs iotest bench` / `beegfs iotest verify`?
+
+4. **How the CLI plumbs into iotest**
+   - The `ctl/pkg/ctl/` layer is the right place for business logic
+   - `ctl/internal/cmd/` for Cobra command tree and output formatting
+   - The verifyio library packages are already importable as `github.com/thinkparq/beegfs-go/verifyio/...`
+
+### Suggested starting point (to confirm in the morning)
+
+A `beegfs iotest` command with two subcommands mirroring posixbench:
+- `beegfs iotest run` — write data files to a target path (flags: threads, file-size, block-size, kind)
+- `beegfs iotest verify` — check data files against the manifest
+
+This gives a client-side benchmark with built-in post-run correctness check,
+which is the main thing `beegfs benchmark` cannot do today.
+
+---
+
+## Multi-node coordination (future TODO, 2026-06-10)
+
+Today `iotest-soak` uses OFD/fcntl locking for cross-goroutine coordination on shared files.
+That's an important test scenario, but HPC apps commonly use other coordination mechanisms
+(MPI ranks, job scheduler decomposition, etc.) and the default mode should be lock-free for
+performance reasons. Three options were discussed for multi-node iotest:
+
+### Option A: Static partition (recommended default)
+
+Each worker is given `--node-id N --total-nodes M`. Block ownership is pure math:
+
+    globalWorkerID = N * threadsPerNode + threadID
+    owns block i  ⟺  i % totalGlobalWorkers == globalWorkerID
+
+No runtime coordination. Maps directly onto SLURM env vars (`$SLURM_NODEID`, `$SLURM_NNODES`).
+
+- Pro: zero overhead; mirrors how MPI apps actually decompose work
+- Pro: trivially launchable from any job scheduler
+- Con: can't test cross-node write contention (by design)
+- Con: misconfigured overlap is caught by the verifier after the fact, not before
+
+Implementation note: `opRunner.runOnce` currently samples `rng.Int63n(nBlocks)`.
+Change to sample from an owned-block filter: `blockIdx % totalWorkers == globalWorkerID`.
+For large files, express as modular arithmetic rather than a pre-built slice.
+
+Open question: `--node-id / --total-nodes` (ergonomic for scheduler) vs.
+`--global-worker-id / --total-global-workers` (flat, simpler for opRunner)?
+Flat form is simpler internally; scheduler form is more natural to specify.
+
+### Option B: Leader-follower work dispatch
+
+One process maintains a work queue; followers pull `(file, offset)` assignments.
+Leader can hand out non-overlapping work OR deliberately create contention.
+
+- Pro: can test contention and non-contention dynamically; leader detects dead followers
+- Con: significant complexity — needs a transport (gRPC listener or coordination file on the mount)
+- Con: leader is a throughput bottleneck for high-frequency small ops
+- Best fit: a future `--mode=contention` flag, not the default path
+
+### Option C: Rendezvous file on the BeeGFS mount (variant of A)
+
+Each node writes `<testdir>/roster/<hostname>.ready`, then polls until it sees
+`--total-nodes` files. Once all are present, each node independently computes its
+partition using the same static math as Option A. Eliminates the need to pass
+`--node-id` explicitly.
+
+- Pro: self-describing — the FS under test is also the coordination plane
+- Pro: no pre-assigned node IDs; hostname-derived
+- Con: adds a barrier at startup; fragile if a node dies before writing its ready file
+- Best fit: ergonomic convenience layer on top of Option A once A is working

--- a/verifyio/bench/TODO.md
+++ b/verifyio/bench/TODO.md
@@ -1,0 +1,57 @@
+# verifyio/bench — planned work
+
+## posixbench: ECC/no-xattr bit-rot regression test
+
+Add a test (mirroring `TestVerifierDetectsCorruption`, but with `NoXattr: true`) that
+runs a `--no-xattr` benchmark, flips a byte on disk in a data file, and asserts
+`verifyECC` reports a per-stripe `CRC mismatch` anomaly. The bit-rot-detection capability
+works today (the in-file CRC32C stripes), but only the default full-body path is covered by
+a test; this locks in the ECC path against regression. Note `--no-xattr` filenames embed the
+block size (`pbench-bs<N>-w000-f000.dat`). Verification stays CRC-only by design (no-xattr is
+the throughput-benchmark mode; full content verification is the default xattr mode's job).
+
+## mdtest: metadata benchmark with integrity verification
+
+Implement `verifyio/bench/mdtest/` as a metadata-focused complement to `posixbench`.
+Modelled on the mdtest benchmark but with per-file integrity verification via the
+verifyio integrity layer (xattr-backed block writer/verifier).
+
+### Phases
+
+Run in sequence; each timed independently and reported as ops/sec:
+
+1. **Create** — each worker creates N files, writing one verifiable block per file
+   via `xattrstore.Writer` (data + xattr header in one operation)
+2. **Stat** — `stat` each file; measures metadata lookup rate
+3. **Read** — `open` + read block + `block.VerifyBlock` + `close`; read phase
+   doubles as an integrity check (unlike plain mdtest)
+4. **Remove** — `unlink` each file
+
+### Directory modes
+
+- **Unique dirs** (default) — each worker gets its own subdirectory, no contention
+- **Shared dir** — all workers operate in one directory, stresses the metadata server
+
+### File size
+
+One block per file, small default (e.g. 4 KiB). Configurable — useful for measuring
+the interaction between metadata rate and data volume.
+
+### Open design questions
+
+- **Phase selection** — run all four phases by default, with flags to skip individual
+  ones (e.g. `--skip-remove` to leave files in place for a later `verify` pass)?
+- **Tree structure** — mdtest supports branching factor and depth for deep directory
+  trees; start flat for the first pass and add later?
+
+### CLI shape (proposed)
+
+    beegfs iotest mdtest run    -path /mnt/beegfs/testdir -files 1000 -threads 8
+    beegfs iotest mdtest verify -path /mnt/beegfs/testdir
+
+### Library shape (proposed)
+
+    verifyio/bench/mdtest/
+        config.go    — Config, Layout, phase flags
+        runner.go    — per-phase runners, directory layout, Result type
+        verifier.go  — post-run integrity re-check

--- a/verifyio/bench/posixbench/config.go
+++ b/verifyio/bench/posixbench/config.go
@@ -1,0 +1,202 @@
+// Package posixbench implements a POSIX IO benchmark that writes deterministic
+// data patterns to a directory and optionally reads them back for throughput
+// measurement.
+//
+// A manifest (posixbench.json, or posixbench-{hostname}.json for multi-node
+// runs) is written alongside the data files so a subsequent Verifier can
+// regenerate the exact expected bytes for every block using (seed, fileIndex,
+// blockIndex) — no out-of-band state is needed.
+//
+// Typical usage:
+//
+//	cfg := posixbench.DefaultConfig()
+//	cfg.Path = "/mnt/beegfs/bench"
+//	cfg.EnsureSeed()
+//	r, _ := posixbench.NewRunner(cfg)
+//	result, _ := r.Run(true)   // true = also run read phase
+//
+//	v, _ := posixbench.NewVerifier(cfg)
+//	anomalies, _ := v.Verify(nil)
+package posixbench
+
+import (
+	"fmt"
+	mrand "math/rand/v2"
+	"path/filepath"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+)
+
+// Layout controls how data files are distributed across workers.
+type Layout string
+
+const (
+	// Layout1to1 assigns each worker its own set of files.
+	Layout1to1 Layout = "1-to-1"
+	// LayoutNto1 has all workers share one file, each writing a
+	// non-overlapping region.
+	LayoutNto1 Layout = "n-to-1"
+)
+
+// DefaultBlockSize is 4 MiB — a common large-IO transfer size.
+const DefaultBlockSize = 4 * 1024 * 1024
+
+// Config is a fully resolved benchmark configuration.
+// Construct with DefaultConfig, override fields, then call EnsureSeed and
+// Validate before passing to NewRunner or NewVerifier.
+type Config struct {
+	Path           string // target directory for data files and manifest
+	Hostname       string // included in data filenames; allows multiple nodes to share one path
+	Threads        int    // number of concurrent worker goroutines
+	BlockSize      int    // IO transfer size in bytes (total on-disk footprint, including ECC stripes when NoXattr=true)
+	FileSize       int64  // per-worker data volume in bytes
+	FilesPerWorker int    // files per worker; ignored when Layout is n-to-1
+	Layout         Layout
+	Kind           block.Kind // data-region pattern
+	Seed           uint64     // must be non-zero before Run or Verify
+	// NoXattr is the throughput-benchmark mode. posixbench never calls
+	// setxattr/getxattr in either mode -- it verifies purely through the
+	// run-level manifest, regenerating each block's expected content from
+	// its (seed, kind) and comparing byte-for-byte against what's on disk,
+	// which catches misdirected, torn, or stale writes as well as bit-rot.
+	// NoXattr trades that depth for speed: instead of the default mode's
+	// full regenerate-and-compare, it writes per-stripe CRC32C checksums
+	// (ECC) directly into the data files and verification is limited to
+	// checking those in-file stripes for internal self-consistency, which
+	// detects bit-rot / in-place corruption but NOT misdirected, torn, or
+	// stale writes. BlockSize is embedded in the data filenames so the
+	// verifier can locate the ECC region. Use the default mode when full
+	// content verification is required.
+	NoXattr bool
+}
+
+// DefaultConfig returns a Config with sensible defaults. Set Path before use.
+func DefaultConfig() Config {
+	return Config{
+		Threads:        4,
+		BlockSize:      DefaultBlockSize,
+		FileSize:       1 * 1024 * 1024 * 1024,
+		FilesPerWorker: 1,
+		Layout:         Layout1to1,
+		Kind:           block.KindDecimal,
+	}
+}
+
+// EnsureSeed fills Seed with a random value if it is zero. The chosen seed
+// is written into the manifest so Verify can reconstruct expected data.
+func (c *Config) EnsureSeed() {
+	for c.Seed == 0 {
+		c.Seed = mrand.Uint64()
+	}
+}
+
+// Validate returns the first configuration error found.
+func (c *Config) Validate() error {
+	if c.Path == "" {
+		return fmt.Errorf("posixbench: path is required")
+	}
+	if c.Threads <= 0 {
+		return fmt.Errorf("posixbench: threads must be > 0 (got %d)", c.Threads)
+	}
+	if c.BlockSize <= 0 {
+		return fmt.Errorf("posixbench: blockSize must be > 0 (got %d)", c.BlockSize)
+	}
+	if c.FileSize <= 0 {
+		return fmt.Errorf("posixbench: fileSize must be > 0 (got %d)", c.FileSize)
+	}
+	if c.FileSize%int64(c.BlockSize) != 0 {
+		return fmt.Errorf("posixbench: fileSize (%d) must be a multiple of blockSize (%d)",
+			c.FileSize, c.BlockSize)
+	}
+	if c.NoXattr {
+		if _, err := block.BodyLen(c.BlockSize); err != nil {
+			return fmt.Errorf("posixbench: --no-xattr requires a block-size that partitions evenly into body+ECC stripes: %w", err)
+		}
+	}
+	switch c.Layout {
+	case Layout1to1:
+		if c.FilesPerWorker <= 0 {
+			return fmt.Errorf("posixbench: filesPerWorker must be > 0 (got %d)", c.FilesPerWorker)
+		}
+	case LayoutNto1:
+		// FilesPerWorker is unused; no additional constraint.
+	default:
+		return fmt.Errorf("posixbench: unknown layout %q (want 1-to-1 or n-to-1)", c.Layout)
+	}
+	return nil
+}
+
+// region describes a contiguous byte range within a single file that one
+// worker owns for reading or writing.
+type region struct {
+	path      string // path to the data file
+	fileIndex int    // stable identifier for this region, used by blockSeed
+	startOff  int64  // first byte this worker reads or writes
+	length    int64  // number of bytes in this region
+	exclusive bool   // true when this worker owns the whole file (1-to-1)
+}
+
+// pbenchFilePrefix returns the filename prefix workerRegions and Run's
+// n-to-1 preallocation step both derive shared/per-file names from -- kept
+// in one place so the two can't drift out of sync (they did once: Run's
+// preallocation omitted the "-bs<N>" suffix NoXattr adds here, so every
+// worker opened a shared-file path that preallocate had never created).
+func pbenchFilePrefix(cfg Config) string {
+	prefix := "pbench"
+	if cfg.Hostname != "" {
+		prefix = "pbench-" + cfg.Hostname
+	}
+	if cfg.NoXattr {
+		prefix = fmt.Sprintf("%s-bs%d", prefix, cfg.BlockSize)
+	}
+	return prefix
+}
+
+// workerRegions returns the regions assigned to each worker for cfg.
+// Element [i] is the slice of regions that worker i owns.
+func workerRegions(cfg Config) [][]region {
+	out := make([][]region, cfg.Threads)
+	prefix := pbenchFilePrefix(cfg)
+
+	switch cfg.Layout {
+	case LayoutNto1:
+		shared := filepath.Join(cfg.Path, prefix+"-shared.dat")
+		for w := 0; w < cfg.Threads; w++ {
+			out[w] = []region{{
+				path:      shared,
+				fileIndex: w, // each worker's region has a distinct seed namespace
+				startOff:  int64(w) * cfg.FileSize,
+				length:    cfg.FileSize,
+				exclusive: false, // shared file; pre-allocated by Runner
+			}}
+		}
+	default: // Layout1to1
+		for w := 0; w < cfg.Threads; w++ {
+			regions := make([]region, cfg.FilesPerWorker)
+			for f := 0; f < cfg.FilesPerWorker; f++ {
+				fi := w*cfg.FilesPerWorker + f
+				regions[f] = region{
+					path: filepath.Join(cfg.Path,
+						fmt.Sprintf("%s-w%03d-f%03d.dat", prefix, w, f)),
+					fileIndex: fi,
+					startOff:  0,
+					length:    cfg.FileSize,
+					exclusive: true,
+				}
+			}
+			out[w] = regions
+		}
+	}
+	return out
+}
+
+// blockSeed returns the deterministic seed for the block at (fileIndex,
+// blockIndex within the region). Two calls with identical arguments always
+// return the same value — the invariant that lets Verifier regenerate
+// expected data without any side-channel storage.
+//
+// Assumption: fileIndex < 2^32 and blockIndex < 2^32. At DefaultBlockSize
+// those limits imply files up to 16 TiB each, well beyond practical sizes.
+func blockSeed(userSeed uint64, fileIndex int, blockIndex int64) uint64 {
+	return userSeed ^ uint64(fileIndex)<<32 ^ uint64(blockIndex)
+}

--- a/verifyio/bench/posixbench/manifest.go
+++ b/verifyio/bench/posixbench/manifest.go
@@ -1,0 +1,115 @@
+package posixbench
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+)
+
+const manifestVersion = 1
+const manifestFileName = "posixbench.json"
+
+// ManifestPath returns the path of the manifest file for dir and hostname.
+// When hostname is non-empty the filename is posixbench-{hostname}.json so
+// that multiple nodes can share a directory without clobbering each other.
+func ManifestPath(dir, hostname string) string {
+	return manifestPath(dir, hostname)
+}
+
+// Manifest is the on-disk record of a run. It contains everything Verifier
+// needs to reconstruct the expected data for every block.
+type Manifest struct {
+	Version        int    `json:"version"`
+	Seed           uint64 `json:"seed"`
+	BlockSize      int    `json:"blockSize"`
+	Kind           string `json:"kind"`
+	FilesPerWorker int    `json:"filesPerWorker"`
+	FileSize       int64  `json:"fileSize"`
+	WorkerCount    int    `json:"workerCount"`
+	Layout         string `json:"layout"`
+	Hostname       string `json:"hostname,omitempty"`
+	NoXattr        bool   `json:"noXattr,omitempty"`
+}
+
+func manifestPath(dir, hostname string) string {
+	if hostname != "" {
+		return filepath.Join(dir, fmt.Sprintf("posixbench-%s.json", hostname))
+	}
+	return filepath.Join(dir, manifestFileName)
+}
+
+func configToManifest(c Config) Manifest {
+	return Manifest{
+		Version:        manifestVersion,
+		Seed:           c.Seed,
+		BlockSize:      c.BlockSize,
+		Kind:           c.Kind.String(),
+		FilesPerWorker: c.FilesPerWorker,
+		FileSize:       c.FileSize,
+		WorkerCount:    c.Threads,
+		Layout:         string(c.Layout),
+		Hostname:       c.Hostname,
+		NoXattr:        c.NoXattr,
+	}
+}
+
+func manifestToConfig(m Manifest, dir string) (Config, error) {
+	kind, err := block.KindFromString(m.Kind)
+	if err != nil {
+		return Config{}, fmt.Errorf("posixbench manifest: kind: %w", err)
+	}
+	return Config{
+		Path:           dir,
+		Threads:        m.WorkerCount,
+		BlockSize:      m.BlockSize,
+		FileSize:       m.FileSize,
+		FilesPerWorker: m.FilesPerWorker,
+		Layout:         Layout(m.Layout),
+		Kind:           kind,
+		Seed:           m.Seed,
+		Hostname:       m.Hostname,
+		NoXattr:        m.NoXattr,
+	}, nil
+}
+
+func writeManifest(dir string, m Manifest) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("posixbench: marshal manifest: %w", err)
+	}
+	p := manifestPath(dir, m.Hostname)
+	if err := os.WriteFile(p, append(data, '\n'), 0644); err != nil {
+		return fmt.Errorf("posixbench: write manifest %s: %w", p, err)
+	}
+	return nil
+}
+
+// ReadManifest reads and parses the manifest written by a previous Run in dir
+// that was started without a hostname (i.e. the CLI bench run command).
+// Use ReadManifestHost when the run was started with a hostname set.
+func ReadManifest(dir string) (Config, error) {
+	return ReadManifestHost(dir, "")
+}
+
+// ReadManifestHost reads and parses the manifest for the given hostname.
+// When hostname is non-empty it looks for posixbench-{hostname}.json;
+// when empty it looks for posixbench.json.
+func ReadManifestHost(dir, hostname string) (Config, error) {
+	p := manifestPath(dir, hostname)
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return Config{}, fmt.Errorf("posixbench.ReadManifest: %w", err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Config{}, fmt.Errorf("posixbench.ReadManifest: parse %s: %w", p, err)
+	}
+	if m.Version != manifestVersion {
+		return Config{}, fmt.Errorf("posixbench.ReadManifest: unsupported version %d (want %d)",
+			m.Version, manifestVersion)
+	}
+	return manifestToConfig(m, dir)
+}

--- a/verifyio/bench/posixbench/posixbench_test.go
+++ b/verifyio/bench/posixbench/posixbench_test.go
@@ -1,0 +1,420 @@
+// This is a unit test.
+//
+// Coverage: Config.Validate (including that FilesPerWorker is exempt from
+// its >0 constraint under n-to-1 layout); blockSeed determinism; manifest
+// JSON round-trip; an end-to-end write-then-verify pass on a clean run for
+// both 1-to-1 and n-to-1 layouts, with multiple files per worker and an
+// optional read phase; the verifier correctly flagging injected corruption;
+// and n-to-1 combined with NoXattr, a regression test for Run's
+// preallocation step and workerRegions independently deriving the shared
+// filename and drifting out of sync.
+package posixbench
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+)
+
+func TestConfigValidate(t *testing.T) {
+	good := Config{
+		Path:           "/tmp/test",
+		Threads:        2,
+		BlockSize:      4096,
+		FileSize:       4096 * 4,
+		FilesPerWorker: 1,
+		Layout:         Layout1to1,
+		Kind:           block.KindDecimal,
+		Seed:           1,
+	}
+	if err := good.Validate(); err != nil {
+		t.Fatalf("good config: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{"empty path", func(c *Config) { c.Path = "" }},
+		{"zero threads", func(c *Config) { c.Threads = 0 }},
+		{"zero blockSize", func(c *Config) { c.BlockSize = 0 }},
+		{"zero fileSize", func(c *Config) { c.FileSize = 0 }},
+		{"unaligned fileSize", func(c *Config) { c.FileSize = 4096*4 + 1 }},
+		{"bad layout", func(c *Config) { c.Layout = Layout("bad") }},
+		{"zero filesPerWorker", func(c *Config) { c.FilesPerWorker = 0 }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := good
+			tc.mutate(&c)
+			if err := c.Validate(); err == nil {
+				t.Errorf("expected error for %q, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestNto1ValidateNoFilesPerWorkerConstraint(t *testing.T) {
+	// n-to-1 does not require FilesPerWorker > 0.
+	cfg := Config{
+		Path:      "/tmp/test",
+		Threads:   2,
+		BlockSize: 4096,
+		FileSize:  4096 * 4,
+		Layout:    LayoutNto1,
+		Kind:      block.KindDecimal,
+		Seed:      1,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("n-to-1 with zero FilesPerWorker: %v", err)
+	}
+}
+
+func TestBlockSeedDeterministic(t *testing.T) {
+	const userSeed = uint64(0xdeadbeefcafe1234)
+
+	a := blockSeed(userSeed, 3, 100)
+	b := blockSeed(userSeed, 3, 100)
+	if a != b {
+		t.Errorf("blockSeed not deterministic: %x != %x", a, b)
+	}
+	// Different fileIndex must produce a different seed.
+	if c := blockSeed(userSeed, 4, 100); a == c {
+		t.Errorf("blockSeed identical for fileIndex 3 and 4")
+	}
+	// Different blockIndex must produce a different seed.
+	if d := blockSeed(userSeed, 3, 101); a == d {
+		t.Errorf("blockSeed identical for blockIndex 100 and 101")
+	}
+	// Different userSeed must produce a different seed.
+	if e := blockSeed(userSeed+1, 3, 100); a == e {
+		t.Errorf("blockSeed identical for different userSeeds")
+	}
+}
+
+func TestManifestRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Path:           dir,
+		Threads:        3,
+		BlockSize:      8192,
+		FileSize:       8192 * 10,
+		FilesPerWorker: 2,
+		Layout:         Layout1to1,
+		Kind:           block.KindDecimal,
+		Seed:           0xabcdef1234,
+	}
+	if err := writeManifest(dir, configToManifest(cfg)); err != nil {
+		t.Fatalf("writeManifest: %v", err)
+	}
+	got, err := ReadManifest(dir)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	if got.Seed != cfg.Seed {
+		t.Errorf("Seed: got %x, want %x", got.Seed, cfg.Seed)
+	}
+	if got.BlockSize != cfg.BlockSize {
+		t.Errorf("BlockSize: got %d, want %d", got.BlockSize, cfg.BlockSize)
+	}
+	if got.FileSize != cfg.FileSize {
+		t.Errorf("FileSize: got %d, want %d", got.FileSize, cfg.FileSize)
+	}
+	if got.Layout != cfg.Layout {
+		t.Errorf("Layout: got %q, want %q", got.Layout, cfg.Layout)
+	}
+	if got.Kind != cfg.Kind {
+		t.Errorf("Kind: got %v, want %v", got.Kind, cfg.Kind)
+	}
+	if got.Threads != cfg.Threads {
+		t.Errorf("Threads: got %d, want %d", got.Threads, cfg.Threads)
+	}
+}
+
+func TestRunnerAndVerifierClean(t *testing.T) {
+	const (
+		blockSize = 4096
+		fileSize  = 4096 * 8
+		threads   = 2
+	)
+	dir := t.TempDir()
+	cfg := Config{
+		Path:           dir,
+		Threads:        threads,
+		BlockSize:      blockSize,
+		FileSize:       fileSize,
+		FilesPerWorker: 1,
+		Layout:         Layout1to1,
+		Kind:           block.KindDecimal,
+		Seed:           42,
+	}
+	r, err := NewRunner(cfg)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	res, err := r.Run(false)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if want := int64(threads * fileSize); res.TotalWritten != want {
+		t.Errorf("TotalWritten=%d, want %d", res.TotalWritten, want)
+	}
+	if res.WriteElapsed == 0 {
+		t.Errorf("WriteElapsed is zero")
+	}
+
+	v, err := NewVerifier(cfg)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	n, err := v.Verify(nil)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Verify: %d anomalies, want 0", n)
+	}
+}
+
+func TestVerifierDetectsCorruption(t *testing.T) {
+	const (
+		blockSize = 4096
+		fileSize  = 4096 * 4
+	)
+	dir := t.TempDir()
+	cfg := Config{
+		Path:           dir,
+		Threads:        1,
+		BlockSize:      blockSize,
+		FileSize:       fileSize,
+		FilesPerWorker: 1,
+		Layout:         Layout1to1,
+		Kind:           block.KindDecimal,
+		Seed:           99,
+	}
+	r, err := NewRunner(cfg)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	if _, err := r.Run(false); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Corrupt one byte in the first block. KindDecimal produces bytes in
+	// ['0'-'9', ' '] so 0xFF is always a detectable mismatch.
+	dataFile := filepath.Join(dir, "pbench-w000-f000.dat")
+	f, err := os.OpenFile(dataFile, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open data file: %v", err)
+	}
+	if _, err := f.WriteAt([]byte{0xFF}, 100); err != nil {
+		t.Fatalf("corrupt byte: %v", err)
+	}
+	f.Close()
+
+	v, err := NewVerifier(cfg)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	var anomalies []Anomaly
+	n, err := v.Verify(func(a Anomaly) error {
+		anomalies = append(anomalies, a)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if n == 0 || len(anomalies) == 0 {
+		t.Error("Verify: expected at least one anomaly after corruption, got none")
+	}
+	if anomalies[0].BlockIndex != 0 {
+		t.Errorf("first anomaly: BlockIndex=%d, want 0", anomalies[0].BlockIndex)
+	}
+}
+
+func TestRunnerNto1(t *testing.T) {
+	const (
+		blockSize = 4096
+		fileSize  = 4096 * 4
+		threads   = 3
+	)
+	dir := t.TempDir()
+	cfg := Config{
+		Path:      dir,
+		Threads:   threads,
+		BlockSize: blockSize,
+		FileSize:  fileSize,
+		Layout:    LayoutNto1,
+		Kind:      block.KindDecimal,
+		Seed:      77,
+	}
+	r, err := NewRunner(cfg)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	res, err := r.Run(false)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if want := int64(threads) * fileSize; res.TotalWritten != want {
+		t.Errorf("TotalWritten=%d, want %d", res.TotalWritten, want)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "pbench-shared.dat"))
+	if err != nil {
+		t.Fatalf("stat shared file: %v", err)
+	}
+	if want := int64(threads) * fileSize; info.Size() != want {
+		t.Errorf("shared file size=%d, want %d", info.Size(), want)
+	}
+
+	v, err := NewVerifier(cfg)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	n, err := v.Verify(nil)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("n-to-1 Verify: %d anomalies, want 0", n)
+	}
+}
+
+// TestRunnerNto1NoXattr is a regression test: Run's n-to-1 preallocation
+// step and workerRegions used to derive the shared filename independently,
+// and only workerRegions accounted for NoXattr's "-bs<N>" suffix, so every
+// worker opened a shared-file path preallocate had never created. Both now
+// go through the single pbenchFilePrefix helper.
+func TestRunnerNto1NoXattr(t *testing.T) {
+	const (
+		blockSize = 4096
+		fileSize  = 4096 * 4
+		threads   = 3
+	)
+	dir := t.TempDir()
+	cfg := Config{
+		Path:      dir,
+		Threads:   threads,
+		BlockSize: blockSize,
+		FileSize:  fileSize,
+		Layout:    LayoutNto1,
+		NoXattr:   true,
+		Kind:      block.KindDecimal,
+		Seed:      77,
+	}
+	r, err := NewRunner(cfg)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	res, err := r.Run(false)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if want := int64(threads) * fileSize; res.TotalWritten != want {
+		t.Errorf("TotalWritten=%d, want %d", res.TotalWritten, want)
+	}
+
+	wantPath := filepath.Join(dir, fmt.Sprintf("pbench-bs%d-shared.dat", blockSize))
+	info, err := os.Stat(wantPath)
+	if err != nil {
+		t.Fatalf("stat shared file %s: %v", wantPath, err)
+	}
+	if want := int64(threads) * fileSize; info.Size() != want {
+		t.Errorf("shared file size=%d, want %d", info.Size(), want)
+	}
+
+	v, err := NewVerifier(cfg)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	n, err := v.Verify(nil)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("n-to-1 NoXattr Verify: %d anomalies, want 0", n)
+	}
+}
+
+func TestRunnerWithReadPhase(t *testing.T) {
+	const (
+		blockSize = 4096
+		fileSize  = 4096 * 4
+	)
+	dir := t.TempDir()
+	cfg := Config{
+		Path:           dir,
+		Threads:        2,
+		BlockSize:      blockSize,
+		FileSize:       fileSize,
+		FilesPerWorker: 1,
+		Layout:         Layout1to1,
+		Kind:           block.KindDecimal,
+		Seed:           55,
+	}
+	r, err := NewRunner(cfg)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	res, err := r.Run(true)
+	if err != nil {
+		t.Fatalf("Run(read=true): %v", err)
+	}
+	want := int64(2 * fileSize)
+	if res.TotalWritten != want {
+		t.Errorf("TotalWritten=%d, want %d", res.TotalWritten, want)
+	}
+	if res.TotalRead != want {
+		t.Errorf("TotalRead=%d, want %d", res.TotalRead, want)
+	}
+	if res.ReadElapsed == 0 {
+		t.Errorf("ReadElapsed=0 after read phase")
+	}
+}
+
+func TestMultipleFilesPerWorker(t *testing.T) {
+	const (
+		blockSize = 4096
+		fileSize  = 4096 * 2
+		threads   = 2
+		fpw       = 3
+	)
+	dir := t.TempDir()
+	cfg := Config{
+		Path:           dir,
+		Threads:        threads,
+		BlockSize:      blockSize,
+		FileSize:       fileSize,
+		FilesPerWorker: fpw,
+		Layout:         Layout1to1,
+		Kind:           block.KindPRNG,
+		Seed:           123,
+	}
+	r, err := NewRunner(cfg)
+	if err != nil {
+		t.Fatalf("NewRunner: %v", err)
+	}
+	res, err := r.Run(false)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if want := int64(threads*fpw) * fileSize; res.TotalWritten != want {
+		t.Errorf("TotalWritten=%d, want %d", res.TotalWritten, want)
+	}
+
+	v, err := NewVerifier(cfg)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	n, err := v.Verify(nil)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("Verify: %d anomalies, want 0", n)
+	}
+}

--- a/verifyio/bench/posixbench/result.go
+++ b/verifyio/bench/posixbench/result.go
@@ -1,0 +1,123 @@
+package posixbench
+
+import (
+	"math"
+	"time"
+)
+
+// WorkerResult holds the outcome of a single worker goroutine.
+type WorkerResult struct {
+	WorkerID     int
+	BytesWritten int64
+	WriteElapsed time.Duration
+	WriteErr     error
+	BytesRead    int64
+	ReadElapsed  time.Duration
+	ReadErr      error
+}
+
+// workerMBps returns the worker's bandwidth in MB/s (SI: 1 MB = 10^6 bytes)
+// for the given bytes and elapsed time, or 0 if elapsed is non-positive.
+func workerMBps(bytes int64, elapsed time.Duration) float64 {
+	if elapsed <= 0 {
+		return 0
+	}
+	return float64(bytes) / 1_000_000 / elapsed.Seconds()
+}
+
+// BandwidthStats summarises per-worker bandwidth across all workers.
+type BandwidthStats struct {
+	MinMBps    float64
+	MaxMBps    float64
+	MeanMBps   float64
+	StdDevMBps float64
+}
+
+// Result aggregates outcomes from all workers for a Run.
+type Result struct {
+	Workers      []WorkerResult
+	TotalWritten int64
+	WriteElapsed time.Duration // wall-clock time for the whole write phase
+	TotalRead    int64
+	ReadElapsed  time.Duration // wall-clock time for the read phase; zero if skipped
+}
+
+// WriteMBps returns aggregate write bandwidth in MB/s (SI: 1 MB = 10^6 bytes).
+func (r Result) WriteMBps() float64 {
+	if r.WriteElapsed <= 0 {
+		return 0
+	}
+	return float64(r.TotalWritten) / 1_000_000 / r.WriteElapsed.Seconds()
+}
+
+// ReadMBps returns aggregate read bandwidth in MB/s (SI: 1 MB = 10^6 bytes).
+// Returns 0 if no read phase was run.
+func (r Result) ReadMBps() float64 {
+	if r.ReadElapsed <= 0 {
+		return 0
+	}
+	return float64(r.TotalRead) / 1_000_000 / r.ReadElapsed.Seconds()
+}
+
+// WriteStats returns per-worker write bandwidth statistics.
+func (r Result) WriteStats() BandwidthStats {
+	return bandwidthStats(r.Workers, func(w WorkerResult) (int64, time.Duration) {
+		return w.BytesWritten, w.WriteElapsed
+	})
+}
+
+// ReadStats returns per-worker read bandwidth statistics. Returns a zero
+// BandwidthStats if no read phase was run.
+func (r Result) ReadStats() BandwidthStats {
+	return bandwidthStats(r.Workers, func(w WorkerResult) (int64, time.Duration) {
+		return w.BytesRead, w.ReadElapsed
+	})
+}
+
+func bandwidthStats(workers []WorkerResult, field func(WorkerResult) (int64, time.Duration)) BandwidthStats {
+	if len(workers) == 0 {
+		return BandwidthStats{}
+	}
+	var vals []float64
+	for _, w := range workers {
+		bytes, elapsed := field(w)
+		if elapsed > 0 {
+			vals = append(vals, workerMBps(bytes, elapsed))
+		}
+	}
+	if len(vals) == 0 {
+		return BandwidthStats{}
+	}
+	min, max, sum := vals[0], vals[0], 0.0
+	for _, v := range vals {
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+		sum += v
+	}
+	mean := sum / float64(len(vals))
+	var variance float64
+	for _, v := range vals {
+		d := v - mean
+		variance += d * d
+	}
+	variance /= float64(len(vals))
+	return BandwidthStats{
+		MinMBps:    min,
+		MaxMBps:    max,
+		MeanMBps:   mean,
+		StdDevMBps: math.Sqrt(variance),
+	}
+}
+
+// Anomaly describes a single verification failure.
+type Anomaly struct {
+	File       string // path of the affected file
+	FileIndex  int    // region index passed to blockSeed
+	BlockIndex int64  // block index within the region
+	Offset     int64  // byte offset within the file
+	Err        error
+}

--- a/verifyio/bench/posixbench/runner.go
+++ b/verifyio/bench/posixbench/runner.go
@@ -1,0 +1,213 @@
+package posixbench
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+)
+
+// Runner executes a posixbench write (and optionally read) workload.
+type Runner struct {
+	cfg Config
+}
+
+// NewRunner creates a Runner from cfg. cfg must pass Validate and have a
+// non-zero Seed before this call.
+func NewRunner(cfg Config) (*Runner, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if cfg.Seed == 0 {
+		return nil, fmt.Errorf("posixbench.NewRunner: seed is zero; call cfg.EnsureSeed() first")
+	}
+	return &Runner{cfg: cfg}, nil
+}
+
+// Run executes the write phase and, if doRead is true, a sequential read
+// phase for bandwidth measurement. The manifest is written before IO begins
+// so Verify can always find the run parameters.
+//
+// If any worker encounters a fatal IO error, Run returns the first such error
+// alongside a partial Result (bytes written/read up to that point are still
+// reported).
+func (r *Runner) Run(doRead bool) (Result, error) {
+	if err := os.MkdirAll(r.cfg.Path, 0755); err != nil {
+		return Result{}, fmt.Errorf("posixbench.Run: mkdir %s: %w", r.cfg.Path, err)
+	}
+	if err := writeManifest(r.cfg.Path, configToManifest(r.cfg)); err != nil {
+		return Result{}, fmt.Errorf("posixbench.Run: %w", err)
+	}
+
+	// For n-to-1, the shared file must exist at full size before workers
+	// begin writing to arbitrary offsets within it.
+	if r.cfg.Layout == LayoutNto1 {
+		sharedPath := filepath.Join(r.cfg.Path, pbenchFilePrefix(r.cfg)+"-shared.dat")
+		totalSize := int64(r.cfg.Threads) * r.cfg.FileSize
+		if err := preallocate(sharedPath, totalSize); err != nil {
+			return Result{}, fmt.Errorf("posixbench.Run: preallocate: %w", err)
+		}
+	}
+
+	assignments := workerRegions(r.cfg)
+	workers := make([]WorkerResult, r.cfg.Threads)
+
+	// Write phase.
+	var wg sync.WaitGroup
+	writeStart := time.Now()
+	for i := 0; i < r.cfg.Threads; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			workers[id].WorkerID = id
+			t := time.Now()
+			workers[id].BytesWritten, workers[id].WriteErr = writeRegions(r.cfg, assignments[id])
+			workers[id].WriteElapsed = time.Since(t)
+		}(i)
+	}
+	wg.Wait()
+
+	res := Result{Workers: workers, WriteElapsed: time.Since(writeStart)}
+	for i := range workers {
+		res.TotalWritten += workers[i].BytesWritten
+	}
+	for i := range workers {
+		if workers[i].WriteErr != nil {
+			return res, fmt.Errorf("posixbench.Run: worker %d: %w", i, workers[i].WriteErr)
+		}
+	}
+
+	if !doRead {
+		return res, nil
+	}
+
+	// Read phase (bandwidth measurement only; no verification).
+	readStart := time.Now()
+	for i := 0; i < r.cfg.Threads; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			t := time.Now()
+			workers[id].BytesRead, workers[id].ReadErr = readRegions(r.cfg, assignments[id])
+			workers[id].ReadElapsed = time.Since(t)
+		}(i)
+	}
+	wg.Wait()
+
+	res.ReadElapsed = time.Since(readStart)
+	for i := range workers {
+		res.TotalRead += workers[i].BytesRead
+	}
+	for i := range workers {
+		if workers[i].ReadErr != nil {
+			return res, fmt.Errorf("posixbench.Run: read worker %d: %w", i, workers[i].ReadErr)
+		}
+	}
+
+	return res, nil
+}
+
+// preallocate creates (or truncates) the file at path to exactly size bytes.
+// On Linux this produces a sparse file; actual disk blocks are allocated on
+// first write.
+func preallocate(path string, size int64) (err error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+	return f.Truncate(size)
+}
+
+// writeRegions iterates over all regions assigned to one worker and returns
+// the total bytes written.
+func writeRegions(cfg Config, regions []region) (int64, error) {
+	buf := make([]byte, cfg.BlockSize)
+	var total int64
+	for _, reg := range regions {
+		n, err := writeRegion(cfg, reg, buf)
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+func writeRegion(cfg Config, reg region, buf []byte) (written int64, err error) {
+	var flags int
+	if reg.exclusive {
+		flags = os.O_CREATE | os.O_RDWR | os.O_TRUNC
+	} else {
+		flags = os.O_RDWR
+	}
+	f, err := os.OpenFile(reg.path, flags, 0644)
+	if err != nil {
+		return 0, fmt.Errorf("open %s: %w", reg.path, err)
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	var bodyLen int
+	if cfg.NoXattr {
+		bodyLen, err = block.BodyLen(cfg.BlockSize)
+		if err != nil {
+			return 0, fmt.Errorf("block size %d: %w", cfg.BlockSize, err)
+		}
+	}
+
+	blocks := reg.length / int64(cfg.BlockSize)
+	for b := int64(0); b < blocks; b++ {
+		seed := blockSeed(cfg.Seed, reg.fileIndex, b)
+		off := reg.startOff + b*int64(cfg.BlockSize)
+		if cfg.NoXattr {
+			var hdr block.Header
+			if err := block.MakeBlock(buf, &hdr, cfg.Kind, seed, bodyLen); err != nil {
+				return written, fmt.Errorf("generate ECC block %d in %s: %w", b, reg.path, err)
+			}
+		} else {
+			if err := block.GenerateBody(cfg.Kind, seed, buf); err != nil {
+				return written, fmt.Errorf("generate block %d in %s: %w", b, reg.path, err)
+			}
+		}
+		if _, err := f.WriteAt(buf, off); err != nil {
+			return written, fmt.Errorf("write block %d in %s: %w", b, reg.path, err)
+		}
+		written += int64(cfg.BlockSize)
+	}
+	return written, nil
+}
+
+// readRegions reads all blocks in the assigned regions for bandwidth
+// measurement. Data is not verified here; use Verifier for that.
+func readRegions(cfg Config, regions []region) (int64, error) {
+	buf := make([]byte, cfg.BlockSize)
+	var total int64
+	for _, reg := range regions {
+		f, err := os.Open(reg.path)
+		if err != nil {
+			return total, fmt.Errorf("open %s for read: %w", reg.path, err)
+		}
+		blocks := reg.length / int64(cfg.BlockSize)
+		for b := int64(0); b < blocks; b++ {
+			off := reg.startOff + b*int64(cfg.BlockSize)
+			if _, err := f.ReadAt(buf, off); err != nil {
+				f.Close()
+				return total, fmt.Errorf("read block %d in %s: %w", b, reg.path, err)
+			}
+			total += int64(cfg.BlockSize)
+		}
+		f.Close()
+	}
+	return total, nil
+}

--- a/verifyio/bench/posixbench/verifier.go
+++ b/verifyio/bench/posixbench/verifier.go
@@ -1,0 +1,193 @@
+package posixbench
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+)
+
+// eccTable is the CRC32C polynomial used for ECC stripe verification.
+var eccTable = crc32.MakeTable(crc32.Castagnoli)
+
+// Verifier checks data files written by Runner against the expected pattern
+// derived from the manifest seed.
+type Verifier struct {
+	cfg Config
+}
+
+// NewVerifier creates a Verifier from cfg. cfg is typically obtained from
+// ReadManifest. cfg must pass Validate and have a non-zero Seed.
+func NewVerifier(cfg Config) (*Verifier, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if cfg.Seed == 0 {
+		return nil, fmt.Errorf("posixbench.NewVerifier: seed is zero")
+	}
+	return &Verifier{cfg: cfg}, nil
+}
+
+// Verify reads every block in every region and checks it for integrity.
+//
+// When cfg.NoXattr is false (the default), each block is compared byte-for-byte
+// against the pattern regenerated from (seed, fileIndex, blockIndex).
+//
+// When cfg.NoXattr is true, each block is verified using the per-stripe CRC32C
+// checksums embedded in the data file (ECC-only; no body regeneration).
+//
+// fn is called once per anomaly; if fn returns a non-nil error Verify stops
+// and returns that error. Pass nil to count anomalies without inspecting them.
+//
+// Returns the total number of anomalies found and any error from fn or IO.
+func (v *Verifier) Verify(fn func(Anomaly) error) (int, error) {
+	if fn == nil {
+		fn = func(Anomaly) error { return nil }
+	}
+
+	// Flatten all per-worker region assignments into a single list.
+	// For n-to-1 this produces one region per worker, each with a distinct
+	// fileIndex and startOff into the shared file.
+	var regions []region
+	for _, workerRegs := range workerRegions(v.cfg) {
+		regions = append(regions, workerRegs...)
+	}
+
+	buf := make([]byte, v.cfg.BlockSize)
+	anomalies := 0
+
+	if v.cfg.NoXattr {
+		return v.verifyECC(regions, buf, fn)
+	}
+
+	expected := make([]byte, v.cfg.BlockSize)
+
+	for _, reg := range regions {
+		f, err := os.Open(reg.path)
+		if err != nil {
+			return anomalies, fmt.Errorf("posixbench.Verify: open %s: %w", reg.path, err)
+		}
+
+		blocks := reg.length / int64(v.cfg.BlockSize)
+		for b := int64(0); b < blocks; b++ {
+			seed := blockSeed(v.cfg.Seed, reg.fileIndex, b)
+			if err := block.GenerateBody(v.cfg.Kind, seed, expected); err != nil {
+				f.Close()
+				return anomalies, fmt.Errorf("posixbench.Verify: generate: %w", err)
+			}
+			off := reg.startOff + b*int64(v.cfg.BlockSize)
+			if _, err := f.ReadAt(buf, off); err != nil {
+				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+					// A short read means the block is truncated or missing. Count
+					// it as an anomaly and keep going rather than aborting the run,
+					// so one bad file can't mask corruption in later files.
+					anomalies++
+					if e := fn(Anomaly{
+						File: reg.path, FileIndex: reg.fileIndex, BlockIndex: b, Offset: off,
+						Err: fmt.Errorf("short read (truncated/missing block): %w", err),
+					}); e != nil {
+						f.Close()
+						return anomalies, e
+					}
+					continue
+				}
+				f.Close()
+				return anomalies, fmt.Errorf("posixbench.Verify: read %s at %d: %w",
+					reg.path, off, err)
+			}
+			if !bytes.Equal(expected, buf) {
+				anomalies++
+				if err := fn(Anomaly{
+					File:       reg.path,
+					FileIndex:  reg.fileIndex,
+					BlockIndex: b,
+					Offset:     off,
+					Err:        fmt.Errorf("data mismatch"),
+				}); err != nil {
+					f.Close()
+					return anomalies, err
+				}
+			}
+		}
+		f.Close()
+	}
+	return anomalies, nil
+}
+
+// verifyECC checks per-stripe CRC32C checksums for all blocks in regions.
+// Each block is laid out as [body: bodyLen bytes][stripe CRCs: numStripes*4 bytes]
+// where the split point is derived from cfg.BlockSize.
+//
+// This is the throughput-benchmark (NoXattr) verification path: the in-file CRC
+// stripes detect bit-rot / in-place corruption only — not misdirected, torn, or
+// stale writes. That is by design; --no-xattr trades verification depth for write
+// speed. Use the default (xattr) mode for full content verification.
+func (v *Verifier) verifyECC(regions []region, buf []byte, fn func(Anomaly) error) (int, error) {
+	bodyLen, err := block.BodyLen(v.cfg.BlockSize)
+	if err != nil {
+		return 0, fmt.Errorf("posixbench.Verify: %w", err)
+	}
+	numStripes := block.NumStripes(bodyLen)
+	anomalies := 0
+
+	for _, reg := range regions {
+		f, err := os.Open(reg.path)
+		if err != nil {
+			return anomalies, fmt.Errorf("posixbench.Verify: open %s: %w", reg.path, err)
+		}
+
+		blocks := reg.length / int64(v.cfg.BlockSize)
+		for b := int64(0); b < blocks; b++ {
+			off := reg.startOff + b*int64(v.cfg.BlockSize)
+			if _, err := f.ReadAt(buf, off); err != nil {
+				if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+					// Truncated/missing block: count and continue (see default path).
+					anomalies++
+					if e := fn(Anomaly{
+						File: reg.path, FileIndex: reg.fileIndex, BlockIndex: b, Offset: off,
+						Err: fmt.Errorf("short read (truncated/missing block): %w", err),
+					}); e != nil {
+						f.Close()
+						return anomalies, e
+					}
+					continue
+				}
+				f.Close()
+				return anomalies, fmt.Errorf("posixbench.Verify: read %s at %d: %w",
+					reg.path, off, err)
+			}
+			body := buf[:bodyLen]
+			crcSlice := buf[bodyLen : bodyLen+numStripes*4]
+			for s := range numStripes {
+				start := s * block.StripeSize
+				end := start + block.StripeSize
+				if end > bodyLen {
+					end = bodyLen
+				}
+				want := binary.LittleEndian.Uint32(crcSlice[s*4 : (s+1)*4])
+				got := crc32.Checksum(body[start:end], eccTable)
+				if want != got {
+					anomalies++
+					if err := fn(Anomaly{
+						File:       reg.path,
+						FileIndex:  reg.fileIndex,
+						BlockIndex: b,
+						Offset:     off,
+						Err:        fmt.Errorf("stripe %d CRC mismatch", s),
+					}); err != nil {
+						f.Close()
+						return anomalies, err
+					}
+					break // one anomaly per block is enough
+				}
+			}
+		}
+		f.Close()
+	}
+	return anomalies, nil
+}

--- a/verifyio/block/bench_test.go
+++ b/verifyio/block/bench_test.go
@@ -1,0 +1,137 @@
+// This is a performance benchmark, not a correctness unit test (no
+// assertions; run with `go test -bench=.`).
+//
+// Coverage: throughput of MakeBlock (full block production), VerifyBlock
+// (stripe-CRC check + body regeneration + compare), and GenerateBody in
+// isolation (pattern generation alone, without CRC overhead) -- each across
+// every body-pattern Kind and a few representative body sizes (4/16/64 KiB).
+package block
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// legendOnce ensures the column legend is printed exactly once per
+// `go test -bench=...` invocation, by the first benchmark to run.
+var legendOnce sync.Once
+
+func printLegend() {
+	legendOnce.Do(func() {
+		fmt.Println("# columns: name-<GOMAXPROCS>  iters  ns/op  MB/s (b.SetBytes)  [B/op  allocs/op with -benchmem]")
+	})
+}
+
+// blockSizes covers a few body sizes likely to matter in practice:
+// 4 KiB (page), 16 KiB, 64 KiB. On-disk size = BlockDataSize(bodyLen).
+var blockSizes = []int{4096, 16 * 1024, 64 * 1024}
+
+// BenchmarkMakeBlock measures the cost of producing a complete block
+// (data-region generation + stripe CRCs). Run for each pattern at each
+// body size; KindDecimal is what most tools use.
+func BenchmarkMakeBlock(b *testing.B) {
+	printLegend()
+	kinds := []Kind{KindZeros, KindCountUp, KindRepeat, KindDecimal, KindPRNG}
+	for _, k := range kinds {
+		for _, bodyLen := range blockSizes {
+			b.Run(k.String()+"/"+sizeLabel(bodyLen), func(b *testing.B) {
+				buf := make([]byte, BlockDataSize(bodyLen))
+				h := Header{}
+				b.SetBytes(int64(BlockDataSize(bodyLen)))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if err := MakeBlock(buf, &h, k, uint64(i), bodyLen); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkVerifyBlock measures end-to-end verification: stripe CRC
+// check + body regeneration + bytes.Equal. Uses pre-built blocks.
+func BenchmarkVerifyBlock(b *testing.B) {
+	printLegend()
+	kinds := []Kind{KindZeros, KindCountUp, KindRepeat, KindDecimal, KindPRNG}
+	for _, k := range kinds {
+		for _, bodyLen := range blockSizes {
+			b.Run(k.String()+"/"+sizeLabel(bodyLen), func(b *testing.B) {
+				buf := make([]byte, BlockDataSize(bodyLen))
+				h := Header{}
+				if err := MakeBlock(buf, &h, k, 1, bodyLen); err != nil {
+					b.Fatal(err)
+				}
+				scratch := make([]byte, bodyLen)
+				b.SetBytes(int64(BlockDataSize(bodyLen)))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					v, _ := VerifyBlock(buf, &h, scratch)
+					if v != VerdictOK {
+						b.Fatalf("verdict=%v", v)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkGenerateBody isolates just the data-region-fill cost. Useful
+// for comparing pattern generators in isolation from CRC noise.
+func BenchmarkGenerateBody(b *testing.B) {
+	printLegend()
+	kinds := []Kind{KindZeros, KindCountUp, KindRepeat, KindDecimal, KindPRNG}
+	for _, k := range kinds {
+		for _, bodyLen := range blockSizes {
+			b.Run(k.String()+"/"+sizeLabel(bodyLen), func(b *testing.B) {
+				out := make([]byte, bodyLen)
+				b.SetBytes(int64(bodyLen))
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					if err := GenerateBody(k, uint64(i), out); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func sizeLabel(n int) string {
+	switch {
+	case n >= 1024*1024:
+		return fmtKB(n / 1024)
+	case n >= 1024:
+		return fmtKB(n / 1024)
+	}
+	return "B"
+}
+
+func fmtKB(kb int) string {
+	return itoa(kb) + "KiB"
+}
+
+// itoa returns a base-10 string. Avoids pulling in strconv just for
+// benchmark labels.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/verifyio/block/block.go
+++ b/verifyio/block/block.go
@@ -1,0 +1,616 @@
+// Package block defines a verifiable block format for IO testing.
+//
+// Every on-disk block consists of a body (deterministic data generated
+// from a seed) followed by per-stripe CRC32C checksums. The header
+// describing the block (seed, kind, node, timestamps, etc.) is stored
+// exclusively in an extended attribute (see package xattrstore) rather
+// than embedded in the block data. Keeping metadata out of the data
+// region makes the on-disk layout cleaner and lets the verifier give
+// precise per-stripe corruption reports.
+//
+// # On-disk layout
+//
+//	[body: BodyLen bytes][stripe CRCs: NumStripes(BodyLen)*4 bytes]
+//
+// The body is divided into StripeSize-byte stripes; a CRC32C (4 bytes,
+// little-endian) for each stripe is appended after the body. The last
+// stripe covers however many bytes remain and need not be a full stripe.
+// Total on-disk size for a given body length is BlockDataSize(bodyLen).
+//
+// Header layout (little-endian, 90 bytes total):
+//
+//	offset  size  field
+//	  0      8    Magic   = "BADGERIO"
+//	  8      2    Version = 3
+//	 10      4    Kind (data-region-generation mode)
+//	 14      8    TimeNs    (time.Now().UnixNano())
+//	 22     16    NodeName  (null-padded hostname of the writing node)
+//	 38      4    TID       (caller-supplied; e.g. kernel TID)
+//	 42      4    WorkerID  (caller-supplied)
+//	 46      4    Tag       bits[7:0]=IOType  bit[8]=Fsynced (see TagIOTypeMask, TagFsynced)
+//	 50      8    Cycle
+//	 58      8    Offset    (byte offset in the target file)
+//	 66      8    BodyLen
+//	 74      8    Seed
+//	 82      4    BodyCRC   (CRC32C over body bytes)
+//	 86      4    HeadCRC   (CRC32C over header bytes [0..86))
+//
+// HeadCRC is computed last and covers everything before it, so a
+// verifier can validate the header as a self-contained object before
+// using any of its fields (BodyLen, Seed, ...) to regenerate and check
+// the body.
+package block
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	mrand "math/rand/v2"
+	"time"
+)
+
+// HeaderSize is the on-wire size of a serialized record header.
+const HeaderSize = 90
+
+// HeaderVersion is the current header format version.
+const HeaderVersion uint16 = 3
+
+// Tag bit layout — the Tag field in Header carries two sub-fields:
+//   - bits 7:0  (TagIOTypeMask): the fileops.IOType used for the write
+//   - bit 8     (TagFsynced): set after a successful Sync() confirmed data
+//     reached the storage servers; clear for buffered writes without a flush.
+//
+// A BODY_CORRUPT anomaly with TagFsynced=true proves the writer flushed
+// before releasing the lock, ruling out a missing fsync as the cause.
+const (
+	TagIOTypeMask uint32 = 0x000000FF
+	TagFsynced    uint32 = 1 << 8
+)
+
+// headerMagic is the 8-byte magic tag at the start of every header.
+// Unexported so external code cannot mutate it (a single rogue
+// assignment would silently break parsing process-wide).
+var headerMagic = [8]byte{'B', 'A', 'D', 'G', 'E', 'R', 'I', 'O'}
+
+// Kind identifies how to regenerate the data region of a block from its header.
+type Kind uint32
+
+const (
+	KindPRNG    Kind = 1 // data region = stream from math/rand/v2 PCG seeded by Seed
+	KindRepeat  Kind = 2 // data region = repeating 8-byte pattern derived from Seed
+	KindCountUp Kind = 3 // data region[i] = byte(Seed + i)
+	KindZeros   Kind = 4 // data region = all zero bytes
+	KindOnes    Kind = 5 // data region = all 0xFF bytes
+	KindDecimal Kind = 6 // data region = "NNN " tokens, NNN = (seed%512 + i) % 512, zero-padded
+)
+
+// String returns the printable name of a data-region-generation Kind.
+func (k Kind) String() string {
+	switch k {
+	case KindPRNG:
+		return "prng"
+	case KindRepeat:
+		return "repeat"
+	case KindCountUp:
+		return "countup"
+	case KindZeros:
+		return "zeros"
+	case KindOnes:
+		return "ones"
+	case KindDecimal:
+		return "decimal"
+	default:
+		return fmt.Sprintf("kind(%d)", uint32(k))
+	}
+}
+
+// KindFromString parses a Kind from its printable name.
+func KindFromString(s string) (Kind, error) {
+	switch s {
+	case "prng":
+		return KindPRNG, nil
+	case "repeat":
+		return KindRepeat, nil
+	case "countup":
+		return KindCountUp, nil
+	case "zeros":
+		return KindZeros, nil
+	case "ones":
+		return KindOnes, nil
+	case "decimal":
+		return KindDecimal, nil
+	default:
+		return 0, fmt.Errorf("unknown pattern %q (want decimal | prng | repeat | countup | zeros | ones)", s)
+	}
+}
+
+// Header is the in-memory form of a record header. The on-wire form is
+// produced by MarshalHeader; the inverse parse is UnmarshalHeader.
+//
+// NodeName holds the null-padded hostname of the node that wrote the
+// record. Use NodeNameFromString / NodeNameString to convert between
+// the [16]byte wire form and a plain string.
+type Header struct {
+	Version  uint16
+	Kind     Kind
+	TimeNs   int64
+	NodeName [16]byte
+	TID      int32
+	WorkerID int32
+	Tag      uint32
+	Cycle    uint64
+	Offset   uint64
+	BodyLen  uint64
+	Seed     uint64
+	BodyCRC  uint32
+}
+
+// NodeNameFromString converts a hostname string into the [16]byte form
+// used by Header.NodeName. Strings longer than 15 characters are
+// truncated; the last byte is always zero.
+func NodeNameFromString(s string) [16]byte {
+	var out [16]byte
+	copy(out[:15], s)
+	return out
+}
+
+// NodeNameString returns the NodeName as a plain string, stripping
+// trailing null bytes.
+func NodeNameString(name [16]byte) string {
+	return string(bytes.TrimRight(name[:], "\x00"))
+}
+
+// String returns a single-line human-readable rendering of the header
+// suitable for log lines and quick eyeballing. TimeNs is rendered as
+// an RFC3339 timestamp; numeric fields that are commonly viewed as
+// bitfields (Tag, Offset, Seed, BodyCRC) are printed in hex.
+//
+// Implements fmt.Stringer so callers can pass a Header (or *Header)
+// straight to fmt.Println, log lines, %s / %v formatters, etc.
+func (h Header) String() string {
+	ts := time.Unix(0, h.TimeNs).UTC().Format(time.RFC3339Nano)
+	return fmt.Sprintf(
+		"ver=%d kind=%s time=%s node=%s tid=%d worker=%d tag=0x%08x "+
+			"cycle=%d offset=0x%x bodyLen=%d seed=0x%016x bodyCRC=0x%08x",
+		h.Version, h.Kind, ts, NodeNameString(h.NodeName), h.TID, h.WorkerID, h.Tag,
+		h.Cycle, h.Offset, h.BodyLen, h.Seed, h.BodyCRC)
+}
+
+// castagnoli is the CRC32C polynomial table. Hardware-accelerated on
+// modern x86_64 and ARM64. Shared across all header and body CRCs.
+var castagnoli = crc32.MakeTable(crc32.Castagnoli)
+
+// MarshalHeader writes the 90-byte on-wire form of h into out (which
+// must have at least HeaderSize bytes). The caller must have already
+// populated h.BodyCRC. HeadCRC is computed over the first 86 bytes and
+// placed in the last four. Returns an error if out is too small.
+func MarshalHeader(out []byte, h *Header) error {
+	if len(out) < HeaderSize {
+		return fmt.Errorf("MarshalHeader: buf too small (%d < %d)", len(out), HeaderSize)
+	}
+
+	// Zero the header region first so reserved bytes are deterministic --
+	// important for the header CRC to be stable.
+	clear(out[:HeaderSize])
+
+	copy(out[0:8], headerMagic[:])
+	binary.LittleEndian.PutUint16(out[8:10], h.Version)
+	binary.LittleEndian.PutUint32(out[10:14], uint32(h.Kind))
+	binary.LittleEndian.PutUint64(out[14:22], uint64(h.TimeNs))
+	copy(out[22:38], h.NodeName[:])
+	binary.LittleEndian.PutUint32(out[38:42], uint32(h.TID))
+	binary.LittleEndian.PutUint32(out[42:46], uint32(h.WorkerID))
+	binary.LittleEndian.PutUint32(out[46:50], h.Tag)
+	binary.LittleEndian.PutUint64(out[50:58], h.Cycle)
+	binary.LittleEndian.PutUint64(out[58:66], h.Offset)
+	binary.LittleEndian.PutUint64(out[66:74], h.BodyLen)
+	binary.LittleEndian.PutUint64(out[74:82], h.Seed)
+	binary.LittleEndian.PutUint32(out[82:86], h.BodyCRC)
+	// HeadCRC covers [0..86).
+	headCRC := crc32.Checksum(out[:86], castagnoli)
+	binary.LittleEndian.PutUint32(out[86:90], headCRC)
+	return nil
+}
+
+// Sentinel errors returned by UnmarshalHeader so callers can distinguish
+// "this isn't one of our records" from "this is ours but is corrupt".
+var (
+	ErrBadMagic   = errors.New("block: bad magic")
+	ErrBadHeadCRC = errors.New("block: header CRC mismatch")
+	ErrBadVersion = errors.New("block: unsupported version")
+	ErrTruncated  = errors.New("block: truncated header")
+)
+
+// UnmarshalHeader parses the on-wire header at in[:HeaderSize]. Returns
+// ErrTruncated for a short buffer, ErrBadMagic for non-verifyio data,
+// ErrBadVersion if the version field doesn't match HeaderVersion,
+// or ErrBadHeadCRC if the CRC fails.
+//
+// On ErrBadVersion and ErrBadHeadCRC the returned Header IS populated
+// from the on-wire bytes -- the values are untrusted but useful for
+// diagnostic logging. On ErrTruncated and ErrBadMagic the returned
+// Header is zero-valued (no usable data).
+func UnmarshalHeader(in []byte) (Header, error) {
+	var h Header
+	if len(in) < HeaderSize {
+		return h, ErrTruncated
+	}
+	if !bytes.Equal(in[:8], headerMagic[:]) {
+		return h, ErrBadMagic
+	}
+
+	// Parse all fields before validating Version / HdrLen / CRC, so
+	// callers receive a populated (untrusted) header alongside any
+	// validation error -- helpful for logging "what was actually on
+	// disk" when something fails.
+	h.Version = binary.LittleEndian.Uint16(in[8:10])
+	h.Kind = Kind(binary.LittleEndian.Uint32(in[10:14]))
+	h.TimeNs = int64(binary.LittleEndian.Uint64(in[14:22]))
+	copy(h.NodeName[:], in[22:38])
+	h.TID = int32(binary.LittleEndian.Uint32(in[38:42]))
+	h.WorkerID = int32(binary.LittleEndian.Uint32(in[42:46]))
+	h.Tag = binary.LittleEndian.Uint32(in[46:50])
+	h.Cycle = binary.LittleEndian.Uint64(in[50:58])
+	h.Offset = binary.LittleEndian.Uint64(in[58:66])
+	h.BodyLen = binary.LittleEndian.Uint64(in[66:74])
+	h.Seed = binary.LittleEndian.Uint64(in[74:82])
+	h.BodyCRC = binary.LittleEndian.Uint32(in[82:86])
+
+	// CRC before Version, deliberately: VerdictHeadBadFormat's whole point is
+	// "the header is internally consistent, it's just a different version
+	// than this verifier expects" -- a claim that requires the CRC to have
+	// actually passed. Checking Version first would let ordinary bit-rot
+	// landing on the Version byte get misclassified as benign version skew
+	// instead of corruption, since ErrBadVersion would return before the CRC
+	// was ever computed.
+	wantCRC := binary.LittleEndian.Uint32(in[86:90])
+	gotCRC := crc32.Checksum(in[:86], castagnoli)
+	if wantCRC != gotCRC {
+		return h, ErrBadHeadCRC
+	}
+	if h.Version != HeaderVersion {
+		return h, fmt.Errorf("%w: got %d, want %d", ErrBadVersion, h.Version, HeaderVersion)
+	}
+	return h, nil
+}
+
+// GenerateBody fills out with deterministic bytes derived from
+// (kind, seed). Two calls with the same (kind, seed, len(out)) always
+// produce the same bytes, which is the invariant verification relies
+// on.
+func GenerateBody(kind Kind, seed uint64, out []byte) error {
+	switch kind {
+	case KindPRNG:
+		// math/rand/v2 PCG is specified -- stable across Go versions --
+		// and fast enough that even 4 KiB bodies are cheap to fill or
+		// verify. Derive the two 64-bit PCG state words deterministically
+		// from seed.
+		src := mrand.NewPCG(seed, ^seed)
+		r := mrand.New(src)
+		i := 0
+		for ; i+8 <= len(out); i += 8 {
+			binary.LittleEndian.PutUint64(out[i:i+8], r.Uint64())
+		}
+		if i < len(out) {
+			var tail [8]byte
+			binary.LittleEndian.PutUint64(tail[:], r.Uint64())
+			copy(out[i:], tail[:len(out)-i])
+		}
+	case KindRepeat:
+		// Body = the 8-byte little-endian encoding of seed, repeated.
+		var pat [8]byte
+		binary.LittleEndian.PutUint64(pat[:], seed)
+		for i := range out {
+			out[i] = pat[i%8]
+		}
+	case KindCountUp:
+		for i := range out {
+			out[i] = byte(seed) + byte(i)
+		}
+	case KindZeros:
+		for i := range out {
+			out[i] = 0
+		}
+	case KindOnes:
+		for i := range out {
+			out[i] = 0xFF
+		}
+	case KindDecimal:
+		// Body is a stream of fixed-width "NNN " tokens (3 zero-padded
+		// decimal digits + one space, 4 bytes each). The starting number
+		// is seed % wrap; each subsequent token is the next integer mod
+		// wrap. Fixed width means the byte offset uniquely determines
+		// the expected token, which makes corruption obvious to the eye
+		// in `less` and trivial for the verifier to localize.
+		const tokenLen = 4
+		const wrap = 512
+		start := uint32(seed % wrap)
+		var tok [tokenLen]byte
+		tok[3] = ' '
+		var tokenIdx uint32
+		for i := 0; i < len(out); {
+			n := (start + tokenIdx) % wrap
+			tok[0] = byte('0' + (n/100)%10)
+			tok[1] = byte('0' + (n/10)%10)
+			tok[2] = byte('0' + n%10)
+			remaining := len(out) - i
+			if remaining >= tokenLen {
+				copy(out[i:i+tokenLen], tok[:])
+				i += tokenLen
+			} else {
+				copy(out[i:], tok[:remaining])
+				i += remaining
+			}
+			tokenIdx++
+		}
+	default:
+		return fmt.Errorf("GenerateBody: unknown kind %v", kind)
+	}
+	return nil
+}
+
+// StripeSize is the granularity of per-block integrity checking. The body
+// is divided into StripeSize-byte stripes; a 4-byte CRC32C checksum for
+// each stripe is appended after the body.
+const StripeSize = 512
+
+// NumStripes returns the number of StripeSize-byte stripes covering a body
+// of bodyLen bytes.
+func NumStripes(bodyLen int) int {
+	return (bodyLen + StripeSize - 1) / StripeSize
+}
+
+// BlockDataSize returns the total on-disk byte count for a block with the
+// given body length: body bytes + one 4-byte CRC32C per stripe.
+func BlockDataSize(bodyLen int) int {
+	return bodyLen + NumStripes(bodyLen)*4
+}
+
+// BodyLen returns the body length for a block of the given total on-disk size.
+// The on-disk layout is [body][stripe CRCs], so blockSize = bodyLen + NumStripes(bodyLen)*4.
+// Not all values are achievable; powers of two (512, 1024, 4096, ...) and multiples
+// of StripeSize+4 (516, 1032, ...) always work.
+func BodyLen(blockSize int) (int, error) {
+	if blockSize <= 0 {
+		return 0, fmt.Errorf("block.BodyLen: blockSize must be > 0, got %d", blockSize)
+	}
+	k := (blockSize + StripeSize + 3) / (StripeSize + 4)
+	bodyLen := blockSize - 4*k
+	if bodyLen <= 0 || BlockDataSize(bodyLen) != blockSize {
+		return 0, fmt.Errorf("block.BodyLen: %d cannot be partitioned into body+stripe-CRCs; use a power of two or a multiple of %d", blockSize, StripeSize+4)
+	}
+	return bodyLen, nil
+}
+
+// MakeBlock fills buf with one complete on-disk block: body data followed
+// by per-stripe CRC32C checksums. buf must have length >= BlockDataSize(bodyLen).
+//
+// The header is NOT written into buf. Instead, MakeBlock populates h with
+// Version, Kind, Seed, BodyLen, and BodyCRC so the caller can marshal h
+// into an xattr via MarshalHeader.
+func MakeBlock(buf []byte, h *Header, kind Kind, seed uint64, bodyLen int) error {
+	if bodyLen < 0 {
+		return fmt.Errorf("MakeBlock: negative bodyLen %d", bodyLen)
+	}
+	needed := BlockDataSize(bodyLen)
+	if len(buf) < needed {
+		return fmt.Errorf("MakeBlock: buf too small (%d < %d)", len(buf), needed)
+	}
+
+	body := buf[:bodyLen]
+	if err := GenerateBody(kind, seed, body); err != nil {
+		return err
+	}
+
+	n := NumStripes(bodyLen)
+	crcSlice := buf[bodyLen : bodyLen+n*4]
+	for i := 0; i < n; i++ {
+		start := i * StripeSize
+		end := start + StripeSize
+		if end > bodyLen {
+			end = bodyLen
+		}
+		c := crc32.Checksum(body[start:end], castagnoli)
+		binary.LittleEndian.PutUint32(crcSlice[i*4:(i+1)*4], c)
+	}
+
+	h.Version = HeaderVersion
+	h.Kind = kind
+	h.Seed = seed
+	h.BodyLen = uint64(bodyLen)
+	h.BodyCRC = crc32.Checksum(body, castagnoli)
+	return nil
+}
+
+// Verdict classifies the outcome of verifying one record.
+type Verdict int
+
+const (
+	VerdictOK              Verdict = iota // body consistent with stored header, seed regeneration matches
+	VerdictBodyCorrupt                    // stripe CRCs pass but body bytes differ from regenerated
+	VerdictHeadBadCRC                     // xattr header CRC failed (from UnmarshalHeader)
+	VerdictHeadBadMagic                   // xattr header has no verifyio magic (from UnmarshalHeader)
+	VerdictHeadBadFormat                  // xattr header magic/CRC OK but version disagrees
+	VerdictBodyCRCMismatch                // a stripe CRC does not match the on-disk bytes
+	VerdictTruncated                      // buffer shorter than BlockDataSize(h.BodyLen)
+)
+
+// String returns a short human name for v.
+func (v Verdict) String() string {
+	switch v {
+	case VerdictOK:
+		return "OK"
+	case VerdictBodyCorrupt:
+		return "BODY_CORRUPT"
+	case VerdictHeadBadCRC:
+		return "HEAD_BAD_CRC"
+	case VerdictHeadBadMagic:
+		return "HEAD_BAD_MAGIC"
+	case VerdictHeadBadFormat:
+		return "HEAD_BAD_FORMAT"
+	case VerdictBodyCRCMismatch:
+		return "BODY_CRC_MISMATCH"
+	case VerdictTruncated:
+		return "TRUNCATED"
+	default:
+		return fmt.Sprintf("verdict(%d)", int(v))
+	}
+}
+
+// Explanation returns a one-sentence, human-readable description of what v
+// means. It exists because the short String() code is not self-explanatory —
+// in particular that BODY_CORRUPT is valid-but-wrong-version data (typically a
+// stale cross-node read), which is a different failure than the internal
+// inconsistency of BODY_CRC_MISMATCH (torn write / bit-rot).
+func (v Verdict) Explanation() string {
+	switch v {
+	case VerdictOK:
+		return "body matches the current header and its regenerated seed data."
+	case VerdictBodyCorrupt:
+		return "the block is internally consistent (its own in-data stripe CRCs pass) " +
+			"but does not match the version its header describes. The header is stored in " +
+			"an xattr, separate from the data body, so here the (freshly read) xattr header " +
+			"and the data body disagree: valid data, wrong version. Across nodes this is the " +
+			"classic stale-read signature — the xattr header has advanced to a newer write " +
+			"while the reader still serves an older, coherent copy of the data body from its " +
+			"page cache."
+	case VerdictBodyCRCMismatch:
+		return "the body does not match its own in-data stripe CRCs: the block is " +
+			"internally inconsistent, indicating a torn/partial write or on-media bit-rot " +
+			"(genuine corruption, not merely stale)."
+	case VerdictHeadBadCRC:
+		return "the header's own CRC check failed: the stored header bytes are damaged."
+	case VerdictHeadBadMagic:
+		return "no valid block header was found (magic missing or zeroed): the region was " +
+			"never written, or its xattr record is absent."
+	case VerdictHeadBadFormat:
+		return "the header's version/length is unrecognized: a format mismatch between the " +
+			"writer and this verifier."
+	case VerdictTruncated:
+		return "the on-disk block is shorter than its header claims: an incomplete write or " +
+			"a truncated file."
+	default:
+		return "unknown verdict."
+	}
+}
+
+// VerifyBlock checks the on-disk block in buf against h, which must be the
+// header previously stored in an xattr (via MarshalHeader). buf must contain
+// exactly BlockDataSize(h.BodyLen) bytes.
+//
+// Verification proceeds in two stages:
+//  1. Each 512-byte stripe's CRC32C is checked against the appended CRC.
+//     A mismatch returns VerdictBodyCRCMismatch immediately.
+//  2. The body is regenerated from (h.Kind, h.Seed) and compared
+//     byte-for-byte. A mismatch returns VerdictBodyCorrupt.
+//
+// scratch is an optional reusable buffer for the regenerated body; pass nil
+// to allocate. It must be at least h.BodyLen bytes.
+func VerifyBlock(buf []byte, h *Header, scratch []byte) (Verdict, error) {
+	// Guard against a corrupt or untrusted header: a BodyLen larger than the
+	// buffer can never be satisfied, and converting an out-of-range uint64 to
+	// int below would overflow and panic when slicing the body. Treat it as a
+	// truncated block rather than crashing the verifier.
+	if h.BodyLen > uint64(len(buf)) {
+		return VerdictTruncated, nil
+	}
+	needed := BlockDataSize(int(h.BodyLen))
+	if len(buf) < needed {
+		return VerdictTruncated, nil
+	}
+
+	body := buf[:h.BodyLen]
+	n := NumStripes(int(h.BodyLen))
+	crcSlice := buf[h.BodyLen : uint64(h.BodyLen)+uint64(n*4)]
+
+	for i := 0; i < n; i++ {
+		start := uint64(i) * StripeSize
+		end := start + StripeSize
+		if end > h.BodyLen {
+			end = h.BodyLen
+		}
+		want := binary.LittleEndian.Uint32(crcSlice[i*4 : (i+1)*4])
+		got := crc32.Checksum(body[start:end], castagnoli)
+		if want != got {
+			return VerdictBodyCRCMismatch, nil
+		}
+	}
+
+	if scratch == nil || uint64(len(scratch)) < h.BodyLen {
+		scratch = make([]byte, h.BodyLen)
+	} else {
+		scratch = scratch[:h.BodyLen]
+	}
+	if err := GenerateBody(h.Kind, h.Seed, scratch); err != nil {
+		return VerdictBodyCorrupt, err
+	}
+	if !bytes.Equal(scratch, body) {
+		return VerdictBodyCorrupt, nil
+	}
+	return VerdictOK, nil
+}
+
+// Diagnosis holds forensic detail about a block that failed verification. It is
+// meant to be computed from the SAME buffer VerifyBlock inspected — never a
+// re-read, which on a stale cache could pull different bytes and contradict the
+// reported Verdict.
+type Diagnosis struct {
+	StripesTotal  int    // stripes covering the body
+	StripesFailed int    // stripes whose in-data CRC disagrees with the read bytes
+	ReadBodyCRC   uint32 // CRC32C over the body as read (compare against Header.BodyCRC)
+	FirstDiffByte int    // first body byte differing from seed-regenerated data; -1 if none/unknown
+	ExpByte       byte   // expected byte at FirstDiffByte (valid when FirstDiffByte >= 0)
+	GotByte       byte   // actual byte at FirstDiffByte (valid when FirstDiffByte >= 0)
+}
+
+// Diagnose computes forensic detail for the block in buf against header h,
+// mirroring VerifyBlock's checks but without short-circuiting. StripesFailed==0
+// means the block is internally consistent — a coherent-but-wrong-version stale
+// read rather than corruption. FirstDiffByte locates where the read body first
+// diverges from what the header's seed should regenerate.
+//
+// buf must hold at least BlockDataSize(h.BodyLen) bytes (the same precondition
+// as VerifyBlock); a short buffer yields a zero-value Diagnosis with
+// FirstDiffByte == -1.
+func Diagnose(buf []byte, h *Header) Diagnosis {
+	d := Diagnosis{FirstDiffByte: -1}
+	if h.BodyLen > uint64(len(buf)) || len(buf) < BlockDataSize(int(h.BodyLen)) {
+		return d
+	}
+	body := buf[:h.BodyLen]
+	d.ReadBodyCRC = crc32.Checksum(body, castagnoli)
+
+	n := NumStripes(int(h.BodyLen))
+	d.StripesTotal = n
+	crcSlice := buf[h.BodyLen : uint64(h.BodyLen)+uint64(n*4)]
+	for i := 0; i < n; i++ {
+		start := uint64(i) * StripeSize
+		end := start + StripeSize
+		if end > h.BodyLen {
+			end = h.BodyLen
+		}
+		want := binary.LittleEndian.Uint32(crcSlice[i*4 : (i+1)*4])
+		got := crc32.Checksum(body[start:end], castagnoli)
+		if want != got {
+			d.StripesFailed++
+		}
+	}
+
+	// Locate the first byte where the read body diverges from the data the
+	// header's seed should regenerate. Best-effort: if regeneration errors
+	// (unknown Kind), leave FirstDiffByte == -1.
+	scratch := make([]byte, h.BodyLen)
+	if err := GenerateBody(h.Kind, h.Seed, scratch); err == nil {
+		for i := 0; i < len(body); i++ {
+			if body[i] != scratch[i] {
+				d.FirstDiffByte = i
+				d.ExpByte = scratch[i]
+				d.GotByte = body[i]
+				break
+			}
+		}
+	}
+	return d
+}

--- a/verifyio/block/block_test.go
+++ b/verifyio/block/block_test.go
@@ -1,0 +1,415 @@
+// This is a unit test.
+//
+// Coverage: Header marshal/unmarshal round-trip (including zero-value and
+// negative/max-value edge cases) and unmarshal error paths (truncated, bad
+// magic, bad head CRC, a genuine self-consistent version mismatch, and --
+// pinning the fix for a real bug found by review -- a corrupted version
+// byte with a stale CRC correctly reporting CRC mismatch rather than being
+// misclassified as benign version skew); GenerateBody determinism (same
+// seed -> same bytes), seed-sensitivity per Kind, and pinned known-answer
+// outputs; MakeBlock+VerifyBlock happy path for every Kind; VerifyBlock's
+// verdict classification (OK, Truncated, BodyCorrupt, BodyCRCMismatch);
+// Header.String formatting; and Kind<->string round-trip.
+package block
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"hash/crc32"
+	"strings"
+	"testing"
+)
+
+// roundTripHeader marshals h, unmarshals the result, and returns the
+// parsed copy so tests can compare structurally.
+func roundTripHeader(t *testing.T, h Header) Header {
+	t.Helper()
+	buf := make([]byte, HeaderSize)
+	if err := MarshalHeader(buf, &h); err != nil {
+		t.Fatalf("MarshalHeader: %v", err)
+	}
+	got, err := UnmarshalHeader(buf)
+	if err != nil {
+		t.Fatalf("UnmarshalHeader: unexpected error: %v", err)
+	}
+	return got
+}
+
+func TestHeaderRoundTrip(t *testing.T) {
+	cases := []Header{
+		{}, // all-zero header is fine: HeaderLen and CRC fields are filled by Marshal.
+		{
+			Version:  HeaderVersion,
+			Kind:     KindPRNG,
+			TimeNs:   1234567890,
+			NodeName: NodeNameFromString("storage01"),
+			TID:      4096,
+			WorkerID: 7,
+			Tag:      42,
+			Cycle:    1 << 40,
+			Offset:   0x1000,
+			BodyLen:  4016,
+			Seed:     0xcafebabe,
+			BodyCRC:  0x12345678,
+		},
+		{
+			Version:  HeaderVersion,
+			Kind:     KindDecimal,
+			TimeNs:   -1, // negative is allowed; verifies sign-extension
+			TID:      -1,
+			WorkerID: -1,
+			Tag:      0xffffffff,
+			Cycle:    ^uint64(0),
+			Offset:   ^uint64(0),
+			BodyLen:  0,
+			Seed:     ^uint64(0),
+			BodyCRC:  0xffffffff,
+		},
+	}
+
+	for i, want := range cases {
+		// MarshalHeader sets Version to HeaderVersion regardless of the input,
+		// so normalize for comparison.
+		want.Version = HeaderVersion
+		got := roundTripHeader(t, want)
+		if got != want {
+			t.Errorf("case %d: round-trip mismatch\n got: %+v\nwant: %+v", i, got, want)
+		}
+	}
+}
+
+func TestUnmarshalErrors(t *testing.T) {
+	good := make([]byte, HeaderSize)
+	if err := MarshalHeader(good, &Header{Version: HeaderVersion, Kind: KindZeros}); err != nil {
+		t.Fatalf("MarshalHeader setup: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func([]byte) []byte
+		wantErr error
+	}{
+		{
+			name:    "short buffer",
+			mutate:  func(b []byte) []byte { return b[:HeaderSize-1] },
+			wantErr: ErrTruncated,
+		},
+		{
+			name: "bad magic",
+			mutate: func(b []byte) []byte {
+				out := make([]byte, len(b))
+				copy(out, b)
+				out[0] ^= 0xFF
+				return out
+			},
+			wantErr: ErrBadMagic,
+		},
+		{
+			name: "bad head crc",
+			mutate: func(b []byte) []byte {
+				out := make([]byte, len(b))
+				copy(out, b)
+				// Flip a byte in the BodyCRC field (offset 82); magic and
+				// version still validate, so the failure mode is HeadCRC.
+				out[82] ^= 0x01
+				return out
+			},
+			wantErr: ErrBadHeadCRC,
+		},
+		{
+			// A genuinely different, but internally self-consistent, on-wire
+			// version: the CRC is recomputed over the mutated bytes, exactly
+			// as a real differently-versioned writer's own CRC would be.
+			// UnmarshalHeader checks CRC before Version specifically so this
+			// case -- CRC passes, only Version disagrees -- is what actually
+			// earns ErrBadVersion/VerdictHeadBadFormat's "CRC OK" claim.
+			name: "bad version (self-consistent CRC)",
+			mutate: func(b []byte) []byte {
+				out := make([]byte, len(b))
+				copy(out, b)
+				binary.LittleEndian.PutUint16(out[8:10], 999)
+				newCRC := crc32.Checksum(out[:86], castagnoli)
+				binary.LittleEndian.PutUint32(out[86:90], newCRC)
+				return out
+			},
+			wantErr: ErrBadVersion,
+		},
+		{
+			// Regression test: ordinary corruption landing on the Version
+			// byte (CRC NOT recomputed, unlike the case above) must report
+			// CRC mismatch, not be misclassified as benign version skew.
+			name: "version byte corrupted (stale CRC)",
+			mutate: func(b []byte) []byte {
+				out := make([]byte, len(b))
+				copy(out, b)
+				binary.LittleEndian.PutUint16(out[8:10], 999)
+				return out
+			},
+			wantErr: ErrBadHeadCRC,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := UnmarshalHeader(tc.mutate(good))
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("got err=%v, want errors.Is(_, %v)", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestGenerateBodyDeterministic(t *testing.T) {
+	const bodyLen = 256
+	kinds := []Kind{KindPRNG, KindRepeat, KindCountUp, KindZeros, KindOnes, KindDecimal}
+	for _, k := range kinds {
+		t.Run(k.String(), func(t *testing.T) {
+			a := make([]byte, bodyLen)
+			b := make([]byte, bodyLen)
+			if err := GenerateBody(k, 0xabcd1234, a); err != nil {
+				t.Fatalf("GenerateBody(a): %v", err)
+			}
+			if err := GenerateBody(k, 0xabcd1234, b); err != nil {
+				t.Fatalf("GenerateBody(b): %v", err)
+			}
+			if !bytes.Equal(a, b) {
+				t.Errorf("two calls produced different bytes")
+			}
+
+			// Different seed should produce different bytes for variable
+			// kinds (PRNG, Repeat, CountUp, Decimal). Constant kinds
+			// (Zeros, Ones) are seed-independent.
+			c := make([]byte, bodyLen)
+			if err := GenerateBody(k, 0xabcd1235, c); err != nil {
+				t.Fatalf("GenerateBody(c): %v", err)
+			}
+			isConstant := k == KindZeros || k == KindOnes
+			eq := bytes.Equal(a, c)
+			if isConstant && !eq {
+				t.Errorf("constant kind %v: bytes changed with seed", k)
+			}
+			if !isConstant && eq {
+				t.Errorf("variable kind %v: bytes did not change with seed", k)
+			}
+		})
+	}
+}
+
+func TestGenerateBodyKnownAnswers(t *testing.T) {
+	// Pin a few small known-output cases so accidental changes to body
+	// generation are caught loudly.
+	tests := []struct {
+		kind Kind
+		seed uint64
+		want []byte
+	}{
+		{KindZeros, 12345, []byte{0, 0, 0, 0, 0, 0, 0, 0}},
+		{KindOnes, 0, []byte{0xFF, 0xFF, 0xFF, 0xFF}},
+		{KindCountUp, 100, []byte{100, 101, 102, 103, 104}},
+		{KindRepeat, 0x0807060504030201, []byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2}},
+		// KindDecimal: seed % 512 = 5 -> "005 006 007 ..."
+		{KindDecimal, 5, []byte{'0', '0', '5', ' ', '0', '0', '6', ' ', '0', '0', '7', ' '}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.kind.String(), func(t *testing.T) {
+			out := make([]byte, len(tc.want))
+			if err := GenerateBody(tc.kind, tc.seed, out); err != nil {
+				t.Fatalf("GenerateBody: %v", err)
+			}
+			if !bytes.Equal(out, tc.want) {
+				t.Errorf("got %v, want %v", out, tc.want)
+			}
+		})
+	}
+}
+
+func TestMakeBlockAndVerifyOK(t *testing.T) {
+	const bodyLen = 4016
+	kinds := []Kind{KindPRNG, KindRepeat, KindCountUp, KindZeros, KindOnes, KindDecimal}
+	for _, k := range kinds {
+		t.Run(k.String(), func(t *testing.T) {
+			buf := make([]byte, BlockDataSize(bodyLen))
+			h := Header{
+				NodeName: NodeNameFromString("n1"),
+				TID:      2,
+				WorkerID: 3,
+				Tag:      0xa5,
+				Cycle:    7,
+				Offset:   0x1000,
+				TimeNs:   1700000000,
+			}
+			if err := MakeBlock(buf, &h, k, 0xdeadbeef, bodyLen); err != nil {
+				t.Fatalf("MakeBlock: %v", err)
+			}
+			scratch := make([]byte, bodyLen)
+			v, err := VerifyBlock(buf, &h, scratch)
+			if err != nil {
+				t.Fatalf("VerifyBlock returned err: %v", err)
+			}
+			if v != VerdictOK {
+				t.Errorf("verdict = %v, want OK", v)
+			}
+			if h.Kind != k || h.Seed != 0xdeadbeef || h.BodyLen != bodyLen {
+				t.Errorf("populated header off: %+v", h)
+			}
+		})
+	}
+}
+
+func TestVerifyBlockOutcomes(t *testing.T) {
+	const bodyLen = 64 // fits in one 512-byte stripe
+	build := func() ([]byte, Header) {
+		buf := make([]byte, BlockDataSize(bodyLen))
+		h := Header{}
+		if err := MakeBlock(buf, &h, KindCountUp, 1, bodyLen); err != nil {
+			t.Fatal(err)
+		}
+		return buf, h
+	}
+
+	tests := []struct {
+		name   string
+		mutate func([]byte) []byte
+		want   Verdict
+	}{
+		{
+			name:   "ok",
+			mutate: func(b []byte) []byte { return b },
+			want:   VerdictOK,
+		},
+		{
+			name: "truncated body",
+			mutate: func(b []byte) []byte {
+				return b[:BlockDataSize(bodyLen)-1]
+			},
+			want: VerdictTruncated,
+		},
+		{
+			name: "body corrupt (matching stripe crc, mismatch bytes)",
+			// Replace body with an alternate generator output and recompute
+			// the single stripe CRC so the seed-regeneration comparison catches it.
+			mutate: func(b []byte) []byte {
+				out := append([]byte(nil), b...)
+				body := out[:bodyLen]
+				if err := GenerateBody(KindOnes, 0, body); err != nil {
+					t.Fatal(err)
+				}
+				newCRC := crc32.Checksum(body, castagnoli)
+				binary.LittleEndian.PutUint32(out[bodyLen:bodyLen+4], newCRC)
+				return out
+			},
+			want: VerdictBodyCorrupt,
+		},
+		{
+			name: "stripe crc mismatch",
+			mutate: func(b []byte) []byte {
+				out := append([]byte(nil), b...)
+				out[0] ^= 0xFF // flip a body byte; stripe CRC now mismatches
+				return out
+			},
+			want: VerdictBodyCRCMismatch,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf, h := build()
+			got, _ := VerifyBlock(tc.mutate(buf), &h, nil)
+			if got != tc.want {
+				t.Errorf("got verdict=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHeaderString(t *testing.T) {
+	h := Header{
+		Version:  HeaderVersion,
+		Kind:     KindDecimal,
+		TimeNs:   1700000000123456789,
+		NodeName: NodeNameFromString("testhost"),
+		TID:      4096,
+		WorkerID: 7,
+		Tag:      0x2a,
+		Cycle:    42,
+		Offset:   0x1000,
+		BodyLen:  4016,
+		Seed:     0xcafebabe,
+		BodyCRC:  0x12345678,
+	}
+	got := h.String()
+	// Spot-check key fields rather than pinning the entire format string,
+	// so trivial whitespace changes don't break the test.
+	wantSubstrings := []string{
+		"ver=3",
+		"kind=decimal",
+		"time=2023-11-14T", // partial RFC3339 prefix
+		"node=testhost",
+		"tid=4096",
+		"worker=7",
+		"tag=0x0000002a",
+		"cycle=42",
+		"offset=0x1000",
+		"bodyLen=4016",
+		"seed=0x00000000cafebabe",
+		"bodyCRC=0x12345678",
+	}
+	for _, sub := range wantSubstrings {
+		if !strings.Contains(got, sub) {
+			t.Errorf("Header.String() missing %q\n  got: %s", sub, got)
+		}
+	}
+}
+
+func TestMarshalHeaderShortBuf(t *testing.T) {
+	short := make([]byte, HeaderSize-1)
+	if err := MarshalHeader(short, &Header{Version: HeaderVersion}); err == nil {
+		t.Errorf("MarshalHeader on undersized buf: expected error, got nil")
+	}
+}
+
+func TestUnmarshalReturnsHeaderOnCRCFailure(t *testing.T) {
+	// Build a valid header, corrupt one byte covered by the HeadCRC (Cycle
+	// field, offset 50), then check UnmarshalHeader returns the partially-
+	// parsed header for diagnostic use even though ErrBadHeadCRC is returned.
+	h := Header{
+		Version:  HeaderVersion,
+		NodeName: NodeNameFromString("myhost"),
+		WorkerID: 11,
+		Cycle:    99,
+		Offset:   0x4000,
+	}
+	buf := make([]byte, HeaderSize)
+	if err := MarshalHeader(buf, &h); err != nil {
+		t.Fatal(err)
+	}
+	buf[50] ^= 0x01 // mutate first byte of Cycle field (offset 50 in v3 layout)
+	got, err := UnmarshalHeader(buf)
+	if !errors.Is(err, ErrBadHeadCRC) {
+		t.Fatalf("err=%v, want ErrBadHeadCRC", err)
+	}
+	// Header values should all be present, even though they're untrusted.
+	if NodeNameString(got.NodeName) != "myhost" || got.WorkerID != 11 || got.Offset != 0x4000 {
+		t.Errorf("populated header missing data on CRC failure: %+v", got)
+	}
+	// And the corrupted Cycle should reflect what was on the wire (not zero).
+	if got.Cycle == 0 {
+		t.Errorf("Cycle=0; expected on-wire value (mutated 99 ^ 1)")
+	}
+}
+
+func TestKindFromStringRoundTrip(t *testing.T) {
+	kinds := []Kind{KindPRNG, KindRepeat, KindCountUp, KindZeros, KindOnes, KindDecimal}
+	for _, k := range kinds {
+		got, err := KindFromString(k.String())
+		if err != nil {
+			t.Errorf("KindFromString(%q): %v", k.String(), err)
+		}
+		if got != k {
+			t.Errorf("round-trip Kind: got %v want %v", got, k)
+		}
+	}
+	if _, err := KindFromString("not-a-kind"); err == nil {
+		t.Errorf("expected error for unknown kind")
+	}
+}

--- a/verifyio/block/diagnose_test.go
+++ b/verifyio/block/diagnose_test.go
@@ -1,0 +1,87 @@
+// This is a unit test.
+//
+// Coverage: Diagnose correctly distinguishes a coherent-but-stale cross-node
+// read (stripe CRCs pass, StripesFailed=0, but the body doesn't match the
+// header's seed -- BODY_CORRUPT) from genuine corruption (a body byte
+// flipped without updating its stripe CRC -- BODY_CRC_MISMATCH,
+// StripesFailed>=1); and every Verdict has a non-empty Explanation, with
+// BODY_CORRUPT's explicitly naming the xattr/version distinction.
+package block
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDiagnoseStaleVsCorrupt verifies that Diagnose distinguishes a
+// coherent-but-wrong-version block (the cross-node stale-read case: stripe CRCs
+// pass, but the body differs from the header's seed) from genuine corruption (a
+// body byte altered without updating its stripe CRC).
+func TestDiagnoseStaleVsCorrupt(t *testing.T) {
+	const bodyLen = 1024 // two 512-byte stripes, like the real soak block
+
+	// Two independent, internally consistent blocks with different seeds.
+	bufOld := make([]byte, BlockDataSize(bodyLen))
+	var hOld Header
+	if err := MakeBlock(bufOld, &hOld, KindPRNG, 0x1111, bodyLen); err != nil {
+		t.Fatalf("MakeBlock old: %v", err)
+	}
+	var hNew Header
+	if err := MakeBlock(make([]byte, BlockDataSize(bodyLen)), &hNew, KindPRNG, 0x2222, bodyLen); err != nil {
+		t.Fatalf("MakeBlock new: %v", err)
+	}
+
+	// Stale read: the data on disk is the coherent OLD block while the xattr
+	// header has already advanced to the NEW version.
+	if v, _ := VerifyBlock(bufOld, &hNew, nil); v != VerdictBodyCorrupt {
+		t.Fatalf("stale scenario: got verdict %v, want BODY_CORRUPT", v)
+	}
+	d := Diagnose(bufOld, &hNew)
+	if d.StripesTotal != NumStripes(bodyLen) {
+		t.Errorf("StripesTotal = %d, want %d", d.StripesTotal, NumStripes(bodyLen))
+	}
+	if d.StripesFailed != 0 {
+		t.Errorf("stale block should be internally consistent; StripesFailed = %d, want 0", d.StripesFailed)
+	}
+	if d.ReadBodyCRC != hOld.BodyCRC {
+		t.Errorf("ReadBodyCRC = 0x%08x, want the OLD block's CRC 0x%08x", d.ReadBodyCRC, hOld.BodyCRC)
+	}
+	if d.ReadBodyCRC == hNew.BodyCRC {
+		t.Errorf("ReadBodyCRC unexpectedly equals the (new) header CRC 0x%08x", hNew.BodyCRC)
+	}
+	if d.FirstDiffByte < 0 {
+		t.Errorf("FirstDiffByte = %d, want a located divergence >= 0", d.FirstDiffByte)
+	}
+
+	// Genuine corruption: flip a body byte without fixing its stripe CRC.
+	bufCorrupt := make([]byte, BlockDataSize(bodyLen))
+	var hC Header
+	if err := MakeBlock(bufCorrupt, &hC, KindPRNG, 0x3333, bodyLen); err != nil {
+		t.Fatalf("MakeBlock corrupt: %v", err)
+	}
+	bufCorrupt[0] ^= 0xFF
+	if v, _ := VerifyBlock(bufCorrupt, &hC, nil); v != VerdictBodyCRCMismatch {
+		t.Fatalf("corruption scenario: got verdict %v, want BODY_CRC_MISMATCH", v)
+	}
+	dc := Diagnose(bufCorrupt, &hC)
+	if dc.StripesFailed < 1 {
+		t.Errorf("corrupt block should fail a stripe CRC; StripesFailed = %d, want >= 1", dc.StripesFailed)
+	}
+}
+
+// TestVerdictExplanation checks every verdict has a non-empty explanation and
+// that BODY_CORRUPT's names the xattr/version distinction (the reason it was
+// added — so a reader knows it means "valid data, wrong version").
+func TestVerdictExplanation(t *testing.T) {
+	for v := VerdictOK; v <= VerdictTruncated; v++ {
+		if strings.TrimSpace(v.Explanation()) == "" {
+			t.Errorf("verdict %v has empty Explanation()", v)
+		}
+	}
+	e := VerdictBodyCorrupt.Explanation()
+	for _, want := range []string{"xattr", "version"} {
+		if !strings.Contains(e, want) {
+			t.Errorf("BODY_CORRUPT explanation missing %q: %s", want, e)
+		}
+	}
+}

--- a/verifyio/block/example_test.go
+++ b/verifyio/block/example_test.go
@@ -1,0 +1,68 @@
+// This is a set of Go runnable examples, not traditional unit tests: each
+// Example function's output is checked against its trailing "// Output:"
+// comment by `go test`, and the source doubles as the package's godoc usage
+// documentation.
+//
+// Coverage: the canonical write-side call (MakeBlock producing a populated
+// header ready to store in an xattr), the canonical read-side call
+// (VerifyBlock against a just-written block), and the diagnostic path
+// (VerifyBlock's verdict after a body byte is corrupted).
+package block_test
+
+import (
+	"fmt"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+)
+
+// ExampleMakeBlock shows the canonical write-side use: fill a block buffer
+// and get back a populated header ready to marshal into an xattr.
+func ExampleMakeBlock() {
+	const bodyLen = 64
+	buf := make([]byte, block.BlockDataSize(bodyLen))
+
+	h := block.Header{
+		WorkerID: 0,
+		Cycle:    7,
+		Offset:   0x1000,
+	}
+	if err := block.MakeBlock(buf, &h, block.KindDecimal, 42, bodyLen); err != nil {
+		fmt.Println("err:", err)
+		return
+	}
+	// h is now populated: Version, Kind, Seed, BodyLen, BodyCRC.
+	// Marshal h to store it in an xattr; buf holds the on-disk block.
+	fmt.Printf("kind=%s seed=%d cycle=%d bodyLen=%d\n",
+		h.Kind, h.Seed, h.Cycle, h.BodyLen)
+	// Output: kind=decimal seed=42 cycle=7 bodyLen=64
+}
+
+// ExampleVerifyBlock shows verifying a block that was just written. The
+// header h is passed in (as if read from an xattr) alongside the on-disk
+// block data.
+func ExampleVerifyBlock() {
+	const bodyLen = 32
+	buf := make([]byte, block.BlockDataSize(bodyLen))
+	h := block.Header{}
+	_ = block.MakeBlock(buf, &h, block.KindCountUp, 100, bodyLen)
+
+	verdict, _ := block.VerifyBlock(buf, &h, nil)
+	fmt.Println(verdict)
+	// Output: OK
+}
+
+// ExampleVerifyBlock_corrupt shows the diagnostic path: corrupting a body
+// byte yields VerdictBodyCRCMismatch. The caller already holds the header
+// and can use it for logging alongside the verdict.
+func ExampleVerifyBlock_corrupt() {
+	const bodyLen = 32
+	buf := make([]byte, block.BlockDataSize(bodyLen))
+	h := block.Header{Cycle: 99}
+	_ = block.MakeBlock(buf, &h, block.KindCountUp, 1, bodyLen)
+
+	buf[0] ^= 0xFF // flip a body byte
+
+	verdict, _ := block.VerifyBlock(buf, &h, nil)
+	fmt.Printf("verdict=%s cycle=%d\n", verdict, h.Cycle)
+	// Output: verdict=BODY_CRC_MISMATCH cycle=99
+}

--- a/verifyio/cmd/iotest-dump/main.go
+++ b/verifyio/cmd/iotest-dump/main.go
@@ -1,0 +1,115 @@
+// iotest-dump -- print every block stored in a verifyio data file.
+//
+// For each record found in the xattr store, iotest-dump reads the
+// corresponding bytes from the data file, verifies them, and prints a
+// human-readable summary. Entries are printed in offset order.
+//
+//	iotest-dump -path /tmp/foo.dat
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+)
+
+type entry struct {
+	offset, length int64
+	header         []byte
+}
+
+func main() {
+	path := flag.String("path", "", "data file to inspect (required)")
+	flag.Usage = func() {
+		w := flag.CommandLine.Output()
+		fmt.Fprintln(w, "Usage: iotest-dump -path <file>")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Print every block stored in a verifyio data file.")
+		fmt.Fprintln(w, "Reads xattrs to discover records, verifies each block, and prints a summary in offset order.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Flags:")
+		flag.PrintDefaults()
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Examples:")
+		fmt.Fprintln(w, "  iotest-dump -path /tmp/smoke.dat")
+		fmt.Fprintln(w, "  iotest-dump -path /tmp/soak/iotest-soak-0.shared")
+	}
+	if len(os.Args) == 1 {
+		flag.Usage()
+		os.Exit(2)
+	}
+	flag.Parse()
+
+	if *path == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	f, err := os.Open(*path)
+	if err != nil {
+		die("open: %v", err)
+	}
+	defer f.Close()
+
+	store, err := xattrstore.OpenStore(*path)
+	if err != nil {
+		die("OpenStore: %v", err)
+	}
+
+	var entries []entry
+	if err := store.ForEachEntry(func(offset, length int64, header []byte) error {
+		h := make([]byte, len(header))
+		copy(h, header)
+		entries = append(entries, entry{offset, length, h})
+		return nil
+	}); err != nil {
+		die("ForEachEntry: %v", err)
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].offset < entries[j].offset
+	})
+
+	fmt.Printf("%s: %d block(s)\n\n", *path, len(entries))
+
+	scratch := make([]byte, 4096)
+	for _, e := range entries {
+		h, err := block.UnmarshalHeader(e.header)
+		if err != nil {
+			fmt.Printf("offset=%-8d length=%-6d  header parse error: %v\n\n", e.offset, e.length, err)
+			continue
+		}
+
+		buf := make([]byte, e.length)
+		_, readErr := f.ReadAt(buf, e.offset)
+
+		var verdictStr string
+		if readErr != nil {
+			verdictStr = fmt.Sprintf("READ_ERROR(%v)", readErr)
+		} else {
+			if int(h.BodyLen) > len(scratch) {
+				scratch = make([]byte, h.BodyLen)
+			}
+			v, _ := block.VerifyBlock(buf, &h, scratch)
+			verdictStr = v.String()
+		}
+
+		ts := time.Unix(0, h.TimeNs).UTC().Format(time.RFC3339Nano)
+		fmt.Printf("offset=%-8d length=%-6d  verdict=%s\n", e.offset, e.length, verdictStr)
+		fmt.Printf("  kind=%-10s worker=%-4d cycle=%-6d node=%s tid=%d\n",
+			h.Kind, h.WorkerID, h.Cycle, block.NodeNameString(h.NodeName), h.TID)
+		fmt.Printf("  time=%s\n", ts)
+		fmt.Printf("  bodyLen=%-6d seed=0x%016x bodyCRC=0x%08x\n\n",
+			h.BodyLen, h.Seed, h.BodyCRC)
+	}
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/verifyio/cmd/iotest-posixbench/main.go
+++ b/verifyio/cmd/iotest-posixbench/main.go
@@ -1,0 +1,241 @@
+// iotest-posixbench -- write-once POSIX IO benchmark with optional verification.
+//
+// Subcommands:
+//
+//	run     write data files (+ optional read phase) and report bandwidth
+//	verify  check data files against the manifest written by run
+//
+// Example:
+//
+//	iotest-posixbench run -path /mnt/beegfs/testdir -threads 8 -file-size 4294967296
+//	iotest-posixbench verify -path /mnt/beegfs/testdir
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/thinkparq/beegfs-go/verifyio/bench/posixbench"
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+	switch os.Args[1] {
+	case "run":
+		cmdRun(os.Args[2:])
+	case "verify":
+		cmdVerify(os.Args[2:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n\n", os.Args[1])
+		usage()
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	w := os.Stderr
+	fmt.Fprintln(w, "Usage: iotest-posixbench <run|verify> [flags]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Write-once POSIX IO benchmark with manifest-based post-run verification.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Subcommands:")
+	fmt.Fprintln(w, "  run     write data files and optionally read them back")
+	fmt.Fprintln(w, "  verify  check data files against the run manifest")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Examples:")
+	fmt.Fprintln(w, "  iotest-posixbench run -path /mnt/testdir -threads 8")
+	fmt.Fprintln(w, "  iotest-posixbench run -path /mnt/testdir -threads 8 -file-size 4294967296 -read")
+	fmt.Fprintln(w, "  iotest-posixbench verify -path /mnt/testdir")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Run 'iotest-posixbench <subcommand>' with no flags for subcommand help.")
+}
+
+func cmdRun(args []string) {
+	fs := flag.NewFlagSet("run", flag.ExitOnError)
+	var (
+		path    = fs.String("path", "", "target directory (required)")
+		threads = fs.Int("threads", 4, "worker goroutines")
+		bs      = fs.Int("block-size", posixbench.DefaultBlockSize, "IO transfer size in bytes")
+		fsz     = fs.Int64("file-size", 1*1024*1024*1024, "per-worker data size in bytes (bytes, not a size suffix)")
+		fpw     = fs.Int("files-per-worker", 1, "files per worker (1-to-1 layout only)")
+		layout  = fs.String("layout", "1-to-1", "file distribution: 1-to-1 or n-to-1")
+		kind    = fs.String("kind", "decimal", "data pattern: decimal|prng|zeros|ones|countup|repeat")
+		seed    = fs.Uint64("seed", 0, "pattern seed (0 = random, recorded in manifest)")
+		doRead  = fs.Bool("read", false, "run a sequential read phase after writing")
+		noXattr = fs.Bool("no-xattr", false,
+			"write per-stripe ECC into data files instead of xattrs; blocksize is encoded in filenames; verification is ECC-only")
+	)
+	fs.Usage = func() {
+		w := fs.Output()
+		fmt.Fprintln(w, "Usage: iotest-posixbench run -path <dir> [flags]")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Write data files to a directory and report write (and optionally read) bandwidth.")
+		fmt.Fprintln(w, "A posixbench.json manifest is written alongside the data for later verification.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Flags:")
+		fs.PrintDefaults()
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Examples:")
+		fmt.Fprintln(w, "  iotest-posixbench run -path /mnt/testdir -threads 8")
+		fmt.Fprintln(w, "  iotest-posixbench run -path /mnt/testdir -threads 8 -file-size 4294967296 -read")
+		fmt.Fprintln(w, "  iotest-posixbench run -path /mnt/testdir -threads 4 -layout n-to-1 -kind prng")
+	}
+	_ = fs.Parse(args)
+
+	if *path == "" {
+		fs.Usage()
+		os.Exit(2)
+	}
+	k, err := block.KindFromString(*kind)
+	if err != nil {
+		die("run: %v", err)
+	}
+
+	cfg := posixbench.Config{
+		Path:           *path,
+		Threads:        *threads,
+		BlockSize:      *bs,
+		FileSize:       *fsz,
+		FilesPerWorker: *fpw,
+		Layout:         posixbench.Layout(*layout),
+		Kind:           k,
+		Seed:           *seed,
+		NoXattr:        *noXattr,
+	}
+	cfg.EnsureSeed()
+	if err := cfg.Validate(); err != nil {
+		die("run: %v", err)
+	}
+
+	r, err := posixbench.NewRunner(cfg)
+	if err != nil {
+		die("run: %v", err)
+	}
+
+	totalData := int64(cfg.Threads) * int64(cfg.FilesPerWorker) * cfg.FileSize
+	if cfg.Layout == posixbench.LayoutNto1 {
+		totalData = int64(cfg.Threads) * cfg.FileSize
+	}
+
+	fmt.Printf("posixbench run\n")
+	fmt.Printf("  path=%s threads=%d layout=%s kind=%s seed=%d\n",
+		cfg.Path, cfg.Threads, cfg.Layout, cfg.Kind, cfg.Seed)
+	fmt.Printf("  blockSize=%s fileSize=%s totalData=%s\n",
+		humanBytes(int64(cfg.BlockSize)), humanBytes(cfg.FileSize), humanBytes(totalData))
+	fmt.Println()
+
+	start := time.Now()
+	res, err := r.Run(*doRead)
+	if err != nil {
+		die("run: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	fmt.Printf("Write:  %7.1f MB/s  %s in %s\n",
+		res.WriteMBps(),
+		humanBytes(res.TotalWritten),
+		res.WriteElapsed.Round(time.Millisecond))
+	if *doRead {
+		fmt.Printf("Read:   %7.1f MB/s  %s in %s\n",
+			res.ReadMBps(),
+			humanBytes(res.TotalRead),
+			res.ReadElapsed.Round(time.Millisecond))
+	}
+	fmt.Printf("Elapsed: %s\n", elapsed.Round(time.Millisecond))
+	fmt.Printf("Manifest: %s/posixbench.json\n", cfg.Path)
+}
+
+func cmdVerify(args []string) {
+	fs := flag.NewFlagSet("verify", flag.ExitOnError)
+	var (
+		path     = fs.String("path", "", "directory containing posixbench.json (required)")
+		verbose  = fs.Bool("verbose", false, "print all anomalies (default: summary only)")
+		hostname = fs.String("hostname", "", "verify files for this hostname (reads posixbench-{hostname}.json)")
+	)
+	fs.Usage = func() {
+		w := fs.Output()
+		fmt.Fprintln(w, "Usage: iotest-posixbench verify -path <dir> [flags]")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Verify data files against the posixbench.json manifest written by 'run'.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "When verifying files written by 'beegfs iotest start bench' on a shared path,")
+		fmt.Fprintln(w, "pass -hostname to select the per-node manifest (posixbench-{hostname}.json).")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Flags:")
+		fs.PrintDefaults()
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Examples:")
+		fmt.Fprintln(w, "  iotest-posixbench verify -path /mnt/testdir")
+		fmt.Fprintln(w, "  iotest-posixbench verify -path /mnt/testdir -verbose")
+	}
+	_ = fs.Parse(args)
+
+	if *path == "" {
+		fs.Usage()
+		os.Exit(2)
+	}
+
+	cfg, err := posixbench.ReadManifestHost(*path, *hostname)
+	if err != nil {
+		die("verify: %v", err)
+	}
+
+	v, err := posixbench.NewVerifier(cfg)
+	if err != nil {
+		die("verify: %v", err)
+	}
+
+	fmt.Printf("posixbench verify\n")
+	fmt.Printf("  path=%s seed=%d kind=%s blockSize=%s\n",
+		*path, cfg.Seed, cfg.Kind, humanBytes(int64(cfg.BlockSize)))
+	fmt.Println()
+
+	start := time.Now()
+	n, err := v.Verify(func(a posixbench.Anomaly) error {
+		if *verbose {
+			fmt.Printf("  MISMATCH  file=%s fileIndex=%d blockIndex=%d offset=%d\n",
+				a.File, a.FileIndex, a.BlockIndex, a.Offset)
+		}
+		return nil
+	})
+	if err != nil {
+		die("verify: %v", err)
+	}
+
+	fmt.Printf("Elapsed: %s\n", time.Since(start).Round(time.Millisecond))
+	if n == 0 {
+		fmt.Println("PASS")
+		return
+	}
+	fmt.Printf("FAIL  %d block(s) mismatched\n", n)
+	os.Exit(1)
+}
+
+func humanBytes(n int64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case n >= gib:
+		return fmt.Sprintf("%.2f GiB", float64(n)/gib)
+	case n >= mib:
+		return fmt.Sprintf("%.2f MiB", float64(n)/mib)
+	case n >= kib:
+		return fmt.Sprintf("%.2f KiB", float64(n)/kib)
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/verifyio/cmd/iotest-smoke/main.go
+++ b/verifyio/cmd/iotest-smoke/main.go
@@ -1,0 +1,177 @@
+// iotest-smoke -- write N blocks to a file, storing each block's header
+// in an xattr, then read everything back and verify.
+//
+// Single-threaded, deterministic. Useful as:
+//
+//   - End-to-end smoke check ("does the lib still work?")
+//   - Copy-paste starter for new consumers of the library
+//   - Sandbox for surfacing API friction
+//
+// The data file is truncated and rewritten on every run.
+//
+//	iotest-smoke -path /tmp/foo.dat -blocks 1000
+//	iotest-smoke -path /tmp/foo.dat -blocks 100 -blocksize 8192 -kind prng
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/fileops"
+	"github.com/thinkparq/beegfs-go/verifyio/internal/trace"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+)
+
+// allVerdicts is the canonical iteration order for tallying. Listed
+// explicitly rather than `for v := VerdictOK; v <= ...` so adding a new
+// Verdict requires touching this list (loud rather than silent).
+var allVerdicts = []block.Verdict{
+	block.VerdictOK,
+	block.VerdictBodyCorrupt,
+	block.VerdictBodyCRCMismatch,
+	block.VerdictHeadBadCRC,
+	block.VerdictHeadBadMagic,
+	block.VerdictHeadBadFormat,
+	block.VerdictTruncated,
+}
+
+func main() {
+	var (
+		path      = flag.String("path", "/tmp/iotest-smoke.dat", "data file path")
+		records   = flag.Int("blocks", 1000, "number of blocks to write")
+		blocksize = flag.Int("blocksize", 4096, "total bytes per block on disk (use a power of two)")
+		kind      = flag.String("kind", "decimal", "body pattern: decimal | prng | repeat | countup | zeros | ones")
+		iotrace   = flag.Int("iotrace", 0, "IO trace level (0=off, 1=error, 2=warn, 3=info, 4/5=debug)")
+		iologfile = flag.String("iologfile", "", "IO trace destination file (default stderr)")
+	)
+	flag.Usage = func() {
+		w := flag.CommandLine.Output()
+		fmt.Fprintln(w, "Usage: iotest-smoke [flags]")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Write N blocks to a file, storing each block's header in an xattr, then read back and verify.")
+		fmt.Fprintln(w, "The file is truncated on every run. Single-threaded and deterministic.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Flags:")
+		flag.PrintDefaults()
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Examples:")
+		fmt.Fprintln(w, "  iotest-smoke -path /tmp/smoke.dat -blocks 1000")
+		fmt.Fprintln(w, "  iotest-smoke -path /tmp/smoke.dat -blocks 500 -blocksize 8192 -kind prng")
+	}
+	if len(os.Args) == 1 {
+		flag.Usage()
+		os.Exit(2)
+	}
+	flag.Parse()
+
+	if *records <= 0 {
+		die("records must be > 0")
+	}
+	bodyKind, err := block.KindFromString(*kind)
+	if err != nil {
+		die("%v", err)
+	}
+	if _, err := block.BodyLen(*blocksize); err != nil {
+		die("invalid -blocksize: %v", err)
+	}
+
+	tl, err := trace.NewTraceLoggers(trace.TraceConfig{
+		Level:   int8(*iotrace),
+		LogFile: *iologfile,
+	})
+	if err != nil {
+		die("trace: %v", err)
+	}
+	defer tl.Sync()
+
+	// Truncate-open so each run starts from a known-clean file. Close is
+	// checked explicitly at the end rather than deferred: die() below calls
+	// os.Exit, which skips deferred functions entirely, so a plain
+	// `defer f.Close()` would only ever run on the PASS path anyway -- and a
+	// silent Close failure there is exactly the class of bug this tool
+	// exists to catch.
+	f, err := fileops.Open(*path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
+	if err != nil {
+		die("open %s: %v", *path, err)
+	}
+
+	store, err := xattrstore.OpenStore(*path)
+	if err != nil {
+		die("OpenStore: %v", err)
+	}
+
+	w, err := xattrstore.NewWriter(f, store, 0, bodyKind, *blocksize, tl.IO)
+	if err != nil {
+		die("NewWriter: %v", err)
+	}
+
+	// Write phase ----------------------------------------------------------
+	fmt.Printf("Writing %d blocks (blocksize=%d kind=%s) to %s\n",
+		*records, *blocksize, bodyKind, *path)
+
+	writeStart := time.Now()
+	for i := 0; i < *records; i++ {
+		offset := int64(i) * int64(*blocksize)
+		if err := w.WriteBlock(offset, fileops.IOTypeBuffered, false); err != nil {
+			die("WriteBlock at i=%d: %v", i, err)
+		}
+	}
+	if err := f.Sync(); err != nil {
+		die("fsync: %v", err)
+	}
+	fmt.Printf("Wrote %d blocks (%d bytes) in %s\n",
+		*records, int64(*records)*int64(*blocksize), time.Since(writeStart).Round(time.Millisecond))
+
+	// Verify phase ---------------------------------------------------------
+	fmt.Println("Verifying ...")
+	buf := make([]byte, *blocksize)
+	counts := make(map[block.Verdict]int, len(allVerdicts))
+	scratch := make([]byte, *blocksize)
+
+	verifyStart := time.Now()
+	for i := 0; i < *records; i++ {
+		offset := int64(i) * int64(*blocksize)
+		if _, err := f.ReadAt(buf, offset); err != nil {
+			die("ReadAt at i=%d offset=%d: %v", i, offset, err)
+		}
+		hdrBytes, err := store.Get(offset, int64(*blocksize))
+		if err != nil {
+			die("store.Get at i=%d offset=%d: %v", i, offset, err)
+		}
+		h, err := block.UnmarshalHeader(hdrBytes)
+		if err != nil {
+			die("UnmarshalHeader at i=%d: %v", i, err)
+		}
+		v, _ := block.VerifyBlock(buf, &h, scratch)
+		counts[v]++
+	}
+	verifyElapsed := time.Since(verifyStart).Round(time.Millisecond)
+
+	// Report ---------------------------------------------------------------
+	fmt.Println("Results:")
+	for _, v := range allVerdicts {
+		if c, ok := counts[v]; ok && c > 0 {
+			fmt.Printf("  %-18s %d\n", v.String()+":", c)
+		}
+	}
+	fmt.Printf("Verify took %s\n", verifyElapsed)
+
+	if err := f.Close(); err != nil {
+		die("close %s: %v", *path, err)
+	}
+
+	if counts[block.VerdictOK] == *records {
+		fmt.Println("PASS")
+		return
+	}
+	fmt.Println("FAIL")
+	os.Exit(1)
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/verifyio/cmd/iotest-soak/main.go
+++ b/verifyio/cmd/iotest-soak/main.go
@@ -1,0 +1,305 @@
+//go:build linux
+
+// iotest-soak -- multi-threaded soak test for verifyio.
+//
+// Thread 0 operates exclusively on its own .noOverlap file. The remaining
+// N-1 threads share a pool of (N-1)/2 .shared files, using OFD locking to
+// coordinate concurrent writes and verifications.
+//
+// Each worker repeatedly picks a random (file, op, offset) triple and
+// executes it until the duration expires or an anomaly is detected.
+//
+//	iotest-soak -path /tmp/soak -threads 8 -duration 5m
+//	iotest-soak -path /tmp/soak -threads 16 -duration 1h -blocksize 4096 -file-blocks 256
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/fileops"
+	"github.com/thinkparq/beegfs-go/verifyio/internal/trace"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+	"go.uber.org/zap"
+)
+
+func main() {
+	var (
+		path       = flag.String("path", "/tmp/iotest-soak", "directory for soak data files")
+		threads    = flag.Int("threads", 4, "number of concurrent worker goroutines (min 1)")
+		duration   = flag.Duration("duration", 30*time.Second, "how long to run (0 = until anomaly)")
+		blockSize  = flag.Int("blocksize", 1024, "total bytes per block on disk (use a power of two: 512, 1024, 4096, ...)")
+		fileBlocks = flag.Int("file-blocks", 64, "number of blocks per file")
+		iotrace    = flag.Int("iotrace", 0, "IO trace level (0=off, 1=error, 2=warn, 3=info, 4/5=debug)")
+		iologfile  = flag.String("iologfile", "", "IO trace destination file (default stderr)")
+	)
+	flag.Usage = func() {
+		w := flag.CommandLine.Output()
+		fmt.Fprintln(w, "Usage: iotest-soak [flags]")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Multi-threaded soak test that continuously writes and verifies blocks with OFD locking.")
+		fmt.Fprintln(w, "Thread 0 uses an exclusive .noOverlap file; remaining threads share a pool of .shared files.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Flags:")
+		flag.PrintDefaults()
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Examples:")
+		fmt.Fprintln(w, "  iotest-soak -path /tmp/soak -threads 8 -duration 5m")
+		fmt.Fprintln(w, "  iotest-soak -path /tmp/soak -threads 16 -duration 1h -blocksize 4096 -file-blocks 256")
+	}
+	if len(os.Args) == 1 {
+		flag.Usage()
+		os.Exit(2)
+	}
+	flag.Parse()
+
+	if *threads <= 0 {
+		die("threads must be > 0")
+	}
+	if *fileBlocks <= 0 {
+		die("file-blocks must be > 0")
+	}
+	if _, err := block.BodyLen(*blockSize); err != nil {
+		die("invalid -blocksize: %v", err)
+	}
+
+	tl, err := trace.NewTraceLoggers(trace.TraceConfig{
+		Level:   int8(*iotrace),
+		LogFile: *iologfile,
+	})
+	if err != nil {
+		die("trace: %v", err)
+	}
+	defer tl.Sync()
+
+	noOverlapPaths, sharedPaths, err := resolveFiles(*path, *threads)
+	if err != nil {
+		die("%v", err)
+	}
+	printPlan(*threads, noOverlapPaths, sharedPaths, *duration)
+
+	// baseCtx is cancelled with a cause on the first anomaly.
+	// ctx adds an optional deadline on top.
+	baseCtx, cancelCause := context.WithCancelCause(context.Background())
+	defer cancelCause(nil)
+	ctx := baseCtx
+	if *duration > 0 {
+		var stop context.CancelFunc
+		ctx, stop = context.WithTimeout(baseCtx, *duration)
+		defer stop()
+	}
+
+	ops := []Op{
+		writeBufferedOp(),
+		verifyRangeOp(*blockSize),
+	}
+	nBlocks := int64(*fileBlocks)
+
+	var (
+		wg       sync.WaitGroup
+		failures atomic.Int64
+		totalOps atomic.Int64
+	)
+	start := time.Now()
+
+	go progressLoop(ctx, start, &totalOps)
+
+	plan := runPlan{ops: ops, nBlocks: nBlocks, blockSize: *blockSize}
+
+	// Thread 0: exclusive noOverlap worker.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		wc := workerCtx{ctx: ctx, cancelCause: cancelCause, workerID: 0, totalOps: &totalOps, log: tl.IO}
+		if err := spawnWorker(wc, noOverlapPaths, plan); err != nil {
+			failures.Add(1)
+		}
+	}()
+
+	// Threads 1..N-1: shared-pool workers.
+	for i := 1; i < *threads; i++ {
+		wg.Add(1)
+		workerID := i
+		go func() {
+			defer wg.Done()
+			wc := workerCtx{ctx: ctx, cancelCause: cancelCause, workerID: workerID, totalOps: &totalOps, log: tl.IO}
+			if err := spawnWorker(wc, sharedPaths, plan); err != nil {
+				failures.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	elapsed := time.Since(start).Round(time.Millisecond)
+	fmt.Printf("elapsed=%s ops=%d\n", elapsed, totalOps.Load())
+
+	cause := context.Cause(baseCtx)
+	if failures.Load() > 0 || (cause != nil && cause != context.DeadlineExceeded) {
+		if cause != nil && cause != context.DeadlineExceeded {
+			fmt.Fprintf(os.Stderr, "cause: %v\n", cause)
+		}
+		fmt.Println("FAIL")
+		os.Exit(1)
+	}
+	fmt.Println("PASS")
+}
+
+// workerCtx bundles the per-worker execution environment: everything a
+// worker needs to report progress and signal a fatal anomaly to its
+// siblings. Identical across every worker spawned from main except workerID.
+type workerCtx struct {
+	ctx         context.Context
+	cancelCause context.CancelCauseFunc
+	workerID    int
+	totalOps    *atomic.Int64
+	log         *zap.Logger
+}
+
+// runPlan bundles the run configuration every worker operates under: which
+// ops to sample from and the block layout. Identical across every worker
+// spawned from main.
+type runPlan struct {
+	ops       []Op
+	nBlocks   int64
+	blockSize int
+}
+
+// spawnWorker opens handles for the given file pool, creates an opRunner,
+// and runs until ctx is done or an anomaly is found.
+func spawnWorker(wc workerCtx, paths []string, plan runPlan) error {
+	handles, err := openHandles(paths, wc.workerID, plan.blockSize, wc.log)
+	if err != nil {
+		err = fmt.Errorf("worker %d: open handles: %w", wc.workerID, err)
+		fmt.Fprintln(os.Stderr, err)
+		wc.cancelCause(err)
+		return err
+	}
+	defer closeHandles(handles)
+
+	r := newOpRunner(handles, plan.ops, int64(wc.workerID), plan.nBlocks, plan.blockSize)
+	return runWorker(wc, r)
+}
+
+// runWorker loops until ctx is done or an anomaly is returned by runOnce.
+func runWorker(wc workerCtx, r *opRunner) error {
+	for {
+		select {
+		case <-wc.ctx.Done():
+			return nil
+		default:
+		}
+		if err := r.runOnce(wc.ctx); err != nil {
+			err = fmt.Errorf("worker %d: %w", wc.workerID, err)
+			fmt.Fprintln(os.Stderr, err)
+			wc.cancelCause(err)
+			return err
+		}
+		wc.totalOps.Add(1)
+	}
+}
+
+// progressLoop prints an ops count line every 5 seconds until ctx is done.
+func progressLoop(ctx context.Context, start time.Time, totalOps *atomic.Int64) {
+	t := time.NewTicker(5 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			elapsed := time.Since(start).Round(time.Second)
+			fmt.Printf("[%s] ops=%d\n", elapsed, totalOps.Load())
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// resolveFiles returns the noOverlap file path and the shared file pool.
+// Both are created inside dir. The number of shared files is (threads-1)/2,
+// clamped to a minimum of 1 when there are shared workers.
+func resolveFiles(dir string, threads int) (noOverlapPaths, sharedPaths []string, err error) {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, nil, fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	noOverlapPaths = []string{filepath.Join(dir, "iotest-soak-0.noOverlap")}
+
+	nShared := threads - 1
+	if nShared <= 0 {
+		return noOverlapPaths, nil, nil
+	}
+	nFiles := nShared / 2
+	if nFiles == 0 {
+		nFiles = 1
+	}
+	sharedPaths = make([]string, nFiles)
+	for i := range sharedPaths {
+		sharedPaths[i] = filepath.Join(dir, fmt.Sprintf("iotest-soak-%d.shared", i))
+	}
+	return noOverlapPaths, sharedPaths, nil
+}
+
+// openHandles opens a fileHandle for each path in paths on behalf of workerID.
+// Each handle gets its own file description so OFD locks between workers work correctly.
+func openHandles(paths []string, workerID, blockSize int, log *zap.Logger) ([]*fileHandle, error) {
+	handles := make([]*fileHandle, 0, len(paths))
+	for _, p := range paths {
+		h, err := openHandle(p, workerID, blockSize, log)
+		if err != nil {
+			closeHandles(handles)
+			return nil, err
+		}
+		handles = append(handles, h)
+	}
+	return handles, nil
+}
+
+func openHandle(path string, workerID, blockSize int, log *zap.Logger) (*fileHandle, error) {
+	f, err := fileops.Open(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	store, err := xattrstore.OpenStore(path)
+	if err != nil {
+		closeErr := f.Close()
+		return nil, fmt.Errorf("OpenStore %s: %w", path, errors.Join(err, closeErr))
+	}
+	w, err := xattrstore.NewWriter(f, store, workerID, block.KindDecimal, blockSize, log)
+	if err != nil {
+		closeErr := f.Close()
+		return nil, fmt.Errorf("NewWriter %s: %w", path, errors.Join(err, closeErr))
+	}
+	return &fileHandle{path: path, file: f, store: store, writer: w}, nil
+}
+
+func closeHandles(handles []*fileHandle) {
+	for _, h := range handles {
+		if err := h.close(); err != nil {
+			fmt.Fprintf(os.Stderr, "close %s: %v\n", h.path, err)
+		}
+	}
+}
+
+func printPlan(threads int, noOverlapPaths, sharedPaths []string, duration time.Duration) {
+	fmt.Printf("Starting soak: %d thread(s)", threads)
+	if duration > 0 {
+		fmt.Printf(" for %s", duration)
+	}
+	fmt.Println()
+	fmt.Printf("  noOverlap: %s\n", noOverlapPaths[0])
+	for _, p := range sharedPaths {
+		fmt.Printf("  shared:    %s\n", p)
+	}
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/verifyio/cmd/iotest-soak/ops.go
+++ b/verifyio/cmd/iotest-soak/ops.go
@@ -1,0 +1,80 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/fileops"
+	"github.com/thinkparq/beegfs-go/verifyio/verifier"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+)
+
+// Op is a single verifiable operation. h is the chosen file handle and
+// offset is a block-aligned position within the file. A non-nil return
+// value is an anomaly that aborts the soak run.
+type Op func(ctx context.Context, h *fileHandle, offset int64) error
+
+// fileHandle bundles the per-file state one worker needs to run ops.
+// Not safe for concurrent use; each goroutine owns its own set.
+type fileHandle struct {
+	path   string
+	file   *fileops.File
+	store  *xattrstore.Store
+	writer *xattrstore.Writer
+}
+
+func (h *fileHandle) close() error {
+	return h.file.Close()
+}
+
+// writeBufferedOp returns an Op that writes one block with IOTypeBuffered.
+// ErrLockBusy and ErrSetChanged are non-fatal skips (return nil).
+func writeBufferedOp() Op {
+	return func(_ context.Context, h *fileHandle, offset int64) error {
+		err := h.writer.WriteBlock(offset, fileops.IOTypeBuffered, true)
+		if errors.Is(err, xattrstore.ErrLockBusy) || errors.Is(err, xattrstore.ErrSetChanged) {
+			return nil
+		}
+		return err
+	}
+}
+
+// verifyRangeOp returns an Op that verifies the range [offset, offset+blockSize).
+// Any anomalous span causes a non-nil return.
+func verifyRangeOp(blockSize int) Op {
+	return func(_ context.Context, h *fileHandle, offset int64) error {
+		return verifier.VerifyFile(h.store, h.file, verifier.Options{
+			Range: &verifier.ByteRange{Offset: offset, Length: int64(blockSize)},
+		}, func(span verifier.Span) error {
+			if spanIsAnomaly(span) {
+				return fmt.Errorf("anomaly in %s at [%d,%d): coverage=%s verdict=%s",
+					h.path, span.Offset, span.Offset+span.Length,
+					span.Coverage, span.Verdict)
+			}
+			return nil
+		})
+	}
+}
+
+func spanIsAnomaly(s verifier.Span) bool {
+	switch s.Coverage {
+	case verifier.CoverageMany:
+		return true
+	case verifier.CoverageOne:
+		// The verifier re-reads each header under the shared lock before
+		// checking the body, so a concurrent reseed is verified against its
+		// fresh header rather than a stale snapshot. Verdict is therefore the
+		// meaningful corruption signal here.
+		return s.Verdict != block.VerdictOK
+	default:
+		// CoverageNone: a write can complete entirely after the xattr snapshot
+		// but before the data read, leaving apparent data with no xattr claim.
+		// CoverageContended: lock was busy; body not read.
+		// Neither is a real anomaly under concurrent writes.
+		return false
+	}
+}

--- a/verifyio/cmd/iotest-soak/runner.go
+++ b/verifyio/cmd/iotest-soak/runner.go
@@ -1,0 +1,37 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"math/rand"
+)
+
+// opRunner executes random operations against a pool of file handles.
+// It is not safe for concurrent use; create one per goroutine.
+type opRunner struct {
+	handles   []*fileHandle
+	ops       []Op
+	rng       *rand.Rand
+	nBlocks   int64 // number of addressable blocks per file
+	blockSize int
+}
+
+func newOpRunner(handles []*fileHandle, ops []Op, seed int64, nBlocks int64, blockSize int) *opRunner {
+	return &opRunner{
+		handles:   handles,
+		ops:       ops,
+		rng:       rand.New(rand.NewSource(seed)),
+		nBlocks:   nBlocks,
+		blockSize: blockSize,
+	}
+}
+
+// runOnce picks a random (file, op, offset) triple and executes the op.
+// A non-nil return is an anomaly; the caller should cancel the run.
+func (r *opRunner) runOnce(ctx context.Context) error {
+	h := r.handles[r.rng.Intn(len(r.handles))]
+	op := r.ops[r.rng.Intn(len(r.ops))]
+	offset := r.rng.Int63n(r.nBlocks) * int64(r.blockSize)
+	return op(ctx, h, offset)
+}

--- a/verifyio/cmd/iotest-util/main.go
+++ b/verifyio/cmd/iotest-util/main.go
@@ -1,0 +1,66 @@
+// iotest-util -- developer utility for iotest experiments.
+//
+// Common file parameters (path, blocksize, blocks) are given as top-level
+// flags; the operation to perform is the first positional argument.
+//
+//	iotest-util -path /mnt/beegfs/test.dat -blocksize 1024 -blocks 64 write
+//	iotest-util -path /mnt/beegfs/test.dat -blocksize 1024 -blocks 200 xattr-capacity
+//
+// Run iotest-util <operation> -help for per-operation flags.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+const topUsage = `iotest-util — developer utility for iotest experiments
+
+Usage: iotest-util -path <p> -blocksize <n> -blocks <n> <operation> [op-flags]
+
+Common flags:
+  -path string       path to the test file (required)
+  -blocksize int     total bytes per block on disk (default 1024; use a power of two)
+  -blocks int        number of blocks (default 64)
+
+Operations:
+  write              write blocks to the file using xattrstore.Writer
+  xattr-capacity     write xattrs at successive offsets until failure
+
+Run iotest-util <operation> -help for operation-specific flags.
+`
+
+func main() {
+	path := flag.String("path", "", "path to the test file (required)")
+	blockSize := flag.Int("blocksize", 1024, "body bytes per block")
+	blocks := flag.Int("blocks", 64, "number of blocks")
+	flag.Usage = func() {
+		fmt.Fprint(os.Stderr, topUsage)
+	}
+	flag.Parse()
+
+	if *path == "" || flag.NArg() == 0 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	op := flag.Arg(0)
+	opArgs := flag.Args()[1:]
+
+	switch op {
+	case "write":
+		runWrite(*path, *blockSize, *blocks, opArgs)
+	case "xattr-capacity":
+		runXattrCapacity(*path, *blockSize, *blocks, opArgs)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown operation %q\n\n", op)
+		flag.Usage()
+		os.Exit(2)
+	}
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/verifyio/cmd/iotest-util/write.go
+++ b/verifyio/cmd/iotest-util/write.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/fileops"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+	"go.uber.org/zap"
+)
+
+func runWrite(path string, blockSize, blocks int, args []string) {
+	fs := flag.NewFlagSet("write", flag.ExitOnError)
+	kind := fs.String("kind", "decimal", "body pattern: decimal | prng | repeat | countup | zeros | ones")
+	fs.Usage = func() {
+		w := fs.Output()
+		fmt.Fprintln(w, "Usage: iotest-util [common flags] write [flags]")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Write blocks to the file using xattrstore.Writer. The file is")
+		fmt.Fprintln(w, "truncated to blocks*blocksize on each run.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Flags:")
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+
+	if blockSize <= 0 {
+		die("blocksize must be > 0 (got %d)", blockSize)
+	}
+	if blocks <= 0 {
+		die("blocks must be > 0")
+	}
+
+	bodyKind, err := block.KindFromString(*kind)
+	if err != nil {
+		die("%v", err)
+	}
+
+	// Close is checked explicitly at the end rather than deferred: die()
+	// calls os.Exit, which skips deferred functions entirely, so a plain
+	// `defer f.Close()` would only ever run on successful completion anyway
+	// -- and a silent Close failure there is exactly the class of bug this
+	// tool exists to catch.
+	f, err := fileops.Open(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
+	if err != nil {
+		die("open %s: %v", path, err)
+	}
+
+	store, err := xattrstore.OpenStore(path)
+	if err != nil {
+		die("OpenStore: %v", err)
+	}
+
+	w, err := xattrstore.NewWriter(f, store, 0, bodyKind, blockSize, zap.NewNop())
+	if err != nil {
+		die("NewWriter: %v", err)
+	}
+
+	fmt.Printf("path=%s  blocksize=%d  blocks=%d  kind=%s\n", path, blockSize, blocks, bodyKind)
+
+	start := time.Now()
+	for i := 0; i < blocks; i++ {
+		offset := int64(i) * int64(blockSize)
+		if err := w.WriteBlock(offset, fileops.IOTypeBuffered, false); err != nil {
+			die("WriteBlock i=%d offset=%d: %v", i, offset, err)
+		}
+	}
+	if err := f.Sync(); err != nil {
+		die("fsync: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		die("close %s: %v", path, err)
+	}
+
+	elapsed := time.Since(start)
+	total := int64(blocks) * int64(blockSize)
+	mibps := 0.0
+	if elapsed.Seconds() > 0 {
+		mibps = float64(total) / elapsed.Seconds() / (1024 * 1024)
+	}
+	fmt.Printf("wrote %d blocks (%d bytes) in %s (%.1f MiB/s)\n",
+		blocks, total, elapsed.Round(time.Millisecond), mibps)
+}

--- a/verifyio/cmd/iotest-util/xattrcap.go
+++ b/verifyio/cmd/iotest-util/xattrcap.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+)
+
+func runXattrCapacity(path string, blockSize, blocks int, args []string) {
+	fs := flag.NewFlagSet("xattr-capacity", flag.ExitOnError)
+	fs.Usage = func() {
+		w := fs.Output()
+		fmt.Fprintln(w, "Usage: iotest-util [common flags] xattr-capacity")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Write one xattr per block offset until setxattr fails, reporting the")
+		fmt.Fprintln(w, "per-inode xattr capacity of the underlying filesystem. The file at")
+		fmt.Fprintln(w, "-path is removed and recreated on each run to start from a clean")
+		fmt.Fprintln(w, "xattr namespace. Increase -blocks until you see a failure to find")
+		fmt.Fprintln(w, "the actual limit.")
+	}
+	_ = fs.Parse(args)
+
+	if blockSize <= 0 {
+		die("blocksize must be > 0 (got %d)", blockSize)
+	}
+	if blocks <= 0 {
+		die("blocks must be > 0")
+	}
+
+	// Remove before creating so the new inode starts with no xattrs.
+	// O_TRUNC would clear data but leave existing xattrs, which would
+	// make overwrite-style puts succeed past the real limit.
+	_ = os.Remove(path)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		die("create %s: %v", path, err)
+	}
+	if err := f.Truncate(int64(blocks) * int64(blockSize)); err != nil {
+		_ = f.Close() // best-effort cleanup; the truncate error below is what matters
+		die("truncate: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		die("close %s: %v", path, err)
+	}
+
+	store, err := xattrstore.OpenStore(path)
+	if err != nil {
+		die("OpenStore: %v", err)
+	}
+
+	fmt.Printf("path=%s  blocksize=%d  blocks=%d\n", path, blockSize, blocks)
+
+	hdrBuf := make([]byte, block.HeaderSize)
+	for i := 0; i < blocks; i++ {
+		offset := int64(i) * int64(blockSize)
+		hdr := block.Header{
+			Version: block.HeaderVersion,
+			Kind:    block.KindDecimal,
+			Offset:  uint64(offset),
+		}
+		if err := block.MarshalHeader(hdrBuf, &hdr); err != nil {
+			die("MarshalHeader i=%d: %v", i, err)
+		}
+		if err := store.Put(offset, int64(blockSize), hdrBuf); err != nil {
+			fmt.Printf("failed at block %d (offset %d): %v\n", i, offset, err)
+			fmt.Printf("xattrs written before failure: %d\n", i)
+			return
+		}
+	}
+	fmt.Printf("wrote all %d xattrs without error — increase -blocks to find the limit\n", blocks)
+}

--- a/verifyio/cmd/iotest-verify/main.go
+++ b/verifyio/cmd/iotest-verify/main.go
@@ -1,0 +1,178 @@
+// iotest-verify -- verify one or more data files written by verifyio.
+//
+// Each span of the file is classified by coverage and verified against its
+// stored xattr header. Anomalies are always printed; use -verbose to print
+// all spans including clean ones.
+//
+//	iotest-verify -path /tmp/iotest-smoke.dat
+//	iotest-verify -path /tmp/soak/iotest-soak-0.noOverlap -verbose
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/fileops"
+	"github.com/thinkparq/beegfs-go/verifyio/verifier"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+)
+
+func main() {
+	var (
+		path    = flag.String("path", "", "data file to verify")
+		verbose = flag.Bool("verbose", false, "print all spans, not just anomalies")
+	)
+	flag.Usage = func() {
+		w := flag.CommandLine.Output()
+		fmt.Fprintln(w, "Usage: iotest-verify -path <file> [flags]")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Verify a data file written by iotest-smoke or iotest-soak.")
+		fmt.Fprintln(w, "Every byte range is classified by coverage and checked against its stored xattr header.")
+		fmt.Fprintln(w, "Anomalies are always printed; -verbose prints all spans including clean ones.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Flags:")
+		flag.PrintDefaults()
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Examples:")
+		fmt.Fprintln(w, "  iotest-verify -path /tmp/smoke.dat")
+		fmt.Fprintln(w, "  iotest-verify -path /tmp/soak/iotest-soak-0.noOverlap -verbose")
+	}
+	if len(os.Args) == 1 {
+		flag.Usage()
+		os.Exit(2)
+	}
+	flag.Parse()
+
+	if *path == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	f, err := fileops.Open(*path, os.O_RDONLY, 0)
+	if err != nil {
+		die("open: %v", err)
+	}
+	defer f.Close()
+
+	store, err := xattrstore.OpenStore(*path)
+	if err != nil {
+		die("OpenStore: %v", err)
+	}
+
+	checkXattrPresence(*path, store)
+
+	anomalies := 0
+	total := 0
+
+	err = verifier.VerifyFile(store, f, verifier.Options{}, func(span verifier.Span) error {
+		total++
+		ok, line, detail := summarise(span)
+		if !ok {
+			anomalies++
+		}
+		if *verbose || !ok {
+			fmt.Print(line)
+			if detail != "" {
+				fmt.Print(detail)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		die("verify: %v", err)
+	}
+
+	fmt.Printf("\n%s: %d span(s) checked", *path, total)
+	if anomalies > 0 {
+		fmt.Printf(", %d anomaly(s)\n", anomalies)
+		fmt.Println("FAIL")
+		os.Exit(1)
+	}
+	fmt.Println(", 0 anomalies")
+	fmt.Println("PASS")
+}
+
+// checkXattrPresence exits with a clear message if the file is non-empty but
+// has no iotest xattr records. This catches the common case of running on a
+// filesystem where user xattrs are not enabled (e.g. BeeGFS without
+// client_extra_mount_options = user_xattr), or a file copied without
+// preserving xattrs.
+func checkXattrPresence(path string, store *xattrstore.Store) {
+	info, err := os.Stat(path)
+	if err != nil || info.Size() == 0 {
+		return
+	}
+	n := 0
+	if err := store.ForEachEntry(func(_, _ int64, _ []byte) error {
+		n++
+		return nil
+	}); err != nil {
+		// A listxattr failure (permissions, the file vanishing mid-check, ...)
+		// is a different problem than "genuinely zero xattr records" -- don't
+		// let it get misdiagnosed as missing xattr support below.
+		fmt.Fprintf(os.Stderr, "%s: listing xattrs: %v\n", path, err)
+		os.Exit(1)
+	}
+	if n == 0 {
+		fmt.Fprintf(os.Stderr, "%s: no iotest xattr records found on a non-empty file\n", path)
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Possible causes:")
+		fmt.Fprintln(os.Stderr, "  - Filesystem does not support user xattrs")
+		fmt.Fprintln(os.Stderr, "    BeeGFS: add 'client_extra_mount_options = user_xattr' to beegfs-client.conf")
+		fmt.Fprintln(os.Stderr, "  - File was copied without preserving xattrs (use 'cp --preserve=xattr')")
+		fmt.Fprintln(os.Stderr, "  - File was not written by verifyio")
+		os.Exit(1)
+	}
+}
+
+// summarise returns whether the span is clean, a one-line summary, and an
+// optional second line with header details (for CoverageOne spans).
+func summarise(s verifier.Span) (ok bool, line, detail string) {
+	switch s.Coverage {
+	case verifier.CoverageOne:
+		clean := s.Verdict == block.VerdictOK
+		status := "ok"
+		if !clean {
+			status = "FAIL"
+		}
+		line = fmt.Sprintf("offset=%-10d length=%-8d coverage=one      verdict=%-18s %s\n",
+			s.Offset, s.Length, s.Verdict, status)
+		if s.Header != nil {
+			detail = fmt.Sprintf("  kind=%-10s worker=%-4d cycle=%-6d node=%s\n",
+				s.Header.Kind, s.Header.WorkerID, s.Header.Cycle,
+				block.NodeNameString(s.Header.NodeName))
+		}
+		return clean, line, detail
+
+	case verifier.CoverageNone:
+		status := "ok"
+		if !s.AllZero {
+			status = "FAIL (non-zero bytes in uncovered region)"
+		}
+		line = fmt.Sprintf("offset=%-10d length=%-8d coverage=none     allzero=%-5v %s\n",
+			s.Offset, s.Length, s.AllZero, status)
+		return s.AllZero, line, ""
+
+	case verifier.CoverageMany:
+		line = fmt.Sprintf("offset=%-10d length=%-8d coverage=many     FAIL (%d overlapping records)\n",
+			s.Offset, s.Length, len(s.Entries))
+		return false, line, ""
+
+	case verifier.CoverageContended:
+		line = fmt.Sprintf("offset=%-10d length=%-8d coverage=contended (lock busy; skipped)\n",
+			s.Offset, s.Length)
+		return true, line, "" // contended is not an anomaly; writer is active
+
+	default:
+		line = fmt.Sprintf("offset=%-10d length=%-8d coverage=unknown(%d)\n",
+			s.Offset, s.Length, int(s.Coverage))
+		return false, line, ""
+	}
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/verifyio/fileops/file.go
+++ b/verifyio/fileops/file.go
@@ -1,0 +1,128 @@
+// Package fileops provides a File type that manages all file handles
+// needed for different IO methods (buffered, O_DIRECT, mmap, vectored).
+// Handles are lazy-initialized on first use of each IO type.
+//
+// File is not safe for concurrent use by multiple goroutines. The
+// intended pattern is one File per worker goroutine.
+package fileops
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+// IOType selects the IO method used for a write operation.
+type IOType int
+
+const (
+	IOTypeBuffered IOType = iota + 1 // standard pwrite(2) via os.File.WriteAt
+	IOTypeODirect                    // O_DIRECT pwrite(2) — bypasses page cache
+	IOTypeMmap                       // mmap(2) + memcpy into mapped region
+	IOTypePwritev                    // pwritev(2) — scatter/gather vectored IO
+)
+
+// String returns the printable name of an IOType.
+func (t IOType) String() string {
+	switch t {
+	case IOTypeBuffered:
+		return "buffered"
+	case IOTypeODirect:
+		return "odirect"
+	case IOTypeMmap:
+		return "mmap"
+	case IOTypePwritev:
+		return "pwritev"
+	default:
+		return fmt.Sprintf("iotype(%d)", int(t))
+	}
+}
+
+// ErrIOTypeNotSupported is returned by Write when the requested IOType
+// has not been implemented yet.
+var ErrIOTypeNotSupported = errors.New("fileops: IOType not supported")
+
+// File owns all file handles required to perform IO against a single
+// path using any supported IOType. Handles beyond the primary buffered
+// fd are opened or mapped lazily on first use.
+type File struct {
+	path  string
+	flags int
+	perm  fs.FileMode
+	f     *os.File // primary buffered fd; also used for OFD locking
+}
+
+// Open opens or creates the file at path with the given flags and
+// permission bits. flags follows the same convention as os.OpenFile
+// (os.O_RDWR, os.O_CREATE, os.O_TRUNC, etc.). The primary buffered fd
+// is opened immediately; other handles are opened lazily.
+func Open(path string, flags int, perm fs.FileMode) (*File, error) {
+	f, err := os.OpenFile(path, flags, perm)
+	if err != nil {
+		return nil, fmt.Errorf("fileops.Open: %w", err)
+	}
+	return &File{
+		path:  path,
+		flags: flags,
+		perm:  perm,
+		f:     f,
+	}, nil
+}
+
+// Close releases all open handles and mapped regions held by the File.
+func (f *File) Close() error {
+	if f.f != nil {
+		if err := f.f.Close(); err != nil {
+			return fmt.Errorf("fileops.Close: %w", err)
+		}
+		f.f = nil
+	}
+	return nil
+}
+
+// LockFd returns the primary file description used for OFD range
+// locking. Callers must not close the returned *os.File directly;
+// use File.Close instead.
+func (f *File) LockFd() *os.File {
+	return f.f
+}
+
+// Write writes buf to the file at offset using the requested IOType.
+// buf must contain exactly the bytes to be written; the caller is
+// responsible for sizing it correctly.
+func (f *File) Write(ioType IOType, buf []byte, offset int64) error {
+	switch ioType {
+	case IOTypeBuffered:
+		return f.writeBuffered(buf, offset)
+	case IOTypeODirect, IOTypeMmap, IOTypePwritev:
+		return fmt.Errorf("%w: %s", ErrIOTypeNotSupported, ioType)
+	default:
+		return fmt.Errorf("%w: %s", ErrIOTypeNotSupported, ioType)
+	}
+}
+
+// ReadAt reads len(buf) bytes from the file starting at offset.
+func (f *File) ReadAt(buf []byte, offset int64) (int, error) {
+	n, err := f.f.ReadAt(buf, offset)
+	if err != nil {
+		return n, fmt.Errorf("fileops.ReadAt: %w", err)
+	}
+	return n, nil
+}
+
+// Sync commits the file's current contents to stable storage.
+func (f *File) Sync() error {
+	if err := f.f.Sync(); err != nil {
+		return fmt.Errorf("fileops.Sync: %w", err)
+	}
+	return nil
+}
+
+// writeBuffered performs a standard pwrite via os.File.WriteAt.
+func (f *File) writeBuffered(buf []byte, offset int64) error {
+	if _, err := f.f.WriteAt(buf, offset); err != nil {
+		return fmt.Errorf("fileops.writeBuffered: %w", err)
+	}
+	return nil
+}

--- a/verifyio/internal/trace/trace.go
+++ b/verifyio/internal/trace/trace.go
@@ -1,0 +1,78 @@
+// Package trace configures IO-level tracing for verifyio tools.
+// It is separate from operational logging so tools can enable verbose
+// per-operation traces independently of their normal log level.
+package trace
+
+import (
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// TraceConfig controls IO-level tracing. Level 0 disables tracing.
+// Levels 1–5 follow the BeeGFS log scale (1=Error, 2=Warn, 3=Info,
+// 4/5=Debug). LogFile is the output path; empty means stderr.
+type TraceConfig struct {
+	Level   int8
+	LogFile string
+}
+
+// TraceLoggers holds one logger per traceable subsystem. Today all
+// subsystems share the same logger; the struct exists so subsystems
+// can be given independent levels later without changing call sites.
+type TraceLoggers struct {
+	IO *zap.Logger
+}
+
+// Sync flushes any buffered log entries. Call before process exit.
+func (t TraceLoggers) Sync() {
+	_ = t.IO.Sync()
+}
+
+// NewTraceLoggers builds TraceLoggers from cfg. If cfg.Level is 0,
+// all loggers are no-ops.
+func NewTraceLoggers(cfg TraceConfig) (TraceLoggers, error) {
+	if cfg.Level <= 0 {
+		return TraceLoggers{IO: zap.NewNop()}, nil
+	}
+
+	encCfg := zapcore.EncoderConfig{
+		TimeKey:     "T",
+		LevelKey:    "L",
+		MessageKey:  "M",
+		EncodeTime:  zapcore.ISO8601TimeEncoder,
+		EncodeLevel: zapcore.CapitalLevelEncoder,
+	}
+	enc := zapcore.NewConsoleEncoder(encCfg)
+
+	var sink zapcore.WriteSyncer
+	if cfg.LogFile != "" {
+		f, err := os.OpenFile(cfg.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			return TraceLoggers{}, fmt.Errorf("trace: open %s: %w", cfg.LogFile, err)
+		}
+		sink = zapcore.AddSync(f)
+	} else {
+		sink = zapcore.AddSync(os.Stderr)
+	}
+
+	level := zap.NewAtomicLevelAt(toZapLevel(cfg.Level))
+	core := zapcore.NewCore(enc, sink, level)
+
+	return TraceLoggers{IO: zap.New(core)}, nil
+}
+
+func toZapLevel(level int8) zapcore.Level {
+	switch level {
+	case 1:
+		return zapcore.ErrorLevel
+	case 2:
+		return zapcore.WarnLevel
+	case 3:
+		return zapcore.InfoLevel
+	default: // 4, 5
+		return zapcore.DebugLevel
+	}
+}

--- a/verifyio/verifier/verifier.go
+++ b/verifyio/verifier/verifier.go
@@ -1,0 +1,433 @@
+// Package verifier provides file-level verification for data files written
+// by verifyio. It classifies every byte range of a file by how many
+// xattr records claim it, verifies each covered range against its stored
+// header, and reports results via a streaming callback so large files
+// can be processed without buffering all spans in memory.
+//
+// Typical usage:
+//
+//	err := verifier.VerifyFile(store, f, verifier.Options{}, func(span verifier.Span) error {
+//	    if span.Coverage != verifier.CoverageOne || span.Verdict != block.VerdictOK {
+//	        log.Printf("anomaly at offset %d: coverage=%s verdict=%s", ...)
+//	    }
+//	    return nil
+//	})
+package verifier
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/fileops"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+	"go.uber.org/zap"
+)
+
+// Coverage classifies how many xattr records claim a given byte range.
+type Coverage int
+
+const (
+	CoverageNone      Coverage = iota // no record claims these bytes
+	CoverageOne                       // exactly one record covers this range
+	CoverageMany                      // two or more records overlap; violates replace-and-shred
+	CoverageContended                 // shared lock was busy; body not verified
+)
+
+// String returns the printable name of a Coverage value.
+func (c Coverage) String() string {
+	switch c {
+	case CoverageNone:
+		return "none"
+	case CoverageOne:
+		return "one"
+	case CoverageMany:
+		return "many"
+	case CoverageContended:
+		return "contended"
+	default:
+		return fmt.Sprintf("coverage(%d)", int(c))
+	}
+}
+
+// LockMode controls whether VerifyFile acquires OFD shared locks before
+// reading each CoverageOne span's body.
+type LockMode int
+
+const (
+	// LockShared acquires a shared OFD lock on each CoverageOne span before
+	// reading its body. Writers that hold exclusive OFD locks while writing
+	// (as Writer.WriteBlock does) guarantee the verifier never observes a
+	// partial write. If the lock is contended, the span is reported as
+	// CoverageContended and the body is not read.
+	//
+	// This is the zero value of LockMode, so Options{} uses LockShared by
+	// default.
+	//
+	// On non-Linux platforms (OFD locks are Linux-only), the underlying
+	// trySharedLock is a no-op that always reports success -- see
+	// verifier_lock_other.go. LockShared is accepted there without error,
+	// but the torn-write guarantee above does not hold: verification
+	// proceeds with no locking at all, identical to LockNone.
+	LockShared LockMode = iota
+
+	// LockNone bypasses all per-span locking in oneSpan. Callers must use
+	// this if they already hold a lock covering the verification range —
+	// see oneSpan for why a redundant lock is unsafe in LockModePOSIX.
+	LockNone
+)
+
+// ByteRange restricts verification to a specific byte range of the file.
+type ByteRange struct {
+	Offset int64
+	Length int64
+}
+
+// Options controls VerifyFile behavior.
+type Options struct {
+	// Range restricts verification to [Range.Offset, Range.Offset+Range.Length).
+	// nil verifies the whole file [0, fileSize).
+	Range *ByteRange
+	// LockMode controls OFD locking before each body read. Defaults to
+	// LockShared (zero value).
+	LockMode LockMode
+	// Log receives a trace entry for every span. nil disables tracing.
+	// Anomalous spans (CoverageMany, failed verdict, xattr mismatch,
+	// non-zero CoverageNone) are logged at Warn; all others at Debug.
+	Log *zap.Logger
+}
+
+// Span describes one contiguous byte range and its verification outcome.
+// Spans are emitted in ascending offset order, are non-overlapping, and
+// together cover the verified range exactly.
+type Span struct {
+	Offset   int64
+	Length   int64
+	Coverage Coverage
+
+	// Entries lists every xattr record whose extent overlaps this range.
+	// Empty for CoverageNone; one entry for CoverageOne and CoverageContended;
+	// two or more for CoverageMany.
+	Entries []xattrstore.Entry
+
+	// Header and Verdict are populated for CoverageOne spans where the
+	// shared lock was acquired and the block was read and verified against
+	// the xattr header. Both are zero/nil for all other Coverage values.
+	Header  *block.Header
+	Verdict block.Verdict
+
+	// AllZero is true when every byte in a CoverageNone span reads as zero
+	// (the expected state after a replace-and-shred that zeroed the uncovered
+	// region). Only meaningful for CoverageNone spans.
+	AllZero bool
+
+	// XattrMatch is true when Coverage is CoverageOne and the xattr header
+	// was successfully parsed (i.e. no header-level error verdict).
+	XattrMatch bool
+
+	// Diag carries forensic detail for a CoverageOne span whose Verdict is not
+	// VerdictOK (stripe-CRC self-consistency, read-body CRC, first differing
+	// byte). It is computed from the same buffer that produced Verdict, so its
+	// numbers always agree with it. Nil for OK spans and non-CoverageOne spans.
+	Diag *block.Diagnosis
+}
+
+// storedEntry holds an xattrstore.Entry discovered during the pre-lock snapshot.
+// The header bytes are deliberately NOT cached here: oneSpan re-reads the header
+// under the shared lock so the body is verified against a header consistent with
+// it, avoiding a false BODY_CORRUPT verdict on a benign concurrent reseed.
+type storedEntry struct {
+	entry xattrstore.Entry
+}
+
+// VerifyFile walks the file and calls fn once per non-overlapping span,
+// in ascending offset order. The spans cover [0, fileSize) unless
+// opts.Range restricts the range.
+//
+// fn is called synchronously. If fn returns a non-nil error, VerifyFile
+// stops immediately and returns that error.
+func VerifyFile(s *xattrstore.Store, f *fileops.File, opts Options, fn func(Span) error) error {
+	info, err := os.Stat(s.Target())
+	if err != nil {
+		return fmt.Errorf("verifier.VerifyFile: stat %s: %w", s.Target(), err)
+	}
+	fileSize := info.Size()
+
+	// Effective range: clamp the requested range to [0, fileSize).
+	rangeStart, rangeEnd := int64(0), fileSize
+	if opts.Range != nil {
+		if opts.Range.Offset > rangeStart {
+			rangeStart = opts.Range.Offset
+		}
+		if end := opts.Range.Offset + opts.Range.Length; end < rangeEnd {
+			rangeEnd = end
+		}
+	}
+	if rangeStart >= rangeEnd {
+		return nil
+	}
+
+	// Snapshot which xattr entries exist (offset/length only). The header is
+	// re-read per span under the shared lock in oneSpan, so we intentionally do
+	// not cache the header bytes here.
+	var entries []storedEntry
+	if err := s.ForEachEntry(func(offset, length int64, _ []byte) error {
+		entries = append(entries, storedEntry{
+			entry: xattrstore.Entry{
+				Offset: offset,
+				Length: length,
+				Name:   xattrstore.XAttrName(offset, length),
+			},
+		})
+		return nil
+	}); err != nil {
+		return fmt.Errorf("verifier.VerifyFile: listing entries: %w", err)
+	}
+
+	// Build the sweep-line boundary set: range endpoints plus every entry
+	// start and end. Including all entry boundaries (even those outside the
+	// effective range) ensures spans inside the range align with entry edges.
+	posSet := map[int64]struct{}{rangeStart: {}, rangeEnd: {}}
+	for _, e := range entries {
+		posSet[e.entry.Offset] = struct{}{}
+		posSet[e.entry.Offset+e.entry.Length] = struct{}{}
+	}
+	positions := make([]int64, 0, len(posSet))
+	for p := range posSet {
+		positions = append(positions, p)
+	}
+	sort.Slice(positions, func(i, j int) bool { return positions[i] < positions[j] })
+
+	// Walk consecutive boundary pairs. Skip pairs fully outside the
+	// effective range; clip any that straddle a boundary.
+	for i := 0; i+1 < len(positions); i++ {
+		lo, hi := positions[i], positions[i+1]
+		if hi <= rangeStart || lo >= rangeEnd {
+			continue
+		}
+		if lo < rangeStart {
+			lo = rangeStart
+		}
+		if hi > rangeEnd {
+			hi = rangeEnd
+		}
+
+		var covering []storedEntry
+		for j := range entries {
+			e := &entries[j]
+			if e.entry.Offset < hi && e.entry.Offset+e.entry.Length > lo {
+				covering = append(covering, *e)
+			}
+		}
+
+		span, err := processSpan(s, f, opts, covering, lo, hi)
+		if err != nil {
+			return err
+		}
+		if opts.Log != nil {
+			logSpan(opts.Log, span)
+		}
+		if err := fn(span); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// processSpan classifies [lo, hi) and verifies it based on coverage.
+func processSpan(s *xattrstore.Store, f *fileops.File, opts Options, covering []storedEntry, lo, hi int64) (Span, error) {
+	public := make([]xattrstore.Entry, len(covering))
+	for i, se := range covering {
+		public[i] = se.entry
+	}
+
+	switch len(covering) {
+	case 0:
+		return noneSpan(s, f, opts, lo, hi)
+	case 1:
+		return oneSpan(s, f, opts, covering[0], public, lo, hi)
+	default:
+		return Span{
+			Offset:   lo,
+			Length:   hi - lo,
+			Coverage: CoverageMany,
+			Entries:  public,
+		}, nil
+	}
+}
+
+// noneSpan reads [lo, hi) and reports whether all bytes are zero.
+//
+// Unlike oneSpan -- which holds a lock across its whole read specifically
+// because its pre-lock header snapshot can go stale -- noneSpan has no
+// record, and therefore nothing to lock, at the moment VerifyFile's
+// snapshot was taken. So if a writer's Put (and its data write) lands in
+// this genuinely-uncovered range after the snapshot but before this read
+// runs, a non-zero read here is an ordinary successful write racing the
+// scan, not corruption. Before reporting a hard anomaly, noneSpan rechecks
+// for a record that wasn't in the snapshot and, if one now exists,
+// reclassifies against the fresh data -- the same dispatch VerifyFile's
+// initial scan would have used had it seen the record in time.
+func noneSpan(s *xattrstore.Store, f *fileops.File, opts Options, lo, hi int64) (Span, error) {
+	buf := make([]byte, hi-lo)
+	n, err := f.ReadAt(buf, lo)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return Span{}, fmt.Errorf("verifier: read [%d, %d): %w", lo, hi, err)
+	}
+	buf = buf[:n]
+	allZero := true
+	for _, b := range buf {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		return Span{Offset: lo, Length: hi - lo, Coverage: CoverageNone, AllZero: true}, nil
+	}
+
+	recheck, recheckErr := s.Overlapping(lo, hi-lo)
+	if recheckErr != nil {
+		return Span{}, fmt.Errorf("verifier: recheck [%d, %d): %w", lo, hi, recheckErr)
+	}
+	switch len(recheck) {
+	case 0:
+		// Still genuinely uncovered -- a real anomaly.
+		return Span{Offset: lo, Length: hi - lo, Coverage: CoverageNone, AllZero: false}, nil
+	case 1:
+		return oneSpan(s, f, opts, storedEntry{entry: recheck[0]}, recheck, lo, hi)
+	default:
+		return Span{Offset: lo, Length: hi - lo, Coverage: CoverageMany, Entries: recheck}, nil
+	}
+}
+
+// logSpan emits a trace entry for span. Anomalies go at Warn, normal
+// spans at Debug.
+func logSpan(log *zap.Logger, span Span) {
+	fields := []zap.Field{
+		zap.Int64("offset", span.Offset),
+		zap.Int64("length", span.Length),
+		zap.String("coverage", span.Coverage.String()),
+	}
+	if span.Header != nil {
+		fields = append(fields,
+			zap.Int32("worker", span.Header.WorkerID),
+			zap.Uint64("cycle", span.Header.Cycle),
+			zap.String("ioType", fileops.IOType(span.Header.Tag&block.TagIOTypeMask).String()),
+			zap.Bool("fsynced", span.Header.Tag&block.TagFsynced != 0),
+			zap.String("verdict", span.Verdict.String()),
+		)
+	}
+	anomaly := span.Coverage == CoverageMany ||
+		(span.Coverage == CoverageOne && span.Verdict != block.VerdictOK) ||
+		(span.Coverage == CoverageNone && !span.AllZero)
+	if anomaly {
+		log.Warn("span anomaly", fields...)
+	} else {
+		log.Debug("span ok", fields...)
+	}
+}
+
+// oneSpan verifies the single record covering [lo, hi). Unless
+// opts.LockMode is LockNone, it acquires a shared lock over the full record
+// extent before reading, so the verifier never observes a partial write in
+// progress.
+//
+// Callers that already hold a lock covering [lo, hi) (e.g. soakVerifyRangeOp,
+// which pre-acquires a shared lock over the whole verification range) must
+// pass LockNone. Acquiring a second shared lock on the same Store would be
+// redundant in LockModeOFD and self-deadlocks in LockModePOSIX, where
+// TryAcquireShared takes the Store's non-reentrant in-process mutex.
+func oneSpan(s *xattrstore.Store, f *fileops.File, opts Options, se storedEntry, entries []xattrstore.Entry, lo, hi int64) (Span, error) {
+	unlock := func() error { return nil }
+	if opts.LockMode != LockNone {
+		// trySharedLock is defined in verifier_lock_linux.go / verifier_lock_other.go.
+		// It returns (unlock, contended, err). On non-Linux it is a no-op.
+		var contended bool
+		var err error
+		unlock, contended, err = trySharedLock(s, f.LockFd(), se.entry.Offset, se.entry.Length)
+		if err != nil {
+			return Span{}, fmt.Errorf("verifier: lock [%d, %d): %w",
+				se.entry.Offset, se.entry.Offset+se.entry.Length, err)
+		}
+		if contended {
+			return Span{
+				Offset:   lo,
+				Length:   hi - lo,
+				Coverage: CoverageContended,
+				Entries:  entries,
+			}, nil
+		}
+	}
+	defer func() { _ = unlock() }()
+
+	// Re-read the header UNDER the shared lock rather than using the pre-lock
+	// snapshot. The writer holds an exclusive lock across xattr-Put + data-write,
+	// so while we hold the shared lock the (header, body) pair is stable and
+	// mutually consistent. Verifying the body against a stale snapshot header
+	// would report a benign concurrent reseed (new body, old captured header) as
+	// BODY_CORRUPT.
+	headerBytes, getErr := s.Get(se.entry.Offset, se.entry.Length)
+	if errors.Is(getErr, xattrstore.ErrNotFound) {
+		// The record was removed or replaced between the snapshot and our lock —
+		// a benign race under concurrent writes; nothing claims this extent now.
+		return Span{
+			Offset:   lo,
+			Length:   hi - lo,
+			Coverage: CoverageContended,
+			Entries:  entries,
+		}, nil
+	}
+	if getErr != nil {
+		return Span{}, fmt.Errorf("verifier: re-read header at %d: %w", se.entry.Offset, getErr)
+	}
+
+	// Read the full record extent (may extend beyond the current span if
+	// the entry straddles the range boundary).
+	buf := make([]byte, se.entry.Length)
+	n, readErr := f.ReadAt(buf, se.entry.Offset)
+	if readErr != nil && !errors.Is(readErr, io.EOF) && !errors.Is(readErr, io.ErrUnexpectedEOF) {
+		return Span{}, fmt.Errorf("verifier: read record at %d: %w", se.entry.Offset, readErr)
+	}
+	buf = buf[:n]
+
+	// Unmarshal the header read above and use it to verify the on-disk block.
+	h, hdrErr := block.UnmarshalHeader(headerBytes)
+	var verdict block.Verdict
+	var diag *block.Diagnosis
+	if hdrErr != nil {
+		switch {
+		case errors.Is(hdrErr, block.ErrBadMagic):
+			verdict = block.VerdictHeadBadMagic
+		case errors.Is(hdrErr, block.ErrBadVersion):
+			verdict = block.VerdictHeadBadFormat
+		case errors.Is(hdrErr, block.ErrTruncated):
+			verdict = block.VerdictTruncated
+		default:
+			verdict = block.VerdictHeadBadCRC
+		}
+	} else {
+		verdict, _ = block.VerifyBlock(buf, &h, nil)
+		// Only anomalies get the extra forensic pass; OK spans (the common case
+		// on a healthy verify sweep) pay nothing beyond VerifyBlock itself.
+		if verdict != block.VerdictOK {
+			d := block.Diagnose(buf, &h)
+			diag = &d
+		}
+	}
+
+	hCopy := h
+	return Span{
+		Offset:     lo,
+		Length:     hi - lo,
+		Coverage:   CoverageOne,
+		Entries:    entries,
+		Header:     &hCopy,
+		Verdict:    verdict,
+		XattrMatch: hdrErr == nil,
+		Diag:       diag,
+	}, nil
+}

--- a/verifyio/verifier/verifier_lock_linux.go
+++ b/verifyio/verifier/verifier_lock_linux.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package verifier
+
+import (
+	"errors"
+	"os"
+
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+)
+
+// trySharedLock tries to acquire a shared OFD lock over [offset,
+// offset+length) using f as the lock fd. Returns:
+//   - unlock: a function that releases the lock (always non-nil)
+//   - contended: true if an exclusive holder blocked the attempt
+//   - err: non-nil only for unexpected failures (not contention)
+func trySharedLock(s *xattrstore.Store, f *os.File, offset, length int64) (unlock func() error, contended bool, err error) {
+	lease, err := s.TryAcquireShared(f, offset, length)
+	if err != nil {
+		if errors.Is(err, xattrstore.ErrLockBusy) {
+			return func() error { return nil }, true, nil
+		}
+		return func() error { return nil }, false, err
+	}
+	return lease.Release, false, nil
+}

--- a/verifyio/verifier/verifier_lock_linux_test.go
+++ b/verifyio/verifier/verifier_lock_linux_test.go
@@ -1,0 +1,145 @@
+//go:build linux
+
+// This is a unit test.
+//
+// Coverage: VerifyFile reports CoverageContended when a span's shared lock
+// can't be acquired (held exclusively elsewhere); and the underlying
+// trySharedLock primitive allows multiple concurrent shared readers but
+// blocks a conflicting exclusive request.
+package verifier_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/fileops"
+	"github.com/thinkparq/beegfs-go/verifyio/verifier"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+)
+
+func TestVerifyFileContended(t *testing.T) {
+	// Hold an exclusive OFD lock on one record while running VerifyFile.
+	// The verifier must report that span as CoverageContended rather than
+	// failing or blocking.
+	const (
+		blockSize = 1024
+		numBlocks = 2
+	)
+	path, store := testEnv(t)
+	writeRecords(t, path, store, blockSize, numBlocks)
+
+	blockDataSize := int64(blockSize)
+
+	// A separate fd holds the exclusive lock on record 0.
+	lockFd, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open lock fd: %v", err)
+	}
+	defer lockFd.Close()
+
+	lease, err := store.TryAcquireExclusive(lockFd, 0, blockDataSize)
+	if err != nil {
+		t.Fatalf("TryAcquireExclusive: %v", err)
+	}
+	defer lease.Release()
+
+	// Verify on a different fd — it should see CoverageContended for
+	// the locked record, CoverageOne+OK for the unlocked one.
+	fv, err := fileops.Open(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("Open for verify: %v", err)
+	}
+	defer fv.Close()
+
+	spans := collectSpans(t, store, fv, verifier.Options{})
+
+	if len(spans) != numBlocks {
+		t.Fatalf("got %d spans, want %d", len(spans), numBlocks)
+	}
+	if spans[0].Coverage != verifier.CoverageContended {
+		t.Errorf("span 0 (locked): coverage=%v, want CoverageContended", spans[0].Coverage)
+	}
+	if spans[1].Coverage != verifier.CoverageOne {
+		t.Errorf("span 1 (unlocked): coverage=%v, want CoverageOne", spans[1].Coverage)
+	}
+	if spans[1].Verdict != block.VerdictOK {
+		t.Errorf("span 1: verdict=%v, want VerdictOK", spans[1].Verdict)
+	}
+}
+
+// TestTryAcquireSharedMultipleReaders verifies that two shared locks can
+// coexist on overlapping ranges (shared locks do not conflict with each other).
+func TestTryAcquireSharedMultipleReaders(t *testing.T) {
+	path, _ := testEnv(t)
+	if err := os.WriteFile(path, make([]byte, 4096), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	store, err := xattrstore.OpenStore(path)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+
+	f1, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("open f1: %v", err)
+	}
+	defer f1.Close()
+
+	f2, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("open f2: %v", err)
+	}
+	defer f2.Close()
+
+	l1, err := store.TryAcquireShared(f1, 0, 1024)
+	if err != nil {
+		t.Fatalf("first shared lock: %v", err)
+	}
+	defer l1.Release()
+
+	// Second shared lock on overlapping range must succeed.
+	l2, err := store.TryAcquireShared(f2, 512, 1024)
+	if err != nil {
+		t.Fatalf("second shared lock (should succeed): %v", err)
+	}
+	if err := l2.Release(); err != nil {
+		t.Fatalf("release l2: %v", err)
+	}
+}
+
+// TestTryAcquireSharedBlocksExclusive verifies that a shared lock blocks a
+// subsequent exclusive acquire on an overlapping range.
+func TestTryAcquireSharedBlocksExclusive(t *testing.T) {
+	path, _ := testEnv(t)
+	if err := os.WriteFile(path, make([]byte, 4096), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	store, err := xattrstore.OpenStore(path)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+
+	f1, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("open f1: %v", err)
+	}
+	defer f1.Close()
+
+	f2, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open f2: %v", err)
+	}
+	defer f2.Close()
+
+	shared, err := store.TryAcquireShared(f1, 0, 1024)
+	if err != nil {
+		t.Fatalf("shared lock: %v", err)
+	}
+	defer shared.Release()
+
+	// Exclusive acquire on overlapping range must fail with ErrLockBusy.
+	if _, err := store.TryAcquireExclusive(f2, 0, 1024); err != xattrstore.ErrLockBusy {
+		t.Errorf("exclusive while shared held: err=%v, want ErrLockBusy", err)
+	}
+}

--- a/verifyio/verifier/verifier_lock_other.go
+++ b/verifyio/verifier/verifier_lock_other.go
@@ -1,0 +1,17 @@
+//go:build !linux
+
+package verifier
+
+import (
+	"os"
+
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+)
+
+// trySharedLock is a no-op on non-Linux platforms where OFD locks are
+// not available. It always reports success so verification proceeds
+// without locking guarantees -- see LockShared's doc comment in
+// verifier.go for what this means for callers on this platform.
+func trySharedLock(s *xattrstore.Store, f *os.File, offset, length int64) (func() error, bool, error) {
+	return func() error { return nil }, false, nil
+}

--- a/verifyio/verifier/verifier_test.go
+++ b/verifyio/verifier/verifier_test.go
@@ -1,0 +1,456 @@
+// This is a unit test.
+//
+// Coverage: VerifyFile's sweep-line classification -- an all-OK sweep,
+// CoverageNone for unwritten byte ranges, CoverageMany for overlapping
+// records, a caller-supplied byte-range filter, an empty file, and the
+// caller's per-span callback short-circuiting the sweep on error -- plus two
+// concurrent-write guarantees: a block reseeded between the xattr snapshot
+// and the per-span lock is verified against its fresh header rather than
+// being falsely reported as BODY_CORRUPT against the stale snapshot, and a
+// write landing in a snapshot-uncovered range before the sweep reaches it
+// is detected and verified rather than being falsely reported as a
+// CoverageNone anomaly.
+package verifier_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/fileops"
+	"github.com/thinkparq/beegfs-go/verifyio/verifier"
+	"github.com/thinkparq/beegfs-go/verifyio/xattr"
+	"github.com/thinkparq/beegfs-go/verifyio/xattrstore"
+)
+
+// testEnv creates a temp file with xattr support verified, returns the
+// path and an open Store. Skips the test if xattrs are not supported.
+func testEnv(t *testing.T) (path string, store *xattrstore.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	path = filepath.Join(dir, "data.dat")
+	if err := os.WriteFile(path, nil, 0644); err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+	if err := xattr.Set(path, "user.verifyio_probe", []byte{0}, 0); err != nil {
+		t.Skipf("user xattrs not supported: %v", err)
+	}
+	_ = xattr.Remove(path, "user.verifyio_probe")
+	var err error
+	store, err = xattrstore.OpenStore(path)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	return path, store
+}
+
+// collectSpans runs VerifyFile with the given options and returns all spans.
+func collectSpans(t *testing.T, store *xattrstore.Store, f *fileops.File, opts verifier.Options) []verifier.Span {
+	t.Helper()
+	var spans []verifier.Span
+	if err := verifier.VerifyFile(store, f, opts, func(s verifier.Span) error {
+		spans = append(spans, s)
+		return nil
+	}); err != nil {
+		t.Fatalf("VerifyFile: %v", err)
+	}
+	return spans
+}
+
+// writeRecords writes numBlocks consecutive blocks with blockSize bytes each
+// starting at offset 0, using Worker 0 and KindDecimal.
+func writeRecords(t *testing.T, path string, store *xattrstore.Store, blockSize, numBlocks int) {
+	t.Helper()
+	f, err := fileops.Open(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer f.Close()
+	w, err := xattrstore.NewWriter(f, store, 0, block.KindDecimal, blockSize, nil)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	stride := int64(blockSize)
+	for i := 0; i < numBlocks; i++ {
+		if err := w.WriteBlock(int64(i)*stride, fileops.IOTypeBuffered, false); err != nil {
+			t.Fatalf("WriteBlock %d: %v", i, err)
+		}
+	}
+}
+
+func TestVerifyFileAllOK(t *testing.T) {
+	const (
+		blockSize = 1024
+		numBlocks = 3
+	)
+	path, store := testEnv(t)
+	writeRecords(t, path, store, blockSize, numBlocks)
+
+	f, err := fileops.Open(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("Open for verify: %v", err)
+	}
+	defer f.Close()
+
+	spans := collectSpans(t, store, f, verifier.Options{})
+
+	if len(spans) != numBlocks {
+		t.Fatalf("got %d spans, want %d", len(spans), numBlocks)
+	}
+	for i, s := range spans {
+		wantOffset := int64(i) * int64(blockSize)
+		if s.Offset != wantOffset {
+			t.Errorf("span %d: offset=%d, want %d", i, s.Offset, wantOffset)
+		}
+		if s.Length != int64(blockSize) {
+			t.Errorf("span %d: length=%d, want %d", i, s.Length, blockSize)
+		}
+		if s.Coverage != verifier.CoverageOne {
+			t.Errorf("span %d: coverage=%v, want CoverageOne", i, s.Coverage)
+		}
+		if s.Verdict != block.VerdictOK {
+			t.Errorf("span %d: verdict=%v, want VerdictOK", i, s.Verdict)
+		}
+		if s.Header == nil {
+			t.Errorf("span %d: Header is nil", i)
+		}
+	}
+}
+
+func TestVerifyFileCoverageNone(t *testing.T) {
+	// Write two records with a gap between them.
+	//   record 0: [0, blockDataSize)
+	//   record 1: [2048, 2048+blockDataSize)  ← gap [blockDataSize, 2048) is uncovered
+	const blockSize = 1024
+	path, store := testEnv(t)
+
+	blockDataSize := int64(blockSize)
+	f, err := fileops.Open(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	w, err := xattrstore.NewWriter(f, store, 0, block.KindDecimal, blockSize, nil)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := w.WriteBlock(0, fileops.IOTypeBuffered, false); err != nil {
+		t.Fatalf("WriteBlock 0: %v", err)
+	}
+	if err := w.WriteBlock(2048, fileops.IOTypeBuffered, false); err != nil {
+		t.Fatalf("WriteBlock 2048: %v", err)
+	}
+	f.Close()
+
+	fv, err := fileops.Open(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("Open for verify: %v", err)
+	}
+	defer fv.Close()
+
+	spans := collectSpans(t, store, fv, verifier.Options{})
+
+	// Expect: [0,blockDataSize) one, [blockDataSize,2048) none, [2048,2048+blockDataSize) one.
+	type want struct {
+		offset   int64
+		length   int64
+		coverage verifier.Coverage
+	}
+	wantSpans := []want{
+		{0, blockDataSize, verifier.CoverageOne},
+		{blockDataSize, 2048 - blockDataSize, verifier.CoverageNone},
+		{2048, blockDataSize, verifier.CoverageOne},
+	}
+	if len(spans) != len(wantSpans) {
+		t.Fatalf("got %d spans, want %d: %v", len(spans), len(wantSpans), spans)
+	}
+	for i, w := range wantSpans {
+		s := spans[i]
+		if s.Offset != w.offset || s.Length != w.length || s.Coverage != w.coverage {
+			t.Errorf("span %d: got {%d, %d, %v}, want {%d, %d, %v}",
+				i, s.Offset, s.Length, s.Coverage,
+				w.offset, w.length, w.coverage)
+		}
+		if w.coverage == verifier.CoverageNone && !s.AllZero {
+			t.Errorf("span %d: gap is not all-zero (os should zero it)", i)
+		}
+	}
+}
+
+// TestVerifyFileNoneSpanRechecksBeforeReportingAnomaly is a regression test
+// for a false-positive window: unlike oneSpan (which holds a lock across
+// its whole read specifically because its pre-lock header snapshot can go
+// stale), the CoverageNone path had no record -- and therefore nothing to
+// lock -- at the moment VerifyFile's snapshot was taken, so a write landing
+// in a genuinely-uncovered range after the snapshot but before the read
+// used to be misreported as corruption (non-zero bytes in an uncovered
+// region) instead of being recognized as an ordinary write racing the scan.
+//
+// This uses VerifyFile's own per-span callback as a synchronization point
+// (deterministic, no goroutines/timing needed): while the callback is
+// still processing the span for the FIRST block, it writes a second block
+// into the range the snapshot said was empty, before the sweep reaches it.
+func TestVerifyFileNoneSpanRechecksBeforeReportingAnomaly(t *testing.T) {
+	const blockSize = 1024
+	path, store := testEnv(t)
+
+	f, err := fileops.Open(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer f.Close()
+	w, err := xattrstore.NewWriter(f, store, 0, block.KindDecimal, blockSize, nil)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if err := w.WriteBlock(0, fileops.IOTypeBuffered, false); err != nil {
+		t.Fatalf("WriteBlock 0: %v", err)
+	}
+	// Extend the file so VerifyFile's sweep covers [blockSize, 2*blockSize)
+	// too, while leaving it genuinely uncovered (no xattr, zero-filled by
+	// the OS) at snapshot time.
+	if err := os.Truncate(path, 2*blockSize); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	var spans []verifier.Span
+	err = verifier.VerifyFile(store, f, verifier.Options{}, func(s verifier.Span) error {
+		if s.Offset == 0 && len(spans) == 0 {
+			// Simulate a writer landing in the snapshot-uncovered range
+			// before the sweep reaches it.
+			if err := w.WriteBlock(blockSize, fileops.IOTypeBuffered, false); err != nil {
+				t.Fatalf("mid-scan WriteBlock: %v", err)
+			}
+		}
+		spans = append(spans, s)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("VerifyFile: %v", err)
+	}
+
+	if len(spans) != 2 {
+		t.Fatalf("got %d spans, want 2: %+v", len(spans), spans)
+	}
+	second := spans[1]
+	if second.Offset != blockSize || second.Length != blockSize {
+		t.Fatalf("second span = {offset=%d, length=%d}, want {%d, %d}",
+			second.Offset, second.Length, blockSize, blockSize)
+	}
+	if second.Coverage != verifier.CoverageOne {
+		t.Errorf("second span coverage=%v, want CoverageOne (the mid-scan write should have been detected, not reported as a CoverageNone anomaly)", second.Coverage)
+	}
+	if second.Verdict != block.VerdictOK {
+		t.Errorf("second span verdict=%v, want VerdictOK", second.Verdict)
+	}
+}
+
+func TestVerifyFileCoverageMany(t *testing.T) {
+	// Directly Put two overlapping xattrs without using ReplaceRange,
+	// which is the condition CoverageMany is designed to surface.
+	path, store := testEnv(t)
+
+	makeHdr := func(offset, seed int64) []byte {
+		h := block.Header{
+			Version: block.HeaderVersion,
+			Kind:    block.KindZeros,
+			Seed:    uint64(seed),
+			Offset:  uint64(offset),
+		}
+		buf := make([]byte, block.HeaderSize)
+		if err := block.MarshalHeader(buf, &h); err != nil {
+			t.Fatalf("MarshalHeader: %v", err)
+		}
+		return buf
+	}
+	if err := store.Put(0, 2048, makeHdr(0, 1)); err != nil {
+		t.Fatalf("Put A: %v", err)
+	}
+	if err := store.Put(1024, 2048, makeHdr(1024, 2)); err != nil {
+		t.Fatalf("Put B: %v", err)
+	}
+	// Write enough bytes to the file so ReadAt doesn't fail.
+	if err := os.WriteFile(path, make([]byte, 4096), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	// Re-open store after truncation.
+	store, err := xattrstore.OpenStore(path)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	// Re-put (WriteFile truncates xattrs... actually no, WriteFile uses O_TRUNC
+	// which shouldn't touch xattrs). Let's verify xattrs are still there.
+	if err := store.Put(0, 2048, makeHdr(0, 1)); err != nil {
+		t.Fatalf("re-Put A: %v", err)
+	}
+	if err := store.Put(1024, 2048, makeHdr(1024, 2)); err != nil {
+		t.Fatalf("re-Put B: %v", err)
+	}
+
+	fv, err := fileops.Open(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("Open for verify: %v", err)
+	}
+	defer fv.Close()
+
+	spans := collectSpans(t, store, fv, verifier.Options{})
+
+	// Sort by offset for deterministic comparison.
+	sort.Slice(spans, func(i, j int) bool { return spans[i].Offset < spans[j].Offset })
+
+	foundMany := false
+	for _, s := range spans {
+		if s.Coverage == verifier.CoverageMany {
+			foundMany = true
+		}
+	}
+	if !foundMany {
+		t.Errorf("expected at least one CoverageMany span; got: %v", spans)
+	}
+}
+
+func TestVerifyFileRangeFilter(t *testing.T) {
+	// Write 5 records. Verify only the middle 3 (blocks 1-3).
+	const (
+		blockSize = 1024
+		numBlocks = 5
+	)
+	path, store := testEnv(t)
+	writeRecords(t, path, store, blockSize, numBlocks)
+
+	fv, err := fileops.Open(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("Open for verify: %v", err)
+	}
+	defer fv.Close()
+
+	blockDataSize := int64(blockSize)
+	opts := verifier.Options{
+		Range: &verifier.ByteRange{Offset: blockDataSize, Length: 3 * blockDataSize},
+	}
+	spans := collectSpans(t, store, fv, opts)
+
+	if len(spans) != 3 {
+		t.Fatalf("got %d spans, want 3", len(spans))
+	}
+	for i, s := range spans {
+		wantOffset := blockDataSize * int64(1+i)
+		if s.Offset != wantOffset {
+			t.Errorf("span %d: offset=%d, want %d", i, s.Offset, wantOffset)
+		}
+		if s.Coverage != verifier.CoverageOne {
+			t.Errorf("span %d: coverage=%v, want CoverageOne", i, s.Coverage)
+		}
+		if s.Verdict != block.VerdictOK {
+			t.Errorf("span %d: verdict=%v, want VerdictOK", i, s.Verdict)
+		}
+	}
+}
+
+func TestVerifyFileEmptyFile(t *testing.T) {
+	path, store := testEnv(t)
+	fv, err := fileops.Open(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer fv.Close()
+	spans := collectSpans(t, store, fv, verifier.Options{})
+	if len(spans) != 0 {
+		t.Errorf("empty file: got %d spans, want 0", len(spans))
+	}
+}
+
+func TestVerifyFileCallbackError(t *testing.T) {
+	const (
+		blockSize = 1024
+		numBlocks = 3
+	)
+	path, store := testEnv(t)
+	writeRecords(t, path, store, blockSize, numBlocks)
+
+	fv, err := fileops.Open(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer fv.Close()
+
+	sentinel := os.ErrInvalid
+	saw := 0
+	err = verifier.VerifyFile(store, fv, verifier.Options{}, func(s verifier.Span) error {
+		saw++
+		return sentinel
+	})
+	if err != sentinel {
+		t.Errorf("VerifyFile returned %v, want sentinel", err)
+	}
+	if saw != 1 {
+		t.Errorf("callback called %d times after error, want 1", saw)
+	}
+}
+
+// TestVerifyFileConcurrentReseedNoFalseCorrupt is a regression test for the
+// snapshot-vs-lock race. VerifyFile snapshots the entry set before taking
+// per-span shared locks, but must re-read each header UNDER the lock. Here a
+// writer reseeds one block (new header + new body, under its exclusive lock) in
+// a loop while the verifier sweeps concurrently. Because the writer holds the
+// exclusive lock across both the xattr and the data write, a shared-lock holder
+// always observes a consistent (header, body) pair, so the verifier must never
+// report BODY_CORRUPT / BODY_CRC_MISMATCH. Before the fix, verifying the new
+// body against the stale snapshot header produced a false VerdictBodyCorrupt.
+func TestVerifyFileConcurrentReseedNoFalseCorrupt(t *testing.T) {
+	const blockSize = 1024
+	path, store := testEnv(t)
+
+	fw, err := fileops.Open(path, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("open writer: %v", err)
+	}
+	defer fw.Close()
+	w, err := xattrstore.NewWriter(fw, store, 0, block.KindDecimal, blockSize, nil)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	// First locked write; skip if OFD locking isn't available on this platform/fs.
+	if err := w.WriteBlock(0, fileops.IOTypeBuffered, true); err != nil {
+		t.Skipf("OFD-locked write not supported here: %v", err)
+	}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = w.WriteBlock(0, fileops.IOTypeBuffered, true) // reseed under exclusive lock
+				time.Sleep(50 * time.Microsecond)                 // leave the verifier lock-free windows
+			}
+		}
+	}()
+	defer func() { close(stop); <-done }()
+
+	fv, err := fileops.Open(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("open verifier: %v", err)
+	}
+	defer fv.Close()
+
+	for i := 0; i < 300; i++ {
+		verr := verifier.VerifyFile(store, fv, verifier.Options{LockMode: verifier.LockShared},
+			func(s verifier.Span) error {
+				if s.Verdict == block.VerdictBodyCorrupt || s.Verdict == block.VerdictBodyCRCMismatch {
+					return fmt.Errorf("false %s at offset %d (iteration %d)", s.Verdict, s.Offset, i)
+				}
+				return nil
+			})
+		if verr != nil {
+			t.Fatalf("VerifyFile under concurrent reseed: %v — the verifier must re-read the header under the shared lock", verr)
+		}
+	}
+}

--- a/verifyio/xattr/notfound_darwin.go
+++ b/verifyio/xattr/notfound_darwin.go
@@ -1,0 +1,13 @@
+package xattr
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+// isNotFound reports whether err is the platform's "attribute does not
+// exist" errno. Darwin returns ENOATTR.
+func isNotFound(err error) bool {
+	return errors.Is(err, unix.ENOATTR)
+}

--- a/verifyio/xattr/notfound_linux.go
+++ b/verifyio/xattr/notfound_linux.go
@@ -1,0 +1,13 @@
+package xattr
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+// isNotFound reports whether err is the platform's "attribute does not
+// exist" errno. Linux returns ENODATA.
+func isNotFound(err error) bool {
+	return errors.Is(err, unix.ENODATA)
+}

--- a/verifyio/xattr/xattr.go
+++ b/verifyio/xattr/xattr.go
@@ -1,0 +1,129 @@
+// Package xattr provides ergonomic wrappers around the Linux/Darwin
+// extended-attribute syscalls.
+//
+// The raw unix.Getxattr / unix.Listxattr calls use a two-step size-probe
+// protocol (call with nil to get the needed buffer size, then call with
+// a real buffer). These helpers hide that detail and return a single
+// []byte or []string.
+//
+// All operations target a path; if you want the fd-based variants, use
+// unix.Fsetxattr / Fgetxattr / Flistxattr / Fremovexattr directly.
+//
+// Errors: this package normalizes the platform-specific "no such
+// attribute" errno (ENODATA on Linux, ENOATTR on Darwin) to the
+// exported sentinel ErrNotFound. Other syscall errors are returned
+// unwrapped.
+//
+// Namespace note: on Linux, unprivileged processes can only touch the
+// "user." namespace on regular files and directories. "trusted.*",
+// "security.*", and "system.*" require capabilities. Tests should use
+// "user.*" names unless specifically exercising the other namespaces.
+package xattr
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// ErrNotFound is returned by Get and Remove when the named attribute
+// does not exist. The platform-specific errno (ENODATA on Linux,
+// ENOATTR on Darwin) is hidden behind this sentinel so callers can
+// write portable error checks with errors.Is.
+var ErrNotFound = errors.New("xattr: attribute not found")
+
+// Set creates or replaces an extended attribute on path. Pass flags=0
+// for "create or replace", unix.XATTR_CREATE to require the attribute
+// not already exist, or unix.XATTR_REPLACE to require it does. With
+// XATTR_REPLACE on a missing attribute, returns ErrNotFound.
+func Set(path, name string, value []byte, flags int) error {
+	if err := unix.Setxattr(path, name, value, flags); err != nil {
+		if isNotFound(err) {
+			return ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// Get returns the current value of an extended attribute. Returns
+// ErrNotFound if the attribute does not exist.
+func Get(path, name string) ([]byte, error) {
+	for {
+		sz, err := unix.Getxattr(path, name, nil)
+		if err != nil {
+			if isNotFound(err) {
+				return nil, ErrNotFound
+			}
+			return nil, err
+		}
+		if sz == 0 {
+			return []byte{}, nil
+		}
+		buf := make([]byte, sz)
+		n, err := unix.Getxattr(path, name, buf)
+		if err != nil {
+			if errors.Is(err, unix.ERANGE) {
+				continue // value grew between probe and read; retry
+			}
+			return nil, err
+		}
+		return buf[:n], nil
+	}
+}
+
+// List returns the names of every extended attribute on path.
+func List(path string) ([]string, error) {
+	for {
+		sz, err := unix.Listxattr(path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("size probe: %w", err)
+		}
+		if sz == 0 {
+			return nil, nil
+		}
+		buf := make([]byte, sz)
+		n, err := unix.Listxattr(path, buf)
+		if err != nil {
+			if errors.Is(err, unix.ERANGE) {
+				continue // list grew between probe and read; retry
+			}
+			return nil, fmt.Errorf("read (buf=%d): %w", sz, err)
+		}
+		return SplitNULStrings(buf[:n]), nil
+	}
+}
+
+// Remove deletes an extended attribute. Returns ErrNotFound if the
+// attribute did not exist.
+func Remove(path, name string) error {
+	if err := unix.Removexattr(path, name); err != nil {
+		if isNotFound(err) {
+			return ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// SplitNULStrings converts the NUL-separated byte stream that Listxattr
+// returns into a slice of Go strings. Empty trailing segments are
+// dropped. Exposed because it's occasionally useful when working with
+// the raw unix.Listxattr output directly.
+func SplitNULStrings(data []byte) []string {
+	var out []string
+	start := 0
+	for i, b := range data {
+		if b == 0 {
+			if i > start {
+				out = append(out, string(data[start:i]))
+			}
+			start = i + 1
+		}
+	}
+	if start < len(data) {
+		out = append(out, string(data[start:]))
+	}
+	return out
+}

--- a/verifyio/xattr/xattr_test.go
+++ b/verifyio/xattr/xattr_test.go
@@ -1,0 +1,136 @@
+// This is a unit test. It exercises real xattr syscalls against a temp file
+// (skipped if the underlying filesystem doesn't support user xattrs).
+//
+// Coverage: Set/Get/Remove round-trip and replace-in-place; Get/Remove of a
+// missing attribute returning ErrNotFound; List; XATTR_REPLACE against a
+// missing attribute; XATTR_CREATE exclusivity (second create fails EEXIST);
+// and SplitNULStrings parsing of the raw listxattr byte stream (empty input,
+// single/multiple NUL-terminated names, missing trailing NUL, empty segments
+// dropped).
+package xattr
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// makeTempFile creates a regular file in the test's temp directory and
+// returns its path. Skips the test if the underlying tmp filesystem
+// does not support user xattrs (e.g., tmpfs without user_xattr, or a
+// system without xattr support at all).
+func makeTempFile(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "xattr-test")
+	if err := os.WriteFile(path, []byte("hi"), 0644); err != nil {
+		t.Fatalf("create tempfile: %v", err)
+	}
+	// Probe support: try setting and immediately removing a probe attr.
+	if err := Set(path, "user.verifyio_probe", []byte{0}, 0); err != nil {
+		t.Skipf("user xattrs not supported on tmp filesystem: %v", err)
+	}
+	_ = Remove(path, "user.verifyio_probe")
+	return path
+}
+
+func TestSetGetRemove(t *testing.T) {
+	p := makeTempFile(t)
+	const name = "user.verifyio_one"
+	val := []byte("hello world")
+
+	if err := Set(p, name, val, 0); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := Get(p, name)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, val) {
+		t.Errorf("Get returned %q, want %q", got, val)
+	}
+
+	// Replace
+	val2 := []byte("replaced")
+	if err := Set(p, name, val2, 0); err != nil {
+		t.Fatalf("Set replace: %v", err)
+	}
+	got, _ = Get(p, name)
+	if !bytes.Equal(got, val2) {
+		t.Errorf("after replace: got %q, want %q", got, val2)
+	}
+
+	if err := Remove(p, name); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := Get(p, name); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get after Remove: err = %v, want ErrNotFound", err)
+	}
+	if err := Remove(p, name); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Remove of missing attr: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestList(t *testing.T) {
+	p := makeTempFile(t)
+	names := []string{"user.verifyio_a", "user.verifyio_b", "user.verifyio_c"}
+	for _, n := range names {
+		if err := Set(p, n, []byte("v"), 0); err != nil {
+			t.Fatalf("Set %s: %v", n, err)
+		}
+	}
+	got, err := List(p)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, n := range names {
+		if !slices.Contains(got, n) {
+			t.Errorf("List missing %q (got %v)", n, got)
+		}
+	}
+}
+
+func TestSetReplaceMissing(t *testing.T) {
+	p := makeTempFile(t)
+	if err := Set(p, "user.verifyio_nope", []byte("x"), unix.XATTR_REPLACE); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Set REPLACE on missing: err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestSetCreateExclusive(t *testing.T) {
+	p := makeTempFile(t)
+	const name = "user.verifyio_excl"
+	if err := Set(p, name, []byte("x"), unix.XATTR_CREATE); err != nil {
+		t.Fatalf("first XATTR_CREATE: %v", err)
+	}
+	if err := Set(p, name, []byte("y"), unix.XATTR_CREATE); !errors.Is(err, unix.EEXIST) {
+		t.Errorf("second XATTR_CREATE: err = %v, want EEXIST", err)
+	}
+}
+
+func TestSplitNULStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want []string
+	}{
+		{"empty", nil, nil},
+		{"single nul-terminated", []byte("foo\x00"), []string{"foo"}},
+		{"multiple", []byte("foo\x00bar\x00baz\x00"), []string{"foo", "bar", "baz"}},
+		{"missing trailing nul", []byte("foo\x00bar"), []string{"foo", "bar"}},
+		{"empty segments dropped", []byte("\x00foo\x00\x00bar\x00"), []string{"foo", "bar"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SplitNULStrings(tc.in)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/verifyio/xattrstore/errors.go
+++ b/verifyio/xattrstore/errors.go
@@ -1,0 +1,42 @@
+package xattrstore
+
+import "errors"
+
+// ErrLockBusy is returned by TryAcquireExclusive when another lock
+// holder conflicts with the requested range — either an OFD holder on
+// this node or a POSIX holder on another node. Callers should treat
+// this as "pick a different file or region" rather than retrying
+// immediately.
+var ErrLockBusy = errors.New("xattrstore: range lock busy")
+
+// ErrSetChanged is returned by TryAcquireExclusive when the set of
+// records overlapping the requested range changed between the initial
+// scan and the post-lock re-scan. The lock has already been released
+// before this error is returned. Callers should treat this as "pick a
+// different file or region" rather than retrying immediately.
+var ErrSetChanged = errors.New("xattrstore: overlap set changed during lock acquisition")
+
+// ErrLockViolation is returned by Writer.WriteBlock when a post-write
+// xattr read-back does not match what was just written. This indicates
+// that another writer modified the range while the locks were held —
+// i.e. the filesystem's distributed locking did not provide the
+// expected exclusivity. This is always a hard test failure.
+var ErrLockViolation = errors.New("xattrstore: lock violation — xattr overwritten while lock was held")
+
+// ErrLockTimeout is returned by TryAcquireExclusive and TryAcquireShared in
+// LockModePOSIX when an underlying syscall (F_SETLK, or one of the xattr
+// scans used to compute the lock range) does not return within the Store's
+// lock timeout.
+//
+// F_SETLK is documented as non-blocking, but BeeGFS's distributed lock
+// manager can cause it — and xattr operations on the same file — to block
+// indefinitely if the metadata server is unresponsive or deadlocked.
+// ErrLockTimeout is the "give up and report" signal for that condition.
+//
+// Go cannot interrupt a blocked syscall: the goroutine that issued the call
+// keeps running until the kernel returns, which may be never. After
+// ErrLockTimeout the Store's in-process mutex has already been released by
+// the caller, but the underlying POSIX lock state is no longer reliable —
+// callers should treat this as a hard failure for the affected Store, not a
+// transient condition to retry.
+var ErrLockTimeout = errors.New("xattrstore: timed out waiting for syscall to return")

--- a/verifyio/xattrstore/lock_linux.go
+++ b/verifyio/xattrstore/lock_linux.go
@@ -1,0 +1,396 @@
+// Linux-only: OFD locks (F_OFD_SETLK) require Linux 3.15+.
+//go:build linux
+
+package xattrstore
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// Lease represents a write lock held over a contiguous byte range of the
+// data file. The locked range covers [offset, offset+length) of the
+// TryAcquireExclusive call AND every record-extent that overlapped that
+// range at acquire time (the "union extent"). It is reported by Range.
+//
+// The underlying mechanism depends on the Store's LockMode:
+//   - LockModeOFD: an OFD F_WRLCK on the data file
+//   - LockModePOSIX: a POSIX F_SETLK on the data file plus the Store's
+//     in-process mutex
+//
+// Lease values must not be copied after creation; the embedded released
+// flag would be tracked independently in each copy and could lead to
+// double-Release. Pass by pointer or call Release before returning the
+// value from a function.
+//
+// Release must be called exactly once. Subsequent calls return an error.
+type Lease struct {
+	file        *os.File
+	start       int64
+	length      int64
+	released    bool
+	ranges      *rangeLockTable // non-nil in LockModePOSIX; Release frees the [start,start+length) entry after POSIX unlock
+	exclusive   bool            // LockModePOSIX only; which kind of entry was registered in ranges
+	lockTimeout time.Duration   // LockModePOSIX only; bounds the F_SETLK F_UNLCK call in Release
+}
+
+// Range returns the byte range the lease holds locked. Useful for
+// logging or for callers that want to assert their write extent is
+// inside the lock.
+func (l Lease) Range() (offset, length int64) {
+	return l.start, l.length
+}
+
+// Release drops all locks held by this lease. In LockModePOSIX the
+// POSIX lock is released before the in-process range-lock table entry is
+// freed. The ordering is required: freeing the table entry first would
+// allow another goroutine to issue a new F_SETLK while this goroutine's
+// F_UNLCK is still in flight. Because POSIX locks are per-process, the
+// kernel records the new goroutine's lock atomically with the existing
+// one — our subsequent F_UNLCK would then remove the other goroutine's
+// lock, not our own.
+// Returns an error if the lease was already released or if an unlock
+// call fails (the table entry is always freed even on error).
+func (l *Lease) Release() error {
+	if l.released {
+		return errors.New("xattrstore.Lease.Release: already released")
+	}
+	l.released = true
+
+	if l.ranges != nil {
+		// LockModePOSIX: release the POSIX lock, then free the range-table entry.
+		desc := fmt.Sprintf("F_SETLK F_UNLCK [%d,%d)", l.start, l.start+l.length)
+		_, err := withTimeout(l.lockTimeout, desc, func() (struct{}, error) {
+			return struct{}{}, unix.FcntlFlock(l.file.Fd(), unix.F_SETLK, &unix.Flock_t{
+				Type:   unix.F_UNLCK,
+				Whence: int16(unix.SEEK_SET),
+				Start:  l.start,
+				Len:    l.length,
+			})
+		})
+		l.ranges.release(l.start, l.length, l.exclusive)
+		if err != nil {
+			return fmt.Errorf("xattrstore.Lease.Release: %w", err)
+		}
+		return nil
+	}
+
+	// LockModeOFD: release the OFD lock.
+	if err := unix.FcntlFlock(l.file.Fd(), unix.F_OFD_SETLK, &unix.Flock_t{
+		Type:   unix.F_UNLCK,
+		Whence: int16(unix.SEEK_SET),
+		Start:  l.start,
+		Len:    l.length,
+	}); err != nil {
+		return fmt.Errorf("xattrstore.Lease.Release: F_OFD_SETLK F_UNLCK: %w", err)
+	}
+	return nil
+}
+
+// hookAfterLock is a test-only injection point. When non-nil, it is
+// invoked after the lock is acquired and before the rescan. Tests use
+// this to insert xattr changes that the rescan must detect.
+var hookAfterLock func()
+
+// withTimeout runs fn in its own goroutine and returns its result, unless
+// timeout elapses first, in which case it returns ErrLockTimeout wrapping
+// desc -- a description of the call that timed out (e.g. "F_SETLK F_WRLCK
+// [4096,8192)"), so callers can tell exactly which syscall got stuck.
+//
+// If timeout is <= 0, fn is called directly with no timeout.
+//
+// Go cannot interrupt a blocked syscall: if fn does not return before the
+// timeout, its goroutine keeps running until fn actually returns, and its
+// result is discarded. Callers in LockModePOSIX rely on this only as a
+// last-resort diagnostic -- ErrLockTimeout means the calling goroutine has
+// given up, not that the underlying syscall has.
+func withTimeout[T any](timeout time.Duration, desc string, fn func() (T, error)) (T, error) {
+	if timeout <= 0 {
+		return fn()
+	}
+	type result struct {
+		val T
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		v, err := fn()
+		done <- result{v, err}
+	}()
+	select {
+	case r := <-done:
+		return r.val, r.err
+	case <-time.After(timeout):
+		var zero T
+		return zero, fmt.Errorf("%s: %w (after %s)", desc, ErrLockTimeout, timeout)
+	}
+}
+
+// unionExtent returns the smallest contiguous range that covers
+// [offset, offset+length) and every Entry in overlaps. Because every
+// Entry in overlaps already intersects the requested range (that is
+// the contract of Overlapping), the union is always contiguous.
+func unionExtent(offset, length int64, overlaps []Entry) (start, totalLen int64) {
+	start = offset
+	end := offset + length
+	for _, e := range overlaps {
+		if e.Offset < start {
+			start = e.Offset
+		}
+		if e.Offset+e.Length > end {
+			end = e.Offset + e.Length
+		}
+	}
+	return start, end - start
+}
+
+// sameOverlapSet reports whether a and b contain the same set of
+// records, identified by xattr Name (which uniquely encodes (offset,
+// length)). Order does not matter.
+func sameOverlapSet(a, b []Entry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[string]struct{}, len(a))
+	for _, e := range a {
+		set[e.Name] = struct{}{}
+	}
+	for _, e := range b {
+		if _, ok := set[e.Name]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// TryAcquireShared takes a non-blocking shared (read) lock over
+// [offset, offset+length).
+//
+// In LockModeOFD, an OFD F_RDLCK is used; multiple callers with
+// distinct open file descriptions may hold overlapping shared locks
+// simultaneously.
+//
+// In LockModePOSIX, a POSIX F_RDLCK combined with the Store's in-process
+// range-lock table provides cross-node and intra-process exclusivity
+// against concurrent writers. Readers on this node are serialised against
+// local writers -- an exclusive request over an overlapping range is
+// rejected while any shared lock on it is held -- but not against each
+// other: multiple overlapping shared locks may be held simultaneously,
+// matching ordinary POSIX read-lock semantics.
+//
+// Returns ErrLockBusy if an exclusive holder conflicts with the range.
+func (s *Store) TryAcquireShared(f *os.File, offset, length int64) (Lease, error) {
+	if f == nil {
+		return Lease{}, fmt.Errorf("xattrstore.TryAcquireShared: nil file")
+	}
+	if length <= 0 {
+		return Lease{}, fmt.Errorf("xattrstore.TryAcquireShared: length must be > 0 (got %d)", length)
+	}
+	if s.lockMode == LockModePOSIX {
+		return s.tryAcquireSharedPOSIX(f, offset, length)
+	}
+	if err := unix.FcntlFlock(f.Fd(), unix.F_OFD_SETLK, &unix.Flock_t{
+		Type:   unix.F_RDLCK,
+		Whence: int16(unix.SEEK_SET),
+		Start:  offset,
+		Len:    length,
+	}); err != nil {
+		if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) {
+			return Lease{}, ErrLockBusy
+		}
+		return Lease{}, fmt.Errorf("xattrstore.TryAcquireShared: F_OFD_SETLK: %w", err)
+	}
+	return Lease{file: f, start: offset, length: length}, nil
+}
+
+func (s *Store) tryAcquireSharedPOSIX(f *os.File, offset, length int64) (Lease, error) {
+	if !s.ranges.tryAcquire(offset, length, false) {
+		return Lease{}, ErrLockBusy
+	}
+	desc := fmt.Sprintf("F_SETLK F_RDLCK [%d,%d)", offset, offset+length)
+	_, err := withTimeout(s.lockTimeout, desc, func() (struct{}, error) {
+		return struct{}{}, unix.FcntlFlock(f.Fd(), unix.F_SETLK, &unix.Flock_t{
+			Type:   unix.F_RDLCK,
+			Whence: int16(unix.SEEK_SET),
+			Start:  offset,
+			Len:    length,
+		})
+	})
+	if err != nil {
+		s.ranges.release(offset, length, false)
+		if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) {
+			return Lease{}, ErrLockBusy
+		}
+		if errors.Is(err, ErrLockTimeout) {
+			return Lease{}, fmt.Errorf("xattrstore.TryAcquireShared: %w", err)
+		}
+		return Lease{}, fmt.Errorf("xattrstore.TryAcquireShared: F_SETLK: %w", err)
+	}
+	return Lease{file: f, start: offset, length: length, ranges: &s.ranges, exclusive: false, lockTimeout: s.lockTimeout}, nil
+}
+
+// TryAcquireExclusive takes a non-blocking exclusive lock over the union
+// of [offset, offset+length) and every existing record-extent that
+// overlaps that range. The locking mechanism depends on the Store's
+// LockMode:
+//
+// LockModeOFD (single-node):
+//  1. Scan xattrs; compute union extent.
+//  2. F_OFD_SETLK F_WRLCK (non-blocking). Returns ErrLockBusy on conflict.
+//  3. Rescan. Returns ErrSetChanged if the overlap set changed.
+//
+// LockModePOSIX (multi-node):
+//  1. Lock the Store's in-process mutex (serialises goroutines on this node).
+//  2. Scan xattrs; compute union extent.
+//  3. F_SETLK F_WRLCK (non-blocking). Returns ErrLockBusy on conflict,
+//     unlocking the mutex first.
+//  4. Rescan. Returns ErrSetChanged if the overlap set changed, releasing
+//     both the POSIX lock and the mutex.
+//
+// f must be an *os.File open on the same file the Store targets with at
+// least read access. The caller retains ownership of f.
+func (s *Store) TryAcquireExclusive(f *os.File, offset, length int64) (Lease, error) {
+	if f == nil {
+		return Lease{}, fmt.Errorf("xattrstore.TryAcquireExclusive: nil file")
+	}
+	if length <= 0 {
+		return Lease{}, fmt.Errorf("xattrstore.TryAcquireExclusive: length must be > 0 (got %d)", length)
+	}
+
+	if s.lockMode == LockModePOSIX {
+		return s.tryAcquireExclusivePOSIX(f, offset, length)
+	}
+	return s.tryAcquireExclusiveOFD(f, offset, length)
+}
+
+func (s *Store) tryAcquireExclusiveOFD(f *os.File, offset, length int64) (Lease, error) {
+	initial, err := s.Overlapping(offset, length)
+	if err != nil {
+		return Lease{}, fmt.Errorf("xattrstore.TryAcquireExclusive: initial scan: %w", err)
+	}
+	lockOff, lockLen := unionExtent(offset, length, initial)
+
+	if err := unix.FcntlFlock(f.Fd(), unix.F_OFD_SETLK, &unix.Flock_t{
+		Type:   unix.F_WRLCK,
+		Whence: int16(unix.SEEK_SET),
+		Start:  lockOff,
+		Len:    lockLen,
+	}); err != nil {
+		if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) {
+			return Lease{}, ErrLockBusy
+		}
+		return Lease{}, fmt.Errorf("xattrstore.TryAcquireExclusive: F_OFD_SETLK: %w", err)
+	}
+
+	lease := Lease{file: f, start: lockOff, length: lockLen}
+
+	if hookAfterLock != nil {
+		hookAfterLock()
+	}
+
+	recheck, err := s.Overlapping(offset, length)
+	if err != nil {
+		_ = lease.Release()
+		return Lease{}, fmt.Errorf("xattrstore.TryAcquireExclusive: rescan: %w", err)
+	}
+	if !sameOverlapSet(initial, recheck) {
+		_ = lease.Release()
+		return Lease{}, ErrSetChanged
+	}
+	return lease, nil
+}
+
+// posixGuardSafeToRelease reports whether it's safe to free the in-process
+// range-table guard after a failed F_SETLK or rescan syscall in
+// tryAcquireExclusivePOSIX. It is NOT safe when the syscall may have timed
+// out rather than definitively failed: withTimeout gives up waiting, but
+// the syscall's goroutine keeps running and its eventual outcome (did the
+// kernel grant the lock or not?) is unknown. Freeing the guard in that case
+// would let another same-process goroutine wrongly believe an overlapping
+// range is free -- same-process F_SETLK calls never conflict with each
+// other, which is the entire reason the guard exists.
+func posixGuardSafeToRelease(err error) bool {
+	return !errors.Is(err, ErrLockTimeout)
+}
+
+func (s *Store) tryAcquireExclusivePOSIX(f *os.File, offset, length int64) (Lease, error) {
+	initial, err := withTimeout(s.lockTimeout, fmt.Sprintf("initial xattr scan [%d,%d)", offset, offset+length),
+		func() ([]Entry, error) { return s.Overlapping(offset, length) })
+	if err != nil {
+		return Lease{}, fmt.Errorf("xattrstore.TryAcquireExclusive: %w", err)
+	}
+	lockOff, lockLen := unionExtent(offset, length, initial)
+
+	if !s.ranges.tryAcquire(lockOff, lockLen, true) {
+		return Lease{}, ErrLockBusy
+	}
+
+	desc := fmt.Sprintf("F_SETLK F_WRLCK [%d,%d)", lockOff, lockOff+lockLen)
+	_, err = withTimeout(s.lockTimeout, desc, func() (struct{}, error) {
+		return struct{}{}, unix.FcntlFlock(f.Fd(), unix.F_SETLK, &unix.Flock_t{
+			Type:   unix.F_WRLCK,
+			Whence: int16(unix.SEEK_SET),
+			Start:  lockOff,
+			Len:    lockLen,
+		})
+	})
+	if err != nil {
+		if !posixGuardSafeToRelease(err) {
+			// The F_SETLK syscall itself didn't return before lockTimeout --
+			// on LockModePOSIX this can mean a slow round-trip to BeeGFS's
+			// distributed lock manager, not a local blocking call, and
+			// withTimeout's goroutine keeps running in the background. We
+			// don't know whether the kernel eventually grants the lock. Do
+			// NOT free the in-process guard: if the lock lands after we've
+			// given up, another same-process goroutine must not be able to
+			// wrongly believe this range is free and successfully
+			// re-acquire it (same-process F_SETLK calls never conflict with
+			// each other -- see rangeLockTable's doc comment). The range is
+			// leaked in-process for the life of the Store rather than risk
+			// that collision.
+			return Lease{}, fmt.Errorf("xattrstore.TryAcquireExclusive: %w", err)
+		}
+		// A definite, immediate failure -- the kernel did not grant the
+		// lock, so freeing the guard is safe.
+		s.ranges.release(lockOff, lockLen, true)
+		if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) {
+			return Lease{}, ErrLockBusy
+		}
+		return Lease{}, fmt.Errorf("xattrstore.TryAcquireExclusive: F_SETLK: %w", err)
+	}
+
+	lease := Lease{file: f, start: lockOff, length: lockLen, ranges: &s.ranges, exclusive: true, lockTimeout: s.lockTimeout}
+
+	if hookAfterLock != nil {
+		hookAfterLock()
+	}
+
+	recheck, err := withTimeout(s.lockTimeout, fmt.Sprintf("rescan [%d,%d)", offset, offset+length),
+		func() ([]Entry, error) { return s.Overlapping(offset, length) })
+	if err != nil {
+		if !posixGuardSafeToRelease(err) {
+			// The Overlapping call (a plain listxattr, unrelated to the lock
+			// itself) is stuck -- but the F_SETLK above already succeeded,
+			// so the real POSIX lock is genuinely held right now, with no
+			// ambiguity. Releasing the lease would issue another syscall
+			// (F_SETLK F_UNLCK) that may also hang, and freeing the
+			// in-process guard without that unlock would let another
+			// same-process goroutine wrongly believe this range is free
+			// (same-process F_SETLK calls never conflict with each other).
+			// Deliberately leak both the real lock and the guard for the
+			// life of the process rather than reopen that collision.
+			return Lease{}, fmt.Errorf("xattrstore.TryAcquireExclusive: %w", err)
+		}
+		_ = lease.Release()
+		return Lease{}, fmt.Errorf("xattrstore.TryAcquireExclusive: rescan: %w", err)
+	}
+	if !sameOverlapSet(initial, recheck) {
+		_ = lease.Release()
+		return Lease{}, ErrSetChanged
+	}
+	return lease, nil
+}

--- a/verifyio/xattrstore/lock_linux_test.go
+++ b/verifyio/xattrstore/lock_linux_test.go
@@ -1,0 +1,390 @@
+//go:build linux
+
+// This is a unit test.
+//
+// Coverage: TryAcquireExclusive's no-overlap success path, union-extent
+// computation across pre-existing overlapping records, contention/busy
+// detection, lock release (and double-release erroring), ErrSetChanged when
+// the overlap set changes between the initial scan and the lock rescan, and
+// bad-input rejection; the unionExtent and sameOverlapSet helpers in
+// isolation; and LockModePOSIX-specific semantics (non-overlapping locks
+// don't block each other, shared locks may overlap, an exclusive request
+// conflicts with an existing shared one). Also posixGuardSafeToRelease's
+// timeout-vs-definite-failure decision in isolation, and the same-process
+// double-exclusive-lock hazard that decision exists to prevent (by
+// directly simulating the state a rescan timeout leaves behind, since the
+// real trigger is a live network/DLM timing condition this suite can't
+// manufacture).
+package xattrstore
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/thinkparq/beegfs-go/verifyio/xattr"
+	"golang.org/x/sys/unix"
+)
+
+// makeTempStorePOSIX creates a temp regular file and returns a Store on it
+// using LockModePOSIX with no lock timeout.
+func makeTempStorePOSIX(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data")
+	if err := os.WriteFile(path, []byte("placeholder"), 0644); err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+	if err := xattr.Set(path, "user.verifyio_probe", []byte{0}, 0); err != nil {
+		t.Skipf("user xattrs not supported: %v", err)
+	}
+	_ = xattr.Remove(path, "user.verifyio_probe")
+	s, err := OpenStoreMultiNode(path, 0)
+	if err != nil {
+		t.Fatalf("OpenStoreMultiNode: %v", err)
+	}
+	return s
+}
+
+// openTarget opens the store's data file for reading+writing and
+// registers cleanup so each test's fds are dropped automatically.
+// Returns a *os.File suitable to pass to TryAcquireExclusive.
+func openTarget(t *testing.T, s *Store) *os.File {
+	t.Helper()
+	f, err := os.OpenFile(s.Target(), os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open target: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	return f
+}
+
+func TestTryAcquireExclusiveNoOverlap(t *testing.T) {
+	s := makeTempStore(t)
+	f := openTarget(t, s)
+
+	lease, err := s.TryAcquireExclusive(f, 0, 4096)
+	if err != nil {
+		t.Fatalf("TryAcquireExclusive: %v", err)
+	}
+	off, ln := lease.Range()
+	if off != 0 || ln != 4096 {
+		t.Errorf("Range=(%d,%d), want (0,4096) when no overlaps", off, ln)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+}
+
+func TestTryAcquireExclusiveUnionExtent(t *testing.T) {
+	s := makeTempStore(t)
+	f := openTarget(t, s)
+
+	// Records that overlap the requested range. The union of
+	// [50, 550) with (0, 100) and (500, 100) is [0, 600).
+	putEntries(t, s,
+		[2]int64{0, 100},
+		[2]int64{500, 100},
+		[2]int64{1000, 100}, // outside the requested range; must NOT enlarge union
+	)
+	lease, err := s.TryAcquireExclusive(f, 50, 500) // [50, 550)
+	if err != nil {
+		t.Fatalf("TryAcquireExclusive: %v", err)
+	}
+	defer lease.Release()
+	off, ln := lease.Range()
+	if off != 0 || ln != 600 {
+		t.Errorf("union extent=(%d,%d), want (0,600)", off, ln)
+	}
+}
+
+func TestTryAcquireExclusiveContention(t *testing.T) {
+	s := makeTempStore(t)
+	f1 := openTarget(t, s)
+	f2 := openTarget(t, s) // separate open file description -> separate OFD
+
+	lease1, err := s.TryAcquireExclusive(f1, 0, 4096)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	defer lease1.Release()
+
+	// Overlapping range on a different fd should fail with ErrLockBusy.
+	if _, err := s.TryAcquireExclusive(f2, 1024, 2048); !errors.Is(err, ErrLockBusy) {
+		t.Errorf("overlapping acquire on second fd: err=%v, want ErrLockBusy", err)
+	}
+
+	// Non-overlapping range on the same second fd should succeed.
+	lease2, err := s.TryAcquireExclusive(f2, 8192, 4096)
+	if err != nil {
+		t.Fatalf("non-overlapping acquire on second fd: %v", err)
+	}
+	if err := lease2.Release(); err != nil {
+		t.Fatalf("Release lease2: %v", err)
+	}
+}
+
+func TestTryAcquireExclusiveReleaseFreesLock(t *testing.T) {
+	s := makeTempStore(t)
+	f1 := openTarget(t, s)
+	f2 := openTarget(t, s)
+
+	lease, err := s.TryAcquireExclusive(f1, 0, 4096)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	// After release, another fd must be able to take the same range.
+	lease2, err := s.TryAcquireExclusive(f2, 0, 4096)
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	if err := lease2.Release(); err != nil {
+		t.Fatalf("Release lease2: %v", err)
+	}
+}
+
+func TestTryAcquireExclusiveDoubleRelease(t *testing.T) {
+	s := makeTempStore(t)
+	f := openTarget(t, s)
+	lease, err := s.TryAcquireExclusive(f, 0, 4096)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatalf("first Release: %v", err)
+	}
+	if err := lease.Release(); err == nil {
+		t.Errorf("second Release: expected error, got nil")
+	}
+}
+
+// TestTryAcquireExclusiveSetChanged uses the hookAfterLock injection
+// point to add a new overlapping record between the initial scan and
+// the rescan. The helper must detect the change, release the lock,
+// and return ErrSetChanged.
+func TestTryAcquireExclusiveSetChanged(t *testing.T) {
+	s := makeTempStore(t)
+	f := openTarget(t, s)
+
+	// Install hook that adds a new record overlapping the requested
+	// range. Hook fires exactly once (then disarms itself) so the
+	// post-error verification call can succeed.
+	called := false
+	hookAfterLock = func() {
+		if called {
+			return
+		}
+		called = true
+		if err := s.Put(2048, 1024, makeHeader(t, 2048, 1)); err != nil {
+			t.Fatalf("hook Put: %v", err)
+		}
+	}
+	t.Cleanup(func() { hookAfterLock = nil })
+
+	if _, err := s.TryAcquireExclusive(f, 0, 4096); !errors.Is(err, ErrSetChanged) {
+		t.Errorf("acquire with set-change: err=%v, want ErrSetChanged", err)
+	}
+	if !called {
+		t.Errorf("hookAfterLock was not invoked")
+	}
+
+	// Lock should have been released. Acquire again (hook is now a
+	// no-op; the new record from the previous attempt is still on
+	// disk, which means rescan == initial-scan on this attempt and
+	// the call succeeds).
+	lease, err := s.TryAcquireExclusive(f, 0, 4096)
+	if err != nil {
+		t.Fatalf("acquire after set-changed release: %v", err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+}
+
+func TestTryAcquireExclusiveBadInputs(t *testing.T) {
+	s := makeTempStore(t)
+	f := openTarget(t, s)
+	if _, err := s.TryAcquireExclusive(nil, 0, 4096); err == nil {
+		t.Errorf("nil file: expected error")
+	}
+	if _, err := s.TryAcquireExclusive(f, 0, 0); err == nil {
+		t.Errorf("length=0: expected error")
+	}
+	if _, err := s.TryAcquireExclusive(f, 0, -1); err == nil {
+		t.Errorf("length=-1: expected error")
+	}
+}
+
+// --- unit tests on the pure helpers ---------------------------------------
+
+func TestUnionExtentNoOverlaps(t *testing.T) {
+	off, ln := unionExtent(100, 200, nil)
+	if off != 100 || ln != 200 {
+		t.Errorf("unionExtent (no overlaps) = (%d,%d), want (100,200)", off, ln)
+	}
+}
+
+func TestUnionExtentExtendsBothEnds(t *testing.T) {
+	overlaps := []Entry{
+		{Offset: 50, Length: 30},  // extends start to 50, end stays
+		{Offset: 280, Length: 50}, // start stays, extends end to 330
+		{Offset: 150, Length: 10}, // strictly inside, no effect
+	}
+	off, ln := unionExtent(100, 200, overlaps) // request [100, 300)
+	if off != 50 || ln != 280 {                // union [50, 330)
+		t.Errorf("unionExtent = (%d,%d), want (50,280)", off, ln)
+	}
+}
+
+func TestSameOverlapSet(t *testing.T) {
+	a := []Entry{
+		{Offset: 0, Length: 100, Name: XAttrName(0, 100)},
+		{Offset: 200, Length: 50, Name: XAttrName(200, 50)},
+	}
+	// Same entries, different order.
+	b := []Entry{
+		{Offset: 200, Length: 50, Name: XAttrName(200, 50)},
+		{Offset: 0, Length: 100, Name: XAttrName(0, 100)},
+	}
+	if !sameOverlapSet(a, b) {
+		t.Errorf("same entries (reordered) reported different")
+	}
+	// Different length.
+	c := []Entry{{Offset: 0, Length: 100, Name: XAttrName(0, 100)}}
+	if sameOverlapSet(a, c) {
+		t.Errorf("different lengths reported same")
+	}
+	// Same length, different members.
+	d := []Entry{
+		{Offset: 0, Length: 100, Name: XAttrName(0, 100)},
+		{Offset: 300, Length: 50, Name: XAttrName(300, 50)},
+	}
+	if sameOverlapSet(a, d) {
+		t.Errorf("different members reported same")
+	}
+}
+
+// TestPosixGuardSafeToRelease pins the decision that caused the
+// rescan/acquire-timeout double-exclusive-lock hazard: a timeout means the
+// syscall's real outcome is unknown, so the in-process guard must not be
+// freed, while a definite failure (or any other error) means the kernel
+// never granted the lock, so freeing it is safe.
+func TestPosixGuardSafeToRelease(t *testing.T) {
+	if posixGuardSafeToRelease(ErrLockTimeout) {
+		t.Errorf("ErrLockTimeout: got safe to release, want not safe")
+	}
+	wrapped := fmt.Errorf("F_SETLK F_WRLCK [0,100): %w (after 5s)", ErrLockTimeout)
+	if posixGuardSafeToRelease(wrapped) {
+		t.Errorf("wrapped ErrLockTimeout: got safe to release, want not safe")
+	}
+	if !posixGuardSafeToRelease(unix.EAGAIN) {
+		t.Errorf("EAGAIN: got not safe to release, want safe")
+	}
+	if !posixGuardSafeToRelease(unix.EWOULDBLOCK) {
+		t.Errorf("EWOULDBLOCK: got not safe to release, want safe")
+	}
+	if !posixGuardSafeToRelease(errors.New("some other definite failure")) {
+		t.Errorf("other error: got not safe to release, want safe")
+	}
+}
+
+// TestPOSIXRescanTimeoutLeaksGuardNotReleasesIt is a regression test for the
+// exact hazard TestPosixGuardSafeToRelease's decision logic exists to
+// prevent: if the rescan step times out, a second same-process attempt on
+// an overlapping range must still be rejected, not incorrectly succeed.
+// This can't deterministically force withTimeout's real timer to fire
+// against a real (fast, local) syscall, so it instead directly verifies the
+// state tryAcquireExclusivePOSIX's timeout path leaves behind: the
+// in-process guard still holding the range. If a future change reintroduces
+// the bug by calling s.ranges.release on this path, this test's setup
+// becomes unnecessary but harmless; the real regression is exercised by
+// symptom rather than by trigger, since the trigger is a live network/DLM
+// timing condition this test suite cannot manufacture.
+func TestPOSIXRescanTimeoutLeaksGuardNotReleasesIt(t *testing.T) {
+	s := makeTempStorePOSIX(t)
+	// Simulate the state left behind by a rescan timeout: the guard was
+	// taken (mirroring tryAcquireExclusivePOSIX's tryAcquire call) and,
+	// per the fix, deliberately never released.
+	if !s.ranges.tryAcquire(0, 4096, true) {
+		t.Fatalf("setup: tryAcquire on a clean table unexpectedly failed")
+	}
+
+	f := openTarget(t, s)
+	if _, err := s.TryAcquireExclusive(f, 1024, 2048); !errors.Is(err, ErrLockBusy) {
+		t.Errorf("second same-process acquire over the leaked range: err=%v, want ErrLockBusy", err)
+	}
+}
+
+// TestPOSIXNonOverlappingLocksDoNotBlock verifies the range-lock table lets
+// disjoint ranges proceed concurrently in LockModePOSIX, instead of
+// serialising on a single whole-file mutex.
+func TestPOSIXNonOverlappingLocksDoNotBlock(t *testing.T) {
+	s := makeTempStorePOSIX(t)
+	f1 := openTarget(t, s)
+	f2 := openTarget(t, s)
+
+	lease1, err := s.TryAcquireExclusive(f1, 0, 4096)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	defer lease1.Release()
+
+	// Overlapping range must fail immediately with ErrLockBusy.
+	if _, err := s.TryAcquireExclusive(f2, 1024, 2048); !errors.Is(err, ErrLockBusy) {
+		t.Errorf("overlapping acquire: err=%v, want ErrLockBusy", err)
+	}
+
+	// Disjoint range must succeed even while lease1 is still held.
+	lease2, err := s.TryAcquireExclusive(f2, 8192, 4096)
+	if err != nil {
+		t.Fatalf("disjoint acquire while lease1 held: %v", err)
+	}
+	if err := lease2.Release(); err != nil {
+		t.Fatalf("Release lease2: %v", err)
+	}
+}
+
+// TestPOSIXSharedLocksOverlapAllowed verifies two shared locks on
+// overlapping ranges can both be held at once in LockModePOSIX.
+func TestPOSIXSharedLocksOverlapAllowed(t *testing.T) {
+	s := makeTempStorePOSIX(t)
+	f1 := openTarget(t, s)
+	f2 := openTarget(t, s)
+
+	lease1, err := s.TryAcquireShared(f1, 0, 4096)
+	if err != nil {
+		t.Fatalf("first shared acquire: %v", err)
+	}
+	defer lease1.Release()
+
+	lease2, err := s.TryAcquireShared(f2, 1024, 2048)
+	if err != nil {
+		t.Fatalf("second shared acquire (overlapping): %v", err)
+	}
+	if err := lease2.Release(); err != nil {
+		t.Fatalf("Release lease2: %v", err)
+	}
+}
+
+// TestPOSIXExclusiveConflictsWithShared verifies an exclusive request
+// overlapping a held shared lock is rejected with ErrLockBusy.
+func TestPOSIXExclusiveConflictsWithShared(t *testing.T) {
+	s := makeTempStorePOSIX(t)
+	f1 := openTarget(t, s)
+	f2 := openTarget(t, s)
+
+	lease1, err := s.TryAcquireShared(f1, 0, 4096)
+	if err != nil {
+		t.Fatalf("shared acquire: %v", err)
+	}
+	defer lease1.Release()
+
+	if _, err := s.TryAcquireExclusive(f2, 1024, 2048); !errors.Is(err, ErrLockBusy) {
+		t.Errorf("exclusive overlapping shared: err=%v, want ErrLockBusy", err)
+	}
+}

--- a/verifyio/xattrstore/store.go
+++ b/verifyio/xattrstore/store.go
@@ -1,0 +1,487 @@
+// Package xattrstore stores per-record headers as extended attributes
+// on a target data file, providing a small key/value layer keyed by
+// (offset, length) -- the byte range the record occupies on disk.
+//
+// Each entry's xattr name is "user.verifyio.<offset>-<length>", and the
+// value is the marshaled block header from package block (block.HeaderSize
+// bytes). Length is the on-disk extent of the block's DATA alone --
+// block.BlockDataSize(bodyLen), i.e. body + stripe CRCs. The header itself
+// is never written to the data file; it exists only as this xattr's value,
+// so it does not contribute to length. Nor is length the header's BodyLen
+// field, which is smaller still: BodyLen counts just the body, excluding
+// the stripe CRCs that make up the rest of length.
+//
+// Including length in the name lets callers identify each record's
+// extent without reading its value, which makes overlap queries
+// (needed for variable-sized records) cheap: list xattrs once, parse
+// names, done.
+//
+// Multiple writers may set xattrs at the same (offset, length); on
+// Linux this is last-write-wins at the kernel level. Verifiers can
+// use the header's TimeNs field to disambiguate when they have access
+// to multiple histories.
+//
+// # Overlap policy: replace-and-shred
+//
+// Put does NOT check whether a new record's extent overlaps existing
+// records. Two entries with overlapping (offset, length) extents can
+// coexist on the same file, and a file-level verifier will flag them
+// as a CoverageMany anomaly.
+//
+// Example: a Put(1024, 3072, headerA) writes a record covering
+// [1024, 4096) (xattr "user.verifyio.1024-3072"). A second, unrelated
+// Put(2048, 2048, headerB) -- meant to describe a different block that
+// happens to start at offset 2048 -- writes "user.verifyio.2048-2048",
+// covering [2048, 4096). Put does not check headerA's existing claim, so
+// both xattrs persist side by side. A verifier walking the file sees
+// [2048, 4096) claimed by two records at once and reports CoverageMany
+// for that span, even though [1024, 2048) is still cleanly CoverageOne.
+//
+// Callers that want overlap-free semantics should write through
+// ReplaceRange instead, which implements replace-and-shred: every
+// overlapping record is removed entirely before the new entry is
+// written. Old records are not split,
+// even if only part of their extent intersects the new range. Bytes
+// that were covered by a removed record but are not inside the new
+// range become uncovered ("sparse" from the xattr layer's point of
+// view), and the caller is responsible for zeroing them in the data
+// file. The library deliberately keeps xattr management and data-file
+// management in separate hands.
+//
+// Example: an existing record covers [0, 4096). A caller calls
+// ReplaceRange(0, 1024, newHeader) to write a smaller record at the same
+// starting offset. The old [0, 4096) record is removed in its entirety --
+// not truncated or split to keep a [1024, 4096) remainder -- and the new
+// [0, 1024) record is written in its place. Bytes [1024, 4096) are now
+// uncovered: no xattr claims them, even though the data file may still
+// physically hold whatever was written there before. ReplaceRange only
+// manages the xattr side; the caller must zero those bytes itself, or a
+// verifier will read stale leftover data in a span that claims to be
+// unwritten.
+//
+// Inside ReplaceRange, overlapping records are removed before the new
+// entry is written. A crash in the middle therefore leaves uncovered
+// bytes (recoverable, verifier-flaggable) rather than two records
+// claiming the same range (harder to reconcile).
+//
+// This package is the on-file variant only -- attributes are written
+// directly to the data file's inode. A sharded sidecar variant (for
+// filesystems with tight per-inode xattr budgets) may follow as a
+// separate Store implementation in a later release.
+package xattrstore
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/xattr"
+)
+
+// LockMode controls the locking strategy used by TryAcquireExclusive.
+type LockMode int
+
+const (
+	// LockModeOFD uses Linux OFD locks (F_OFD_SETLK) for exclusive access.
+	// Each caller must use a distinct *os.File (open file description) to
+	// achieve goroutine-level conflict detection. Provides single-node
+	// exclusivity only — OFD locks are not propagated across nodes on
+	// shared filesystems.
+	LockModeOFD LockMode = iota
+
+	// LockModePOSIX uses POSIX process locks (F_SETLK) for cross-node
+	// exclusivity via the filesystem's distributed lock manager (e.g.
+	// BeeGFS), combined with an in-process range-lock table for
+	// goroutine coordination. Use this when multiple nodes share the
+	// same data files.
+	LockModePOSIX
+)
+
+// ErrNotFound is returned by Get when no header has been recorded at
+// the given offset. Aliased to xattr.ErrNotFound so callers can check
+// either with errors.Is.
+var ErrNotFound = xattr.ErrNotFound
+
+// xattrPrefix is the namespace for every entry this package writes.
+// Kept short so the per-inode xattr budget on tight filesystems is
+// dominated by the value bytes rather than the names.
+const xattrPrefix = "user.verifyio."
+
+// Store is the xattr backing for one data file. All operations target
+// the file directly; no sidecar directory is created.
+//
+// The xattr methods (Put, Get, Remove, etc.) are safe for concurrent
+// use — the underlying syscalls are atomic per attribute. The locking
+// methods (TryAcquireExclusive, TryAcquireShared) follow the protocol
+// determined by the LockMode the Store was opened with.
+type Store struct {
+	target      string
+	lockMode    LockMode
+	lockTimeout time.Duration  // LockModePOSIX only; <=0 means wait indefinitely
+	ranges      rangeLockTable // used only in LockModePOSIX; tracks in-process locks per byte range
+}
+
+// rangeLock describes one in-process lock held over a byte range of the
+// target file under LockModePOSIX.
+type rangeLock struct {
+	offset    int64
+	length    int64
+	exclusive bool
+}
+
+// rangeLockTable tracks in-process locks held over byte ranges of a
+// Store's target file. It exists because traditional POSIX record locks
+// (F_SETLK) do not conflict with other locks held by the same process --
+// without this table, two goroutines on the same node could both
+// successfully F_SETLK overlapping ranges. OFD locks don't have this
+// problem (different open file descriptions in the same process do
+// conflict), but OFD locks aren't propagated across nodes, which is why
+// LockModePOSIX exists in the first place.
+//
+// The table is consulted only to decide whether an in-process conflict
+// exists; it never blocks. tryAcquire returns false immediately on
+// conflict, matching the non-blocking contract of TryAcquireShared and
+// TryAcquireExclusive. The mutex is held only for the brief scan/insert,
+// never across a syscall.
+type rangeLockTable struct {
+	mu    sync.Mutex
+	locks []rangeLock
+}
+
+// tryAcquire registers a lock over [offset, offset+length) and returns
+// true, unless it would conflict with an existing entry. An exclusive
+// request conflicts with any overlapping entry; a shared request
+// conflicts only with overlapping exclusive entries.
+func (t *rangeLockTable) tryAcquire(offset, length int64, exclusive bool) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, l := range t.locks {
+		if !overlaps(offset, length, l.offset, l.length) {
+			continue
+		}
+		if exclusive || l.exclusive {
+			return false
+		}
+	}
+	t.locks = append(t.locks, rangeLock{offset: offset, length: length, exclusive: exclusive})
+	return true
+}
+
+// release removes one entry matching (offset, length, exclusive). It is a
+// no-op if no such entry exists.
+func (t *rangeLockTable) release(offset, length int64, exclusive bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i, l := range t.locks {
+		if l.offset == offset && l.length == length && l.exclusive == exclusive {
+			t.locks = append(t.locks[:i], t.locks[i+1:]...)
+			return
+		}
+	}
+}
+
+func openStore(targetPath string, mode LockMode, lockTimeout time.Duration) (*Store, error) {
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		return nil, fmt.Errorf("xattrstore.OpenStore: stat %s: %w", targetPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("xattrstore.OpenStore: %s is not a regular file (mode=%s)",
+			targetPath, info.Mode())
+	}
+	return &Store{target: targetPath, lockMode: mode, lockTimeout: lockTimeout}, nil
+}
+
+// OpenStore returns a Store using OFD locking (LockModeOFD). Each
+// caller must use a distinct *os.File per goroutine to achieve proper
+// conflict detection. Suitable for single-node use.
+func OpenStore(targetPath string) (*Store, error) {
+	return openStore(targetPath, LockModeOFD, 0)
+}
+
+// OpenStoreMultiNode returns a Store using POSIX locking (LockModePOSIX).
+// POSIX locks are propagated by shared filesystems (e.g. BeeGFS) to
+// their distributed lock manager, providing cross-node exclusivity.
+// An in-process mutex serialises goroutines on this node.
+//
+// lockTimeout bounds how long TryAcquireExclusive and TryAcquireShared will
+// wait for F_SETLK and the xattr scans used to compute the lock range before
+// giving up with ErrLockTimeout. Pass <=0 to wait indefinitely (the original,
+// pre-timeout behavior).
+func OpenStoreMultiNode(targetPath string, lockTimeout time.Duration) (*Store, error) {
+	return openStore(targetPath, LockModePOSIX, lockTimeout)
+}
+
+// Target returns the data-file path this Store operates on.
+func (s *Store) Target() string {
+	return s.target
+}
+
+// XAttrName returns the xattr name for a record occupying [offset,
+// offset+length) bytes on disk. Exposed so verifiers and tests can
+// construct the same names without duplicating the format string.
+func XAttrName(offset, length int64) string {
+	return fmt.Sprintf("%s%d-%d", xattrPrefix, offset, length)
+}
+
+// parseXAttrName recovers (offset, length) from an xattr name. Returns
+// ok=false for names that don't match the expected form.
+func parseXAttrName(name string) (offset, length int64, ok bool) {
+	if !strings.HasPrefix(name, xattrPrefix) {
+		return 0, 0, false
+	}
+	rest := name[len(xattrPrefix):]
+	dash := strings.IndexByte(rest, '-')
+	if dash < 0 {
+		return 0, 0, false
+	}
+	off, err := strconv.ParseInt(rest[:dash], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	ln, err := strconv.ParseInt(rest[dash+1:], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	return off, ln, true
+}
+
+// validRange rejects (offset, length) pairs the store cannot represent or
+// reason about safely: a negative offset (the xattr name "<offset>-<length>"
+// cannot round-trip one, so the entry would be silently dropped on read), a
+// non-positive length, or an extent whose end overflows int64 (which would make
+// the overlap/union interval math wrap and silently misreport).
+func validRange(offset, length int64) error {
+	if offset < 0 {
+		return fmt.Errorf("offset must be >= 0 (got %d)", offset)
+	}
+	if length <= 0 {
+		return fmt.Errorf("length must be > 0 (got %d)", length)
+	}
+	if offset > math.MaxInt64-length {
+		return fmt.Errorf("offset+length overflows int64 (offset=%d length=%d)", offset, length)
+	}
+	return nil
+}
+
+// Put stores header as the xattr value for the record occupying
+// [offset, offset+length) on disk. header must be exactly
+// block.HeaderSize bytes; shorter or longer values are rejected
+// without touching the filesystem. length must be > 0.
+//
+// Uses default flags ("create or replace"), so concurrent writers
+// converge on last-write-wins at the kernel level.
+//
+// Put does not check for overlap with existing records. For "delete
+// all overlapping records, then write this one" semantics, use the
+// ReplaceRange helper (or build it on top of List + Remove + Put).
+//
+// offset must be >= 0 and length > 0, and offset+length must not
+// overflow int64 (see validRange).
+func (s *Store) Put(offset, length int64, header []byte) error {
+	if len(header) != block.HeaderSize {
+		return fmt.Errorf("xattrstore.Put: header is %d bytes, want %d",
+			len(header), block.HeaderSize)
+	}
+	if err := validRange(offset, length); err != nil {
+		return fmt.Errorf("xattrstore.Put: %w", err)
+	}
+	name := XAttrName(offset, length)
+	if err := xattr.Set(s.target, name, header, 0); err != nil {
+		return fmt.Errorf("xattrstore.Put: setxattr %s on %s: %w", name, s.target, err)
+	}
+	return nil
+}
+
+// Get returns the header stored for the record at (offset, length).
+// Returns nil, ErrNotFound if no record has been set with that exact
+// (offset, length) pair. Callers that don't know the length should
+// use List or ForEachEntry to discover it first.
+func (s *Store) Get(offset, length int64) ([]byte, error) {
+	name := XAttrName(offset, length)
+	val, err := xattr.Get(s.target, name)
+	if err != nil {
+		if errors.Is(err, xattr.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("xattrstore.Get: getxattr %s on %s: %w", name, s.target, err)
+	}
+	if len(val) != block.HeaderSize {
+		return nil, fmt.Errorf("xattrstore.Get: %s on %s has size %d, want %d",
+			name, s.target, len(val), block.HeaderSize)
+	}
+	return val, nil
+}
+
+// ForEachEntry iterates every verifyio record-header xattr on the
+// target and invokes fn once for each (offset, length, header) tuple.
+// Iteration order is whatever xattr.List returns -- typically
+// undefined; sort by offset on the caller side if you need order.
+// Iteration stops if fn returns a non-nil error and that error is
+// returned to the caller.
+//
+// Names that don't match the verifyio prefix are skipped. Entries whose
+// stored size doesn't match block.HeaderSize are skipped silently;
+// callers that want to surface such anomalies should iterate via List
+// directly.
+func (s *Store) ForEachEntry(fn func(offset, length int64, header []byte) error) error {
+	names, err := xattr.List(s.target)
+	if err != nil {
+		return fmt.Errorf("xattrstore.ForEachEntry: listxattr %s: %w", s.target, err)
+	}
+	for _, n := range names {
+		offset, length, ok := parseXAttrName(n)
+		if !ok {
+			continue
+		}
+		val, err := xattr.Get(s.target, n)
+		if err != nil {
+			if errors.Is(err, xattr.ErrNotFound) {
+				// Concurrent removal; not fatal.
+				continue
+			}
+			return fmt.Errorf("xattrstore.ForEachEntry: getxattr %s on %s: %w",
+				n, s.target, err)
+		}
+		if len(val) != block.HeaderSize {
+			continue
+		}
+		if err := fn(offset, length, val); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Remove deletes the header for the record at (offset, length).
+// Returns ErrNotFound if no such record exists.
+func (s *Store) Remove(offset, length int64) error {
+	return xattr.Remove(s.target, XAttrName(offset, length))
+}
+
+// Entry identifies one stored record by its on-disk extent and its
+// xattr name. The name is exposed so callers (verifiers, ReplaceRange)
+// can pass it back to Remove without recomputing it.
+//
+// Entry intentionally does not carry the header bytes: Overlapping is
+// built on xattr.List + parseXAttrName, which does not require a
+// per-entry getxattr. Callers that need the header should call Get with
+// (Offset, Length) explicitly.
+type Entry struct {
+	Offset int64
+	Length int64
+	Name   string
+}
+
+// overlaps reports whether half-open intervals [aOff, aOff+aLen) and
+// [bOff, bOff+bLen) share at least one byte. Zero-length intervals
+// never overlap anything (Put already rejects length<=0, but the helper
+// is defensive).
+func overlaps(aOff, aLen, bOff, bLen int64) bool {
+	if aLen <= 0 || bLen <= 0 {
+		return false
+	}
+	return aOff < bOff+bLen && bOff < aOff+aLen
+}
+
+// Overlapping returns every stored record whose on-disk extent
+// intersects [offset, offset+length). Adjacent-but-not-overlapping
+// records (e.g. one ending exactly at offset) are not included.
+//
+// offset must be >= 0 and length > 0 (with offset+length not overflowing
+// int64); an invalid range yields an error rather than silently returning all
+// or no entries.
+//
+// Implementation note: this uses xattr.List + name parsing only -- no
+// per-entry getxattr -- so it is cheap to call before every write in a
+// hot path. Entries whose names don't match the verifyio prefix are
+// skipped.
+func (s *Store) Overlapping(offset, length int64) ([]Entry, error) {
+	if err := validRange(offset, length); err != nil {
+		return nil, fmt.Errorf("xattrstore.Overlapping: %w", err)
+	}
+	names, err := xattr.List(s.target)
+	if err != nil {
+		return nil, fmt.Errorf("xattrstore.Overlapping: listxattr %s: %w", s.target, err)
+	}
+	var out []Entry
+	for _, n := range names {
+		off, ln, ok := parseXAttrName(n)
+		if !ok {
+			continue
+		}
+		if overlaps(offset, length, off, ln) {
+			out = append(out, Entry{Offset: off, Length: ln, Name: n})
+		}
+	}
+	return out, nil
+}
+
+// ReplaceRange implements replace-and-shred at the xattr layer:
+//
+//  1. Find every existing record that overlaps [offset, offset+length).
+//  2. Remove each one.
+//  3. Set the new (offset, length) entry with the given header.
+//
+// Overlapping records are removed entirely -- they are not split, and
+// no attempt is made to preserve the non-overlapping bytes' headers.
+// That is the "shred" half of replace-and-shred.
+//
+// Order matters for crash safety. Removing first means a crash in the
+// middle of ReplaceRange leaves "uncovered bytes" -- ranges no record
+// claims -- which a file-level verifier can flag and which are
+// recoverable. The alternative (Put-first, then remove) could briefly
+// leave two records claiming overlapping ranges, which is harder for a
+// verifier to reconcile. Do not reorder these steps.
+//
+// ReplaceRange does NOT touch the data file. Bytes that were previously
+// covered by a now-removed record but are not inside [offset,
+// offset+length) become sparse from the xattr layer's point of view;
+// the caller is responsible for writing zeros (or otherwise reconciling
+// content) to the data file. Keeping xattr management and data
+// management in separate hands is a deliberate API choice.
+//
+// header must be exactly block.HeaderSize bytes; length must be > 0.
+// Concurrent ReplaceRange on overlapping ranges is unsafe at this
+// layer -- callers should serialize via a file lock that covers the
+// union of the new range and every existing overlap.
+func (s *Store) ReplaceRange(offset, length int64, header []byte) error {
+	if len(header) != block.HeaderSize {
+		return fmt.Errorf("xattrstore.ReplaceRange: header is %d bytes, want %d",
+			len(header), block.HeaderSize)
+	}
+	if err := validRange(offset, length); err != nil {
+		return fmt.Errorf("xattrstore.ReplaceRange: %w", err)
+	}
+
+	overlapping, err := s.Overlapping(offset, length)
+	if err != nil {
+		return fmt.Errorf("xattrstore.ReplaceRange: %w", err)
+	}
+	for _, e := range overlapping {
+		// Skip the exact-match case so the Put below cleanly overwrites
+		// it -- avoids a remove+set syscall pair and a transient
+		// uncovered window for the no-overlap-changes case.
+		if e.Offset == offset && e.Length == length {
+			continue
+		}
+		if err := xattr.Remove(s.target, e.Name); err != nil {
+			if errors.Is(err, xattr.ErrNotFound) {
+				// Concurrent removal; treat as already-done.
+				continue
+			}
+			return fmt.Errorf("xattrstore.ReplaceRange: remove %s on %s: %w",
+				e.Name, s.target, err)
+		}
+	}
+	if err := s.Put(offset, length, header); err != nil {
+		return fmt.Errorf("xattrstore.ReplaceRange: %w", err)
+	}
+	return nil
+}

--- a/verifyio/xattrstore/store_test.go
+++ b/verifyio/xattrstore/store_test.go
@@ -1,0 +1,654 @@
+// This is a unit test. It exercises real xattr syscalls against a temp file
+// (skipped if the underlying filesystem doesn't support user xattrs).
+//
+// Coverage: OpenStore validation (missing path, non-regular-file); Put/Get
+// round-trip, missing-record and wrong-size/zero-length/invalid-range
+// rejection, and variable-length records; ForEachEntry iteration (including
+// ignoring xattrs outside this package's namespace and stopping on a
+// callback error); Overlapping's range classification (exact match, strict
+// subset/superset, partial start/end, adjacent-no-overlap, multiple matches,
+// unrelated entries/namespaces ignored, malformed-length entries ignored);
+// ReplaceRange's shred-and-replace semantics (no overlap, full-overlap exact
+// match, partial-overlap shredding, multiple overlaps collapsing into one);
+// and XAttrName<->offset/length round-trip.
+package xattrstore
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/xattr"
+)
+
+// makeTempStore creates a temp regular file and returns a Store on it.
+// Skips the test if user xattrs aren't supported on the underlying tmp
+// filesystem.
+func makeTempStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data")
+	if err := os.WriteFile(path, []byte("placeholder"), 0644); err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+	if err := xattr.Set(path, "user.verifyio_probe", []byte{0}, 0); err != nil {
+		t.Skipf("user xattrs not supported: %v", err)
+	}
+	_ = xattr.Remove(path, "user.verifyio_probe")
+	s, err := OpenStore(path)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	return s
+}
+
+// makeHeader returns a HeaderSize-byte buffer containing a valid header
+// (enough to round-trip via block.UnmarshalHeader).
+func makeHeader(t *testing.T, offset int64, seed uint64) []byte {
+	t.Helper()
+	h := block.Header{
+		Version: block.HeaderVersion,
+		Kind:    block.KindZeros,
+		Offset:  uint64(offset),
+		Seed:    seed,
+		TimeNs:  1700000000,
+	}
+	buf := make([]byte, block.HeaderSize)
+	if err := block.MarshalHeader(buf, &h); err != nil {
+		t.Fatalf("MarshalHeader: %v", err)
+	}
+	return buf
+}
+
+// recordLen is a synthetic on-disk extent used by tests where the
+// length value doesn't matter beyond being positive and consistent
+// across Put/Get/Remove.
+const recordLen = 4096
+
+func TestOpenStoreMissingPath(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "nope")
+	if _, err := OpenStore(missing); err == nil {
+		t.Errorf("OpenStore on missing path: expected error, got nil")
+	}
+}
+
+func TestOpenStoreOnDirectory(t *testing.T) {
+	dir := t.TempDir() // directory, not a regular file
+	if _, err := OpenStore(dir); err == nil {
+		t.Errorf("OpenStore on directory: expected error, got nil")
+	}
+}
+
+func TestPutGet(t *testing.T) {
+	s := makeTempStore(t)
+	hdr := makeHeader(t, 0x1000, 42)
+
+	if err := s.Put(0x1000, recordLen, hdr); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := s.Get(0x1000, recordLen)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, hdr) {
+		t.Errorf("Get returned different bytes than Put")
+	}
+
+	// Replace at the same (offset, length).
+	hdr2 := makeHeader(t, 0x1000, 99)
+	if err := s.Put(0x1000, recordLen, hdr2); err != nil {
+		t.Fatalf("Put replace: %v", err)
+	}
+	got, _ = s.Get(0x1000, recordLen)
+	if !bytes.Equal(got, hdr2) {
+		t.Errorf("after replace, Get returned old bytes")
+	}
+}
+
+func TestGetMissing(t *testing.T) {
+	s := makeTempStore(t)
+	_, err := s.Get(0xdead, recordLen)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get of missing offset: err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestPutWrongSize(t *testing.T) {
+	s := makeTempStore(t)
+	if err := s.Put(0, recordLen, []byte{1, 2, 3}); err == nil {
+		t.Errorf("Put with wrong size: expected error")
+	}
+}
+
+func TestPutZeroLength(t *testing.T) {
+	s := makeTempStore(t)
+	if err := s.Put(0, 0, makeHeader(t, 0, 0)); err == nil {
+		t.Errorf("Put with length=0: expected error")
+	}
+}
+
+// TestRejectsInvalidRange verifies Put, Overlapping, and ReplaceRange reject
+// ranges the store cannot represent: a negative offset (the "<offset>-<length>"
+// xattr name cannot round-trip one, so the entry would be silently dropped on
+// read) and an offset+length that overflows int64 (which would wrap the
+// overlap/union interval math and silently misreport). A large but valid range
+// must still be accepted.
+func TestRejectsInvalidRange(t *testing.T) {
+	s := makeTempStore(t)
+	hdr := makeHeader(t, 0, 0)
+
+	bad := []struct {
+		name           string
+		offset, length int64
+	}{
+		{"negative offset", -1, recordLen},
+		{"offset+length overflows", math.MaxInt64 - 100, 1000},
+		{"length overflows at max offset", math.MaxInt64, 1},
+	}
+	for _, c := range bad {
+		t.Run(c.name, func(t *testing.T) {
+			if err := s.Put(c.offset, c.length, hdr); err == nil {
+				t.Errorf("Put(%d, %d): expected error", c.offset, c.length)
+			}
+			if _, err := s.Overlapping(c.offset, c.length); err == nil {
+				t.Errorf("Overlapping(%d, %d): expected error", c.offset, c.length)
+			}
+			if err := s.ReplaceRange(c.offset, c.length, hdr); err == nil {
+				t.Errorf("ReplaceRange(%d, %d): expected error", c.offset, c.length)
+			}
+		})
+	}
+
+	// A large but valid range must still be accepted (guards against over-rejection).
+	if err := s.Put(1<<40, recordLen, hdr); err != nil {
+		t.Errorf("Put(1<<40, %d): unexpected error: %v", recordLen, err)
+	}
+}
+
+// TestPutVariableLengths confirms two records at the same offset with
+// different lengths are stored independently (the (offset, length)
+// pair is the key, not offset alone).
+func TestPutVariableLengths(t *testing.T) {
+	s := makeTempStore(t)
+	hdrA := makeHeader(t, 0, 1)
+	hdrB := makeHeader(t, 0, 2)
+	if err := s.Put(0, 1024, hdrA); err != nil {
+		t.Fatalf("Put A: %v", err)
+	}
+	if err := s.Put(0, 4096, hdrB); err != nil {
+		t.Fatalf("Put B: %v", err)
+	}
+	gotA, err := s.Get(0, 1024)
+	if err != nil {
+		t.Fatalf("Get A: %v", err)
+	}
+	gotB, err := s.Get(0, 4096)
+	if err != nil {
+		t.Fatalf("Get B: %v", err)
+	}
+	if !bytes.Equal(gotA, hdrA) || !bytes.Equal(gotB, hdrB) {
+		t.Errorf("variable-length entries leaked into each other")
+	}
+}
+
+func TestForEachEntry(t *testing.T) {
+	s := makeTempStore(t)
+	type entry struct{ off, length int64 }
+	entries := []entry{
+		{0, 4096},
+		{4096, 8192},
+		{12288, 1024},
+		{13312, 2048},
+	}
+	for _, e := range entries {
+		if err := s.Put(e.off, e.length, makeHeader(t, e.off, uint64(e.off))); err != nil {
+			t.Fatalf("Put %+v: %v", e, err)
+		}
+	}
+
+	var got []entry
+	err := s.ForEachEntry(func(off, length int64, hdr []byte) error {
+		got = append(got, entry{off, length})
+		// Sanity: stored bytes parse as a valid header with matching offset.
+		h, err := block.UnmarshalHeader(hdr)
+		if err != nil {
+			t.Errorf("ForEach: header at offset %d does not parse: %v", off, err)
+		}
+		if int64(h.Offset) != off {
+			t.Errorf("ForEach: header.Offset=%d, callback offset=%d", h.Offset, off)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachEntry: %v", err)
+	}
+	sort.Slice(got, func(i, j int) bool { return got[i].off < got[j].off })
+	if len(got) != len(entries) {
+		t.Fatalf("ForEach saw %d entries, want %d (got %+v)", len(got), len(entries), got)
+	}
+	for i, e := range entries {
+		if got[i] != e {
+			t.Errorf("ForEach[%d]=%+v, want %+v", i, got[i], e)
+		}
+	}
+}
+
+func TestForEachIgnoresUnrelatedXattrs(t *testing.T) {
+	s := makeTempStore(t)
+	// Pollute with a non-verifyio xattr.
+	if err := xattr.Set(s.Target(), "user.something_else", []byte("hi"), 0); err != nil {
+		t.Fatalf("seed unrelated xattr: %v", err)
+	}
+	// And one verifyio entry.
+	if err := s.Put(0, recordLen, makeHeader(t, 0, 0)); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	count := 0
+	if err := s.ForEachEntry(func(off, length int64, hdr []byte) error {
+		count++
+		return nil
+	}); err != nil {
+		t.Fatalf("ForEachEntry: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("ForEach saw %d entries, want 1 (unrelated xattr should be ignored)", count)
+	}
+}
+
+func TestForEachStopsOnError(t *testing.T) {
+	s := makeTempStore(t)
+	for _, o := range []int64{0, 4096, 8192} {
+		if err := s.Put(o, recordLen, makeHeader(t, o, 0)); err != nil {
+			t.Fatalf("Put %d: %v", o, err)
+		}
+	}
+	stopErr := errors.New("stop")
+	saw := 0
+	err := s.ForEachEntry(func(off, length int64, hdr []byte) error {
+		saw++
+		return stopErr
+	})
+	if !errors.Is(err, stopErr) {
+		t.Errorf("ForEach error: got %v, want stopErr", err)
+	}
+	if saw != 1 {
+		t.Errorf("ForEach should stop after first non-nil error; saw %d", saw)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	s := makeTempStore(t)
+	if err := s.Put(0, recordLen, makeHeader(t, 0, 0)); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := s.Remove(0, recordLen); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := s.Get(0, recordLen); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get after Remove: err=%v, want ErrNotFound", err)
+	}
+}
+
+// --- Overlapping -----------------------------------------------------------
+
+// putEntries seeds the store with the given (offset, length) extents,
+// each carrying a header whose Seed is derived from the offset so test
+// failures can distinguish them.
+func putEntries(t *testing.T, s *Store, ents ...[2]int64) {
+	t.Helper()
+	for _, e := range ents {
+		off, ln := e[0], e[1]
+		if err := s.Put(off, ln, makeHeader(t, off, uint64(off))); err != nil {
+			t.Fatalf("Put (%d,%d): %v", off, ln, err)
+		}
+	}
+}
+
+// extentSet collects (offset, length) pairs from a slice of Entry,
+// sorted by offset so order-of-iteration in xattr.List doesn't matter.
+func extentSet(ents []Entry) [][2]int64 {
+	out := make([][2]int64, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, [2]int64{e.Offset, e.Length})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i][0] != out[j][0] {
+			return out[i][0] < out[j][0]
+		}
+		return out[i][1] < out[j][1]
+	})
+	return out
+}
+
+func equalExtents(a, b [][2]int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestOverlappingExactMatch(t *testing.T) {
+	s := makeTempStore(t)
+	putEntries(t, s, [2]int64{0, 4096})
+	got, err := s.Overlapping(0, 4096)
+	if err != nil {
+		t.Fatalf("Overlapping: %v", err)
+	}
+	want := [][2]int64{{0, 4096}}
+	if !equalExtents(extentSet(got), want) {
+		t.Errorf("exact match: got %v, want %v", extentSet(got), want)
+	}
+	// Entry.Name should round-trip to (Offset, Length).
+	if got[0].Name != XAttrName(0, 4096) {
+		t.Errorf("Entry.Name=%q, want %q", got[0].Name, XAttrName(0, 4096))
+	}
+}
+
+func TestOverlappingStrictSubset(t *testing.T) {
+	s := makeTempStore(t)
+	putEntries(t, s, [2]int64{0, 4096})
+	// Query strictly inside the stored block.
+	got, err := s.Overlapping(1024, 1024)
+	if err != nil {
+		t.Fatalf("Overlapping: %v", err)
+	}
+	want := [][2]int64{{0, 4096}}
+	if !equalExtents(extentSet(got), want) {
+		t.Errorf("strict subset: got %v, want %v", extentSet(got), want)
+	}
+}
+
+func TestOverlappingStrictSuperset(t *testing.T) {
+	s := makeTempStore(t)
+	putEntries(t, s, [2]int64{1024, 1024})
+	// Query strictly contains the stored block.
+	got, err := s.Overlapping(0, 4096)
+	if err != nil {
+		t.Fatalf("Overlapping: %v", err)
+	}
+	want := [][2]int64{{1024, 1024}}
+	if !equalExtents(extentSet(got), want) {
+		t.Errorf("strict superset: got %v, want %v", extentSet(got), want)
+	}
+}
+
+func TestOverlappingPartialStart(t *testing.T) {
+	s := makeTempStore(t)
+	putEntries(t, s, [2]int64{1024, 2048}) // [1024, 3072)
+	// Query [0, 1500) overlaps the start of the stored block.
+	got, err := s.Overlapping(0, 1500)
+	if err != nil {
+		t.Fatalf("Overlapping: %v", err)
+	}
+	want := [][2]int64{{1024, 2048}}
+	if !equalExtents(extentSet(got), want) {
+		t.Errorf("partial start: got %v, want %v", extentSet(got), want)
+	}
+}
+
+func TestOverlappingPartialEnd(t *testing.T) {
+	s := makeTempStore(t)
+	putEntries(t, s, [2]int64{1024, 2048}) // [1024, 3072)
+	// Query [2048, 4096) overlaps the tail of the stored block.
+	got, err := s.Overlapping(2048, 2048)
+	if err != nil {
+		t.Fatalf("Overlapping: %v", err)
+	}
+	want := [][2]int64{{1024, 2048}}
+	if !equalExtents(extentSet(got), want) {
+		t.Errorf("partial end: got %v, want %v", extentSet(got), want)
+	}
+}
+
+func TestOverlappingAdjacentNoOverlap(t *testing.T) {
+	s := makeTempStore(t)
+	putEntries(t, s, [2]int64{1024, 1024}) // [1024, 2048)
+	// Query starts exactly where the stored record ends -- no shared byte.
+	got, err := s.Overlapping(2048, 1024)
+	if err != nil {
+		t.Fatalf("Overlapping: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("adjacent ranges should not overlap; got %v", extentSet(got))
+	}
+	// And the symmetric case (query ends where stored record starts).
+	got, err = s.Overlapping(0, 1024)
+	if err != nil {
+		t.Fatalf("Overlapping: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("adjacent ranges (symmetric) should not overlap; got %v", extentSet(got))
+	}
+}
+
+func TestOverlappingMultiple(t *testing.T) {
+	s := makeTempStore(t)
+	putEntries(t, s,
+		[2]int64{0, 1024},    // [0, 1024)     - overlaps query at [512,1024)
+		[2]int64{1024, 1024}, // [1024, 2048)  - entirely inside query
+		[2]int64{2048, 1024}, // [2048, 3072)  - adjacent, NOT overlapping
+	)
+	got, err := s.Overlapping(512, 1536) // [512, 2048)
+	if err != nil {
+		t.Fatalf("Overlapping: %v", err)
+	}
+	want := [][2]int64{{0, 1024}, {1024, 1024}}
+	if !equalExtents(extentSet(got), want) {
+		t.Errorf("multiple overlap: got %v, want %v", extentSet(got), want)
+	}
+}
+
+func TestOverlappingIgnoresUnrelatedEntries(t *testing.T) {
+	s := makeTempStore(t)
+	putEntries(t, s,
+		[2]int64{0, 1024},
+		[2]int64{8192, 1024},
+	)
+	got, err := s.Overlapping(0, 2048)
+	if err != nil {
+		t.Fatalf("Overlapping: %v", err)
+	}
+	want := [][2]int64{{0, 1024}}
+	if !equalExtents(extentSet(got), want) {
+		t.Errorf("unrelated entry leaked into result: got %v, want %v",
+			extentSet(got), want)
+	}
+}
+
+func TestOverlappingIgnoresNonIotestXattrs(t *testing.T) {
+	s := makeTempStore(t)
+	if err := xattr.Set(s.Target(), "user.something_else", []byte("hi"), 0); err != nil {
+		t.Fatalf("seed unrelated xattr: %v", err)
+	}
+	putEntries(t, s, [2]int64{0, 1024})
+	got, err := s.Overlapping(0, 2048)
+	if err != nil {
+		t.Fatalf("Overlapping: %v", err)
+	}
+	want := [][2]int64{{0, 1024}}
+	if !equalExtents(extentSet(got), want) {
+		t.Errorf("non-verifyio xattr leaked: got %v, want %v", extentSet(got), want)
+	}
+}
+
+func TestOverlappingBadLength(t *testing.T) {
+	s := makeTempStore(t)
+	if _, err := s.Overlapping(0, 0); err == nil {
+		t.Errorf("Overlapping(_, 0): expected error")
+	}
+	if _, err := s.Overlapping(0, -1); err == nil {
+		t.Errorf("Overlapping(_, -1): expected error")
+	}
+}
+
+// --- ReplaceRange ----------------------------------------------------------
+
+// listExtents returns every verifyio entry on the store, sorted, as
+// (offset, length) pairs. Used by ReplaceRange tests to assert exact
+// post-state.
+func listExtents(t *testing.T, s *Store) [][2]int64 {
+	t.Helper()
+	var got [][2]int64
+	err := s.ForEachEntry(func(off, length int64, _ []byte) error {
+		got = append(got, [2]int64{off, length})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachEntry: %v", err)
+	}
+	sort.Slice(got, func(i, j int) bool {
+		if got[i][0] != got[j][0] {
+			return got[i][0] < got[j][0]
+		}
+		return got[i][1] < got[j][1]
+	})
+	return got
+}
+
+func TestReplaceRangeNoOverlap(t *testing.T) {
+	s := makeTempStore(t)
+	putEntries(t, s, [2]int64{0, 1024})
+	newHdr := makeHeader(t, 2048, 0xbeef)
+	if err := s.ReplaceRange(2048, 1024, newHdr); err != nil {
+		t.Fatalf("ReplaceRange: %v", err)
+	}
+	want := [][2]int64{{0, 1024}, {2048, 1024}}
+	if !equalExtents(listExtents(t, s), want) {
+		t.Errorf("no-overlap: got %v, want %v", listExtents(t, s), want)
+	}
+	// New header is readable.
+	got, err := s.Get(2048, 1024)
+	if err != nil {
+		t.Fatalf("Get after ReplaceRange: %v", err)
+	}
+	if !bytes.Equal(got, newHdr) {
+		t.Errorf("Get returned different bytes than ReplaceRange wrote")
+	}
+}
+
+func TestReplaceRangeFullOverlapExactMatch(t *testing.T) {
+	s := makeTempStore(t)
+	putEntries(t, s, [2]int64{0, 4096})
+	newHdr := makeHeader(t, 0, 0xc0de)
+	if err := s.ReplaceRange(0, 4096, newHdr); err != nil {
+		t.Fatalf("ReplaceRange: %v", err)
+	}
+	want := [][2]int64{{0, 4096}}
+	if !equalExtents(listExtents(t, s), want) {
+		t.Errorf("exact-match overwrite: got %v, want %v", listExtents(t, s), want)
+	}
+	got, err := s.Get(0, 4096)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, newHdr) {
+		t.Errorf("exact-match overwrite did not replace header bytes")
+	}
+}
+
+func TestReplaceRangePartialOverlapShreds(t *testing.T) {
+	// Existing record covers [0, 4096); new range covers only the
+	// second half [2048, 4096). Replace-and-shred: the old record is
+	// removed entirely, not split. The first half [0, 2048) becomes
+	// uncovered (caller's responsibility to zero on the data side).
+	s := makeTempStore(t)
+	putEntries(t, s, [2]int64{0, 4096})
+	newHdr := makeHeader(t, 2048, 1)
+	if err := s.ReplaceRange(2048, 2048, newHdr); err != nil {
+		t.Fatalf("ReplaceRange: %v", err)
+	}
+	want := [][2]int64{{2048, 2048}}
+	if !equalExtents(listExtents(t, s), want) {
+		t.Errorf("partial overlap should shred old entry; got %v, want %v",
+			listExtents(t, s), want)
+	}
+	if _, err := s.Get(0, 4096); !errors.Is(err, ErrNotFound) {
+		t.Errorf("old (0,4096) entry should be gone; got err=%v", err)
+	}
+}
+
+func TestReplaceRangeMultipleOverlapsCollapse(t *testing.T) {
+	s := makeTempStore(t)
+	putEntries(t, s,
+		[2]int64{0, 1024},    // overlaps new range at [512, 1024)
+		[2]int64{1024, 1024}, // entirely inside new range
+		[2]int64{2048, 1024}, // adjacent, NOT overlapping -> untouched
+	)
+	newHdr := makeHeader(t, 512, 7)
+	if err := s.ReplaceRange(512, 1536, newHdr); err != nil { // [512, 2048)
+		t.Fatalf("ReplaceRange: %v", err)
+	}
+	want := [][2]int64{{512, 1536}, {2048, 1024}}
+	if !equalExtents(listExtents(t, s), want) {
+		t.Errorf("multi-overlap collapse: got %v, want %v",
+			listExtents(t, s), want)
+	}
+	// Untouched neighbor still has its original header.
+	got, err := s.Get(2048, 1024)
+	if err != nil {
+		t.Fatalf("Get(2048,1024): %v", err)
+	}
+	wantHdr := makeHeader(t, 2048, 2048)
+	if !bytes.Equal(got, wantHdr) {
+		t.Errorf("untouched neighbor's header changed")
+	}
+}
+
+func TestReplaceRangeBadInputs(t *testing.T) {
+	s := makeTempStore(t)
+	if err := s.ReplaceRange(0, 1024, []byte{1, 2, 3}); err == nil {
+		t.Errorf("ReplaceRange wrong-size header: expected error")
+	}
+	if err := s.ReplaceRange(0, 0, makeHeader(t, 0, 0)); err == nil {
+		t.Errorf("ReplaceRange length=0: expected error")
+	}
+	if err := s.ReplaceRange(0, -1, makeHeader(t, 0, 0)); err == nil {
+		t.Errorf("ReplaceRange length=-1: expected error")
+	}
+}
+
+// --- existing helpers below -----------------------------------------------
+
+func TestXAttrNameRoundTrip(t *testing.T) {
+	cases := []struct{ off, length int64 }{
+		{0, 1},
+		{1, 1024},
+		{0x1000, 4096},
+		{1<<32 - 1, 8192},
+		{1 << 50, 1024},
+	}
+	for _, c := range cases {
+		name := XAttrName(c.off, c.length)
+		gotOff, gotLen, ok := parseXAttrName(name)
+		if !ok {
+			t.Errorf("parseXAttrName(%q) ok=false", name)
+			continue
+		}
+		if gotOff != c.off || gotLen != c.length {
+			t.Errorf("round-trip (%d,%d): got (%d,%d)", c.off, c.length, gotOff, gotLen)
+		}
+	}
+	if _, _, ok := parseXAttrName("user.verifyio.123"); ok {
+		t.Errorf("name without -length should not parse")
+	}
+	if _, _, ok := parseXAttrName("user.verifyio.notanint-1024"); ok {
+		t.Errorf("non-numeric offset should not parse")
+	}
+	if _, _, ok := parseXAttrName("user.verifyio.123-notanint"); ok {
+		t.Errorf("non-numeric length should not parse")
+	}
+	if _, _, ok := parseXAttrName("user.other.123-456"); ok {
+		t.Errorf("non-verifyio prefix should not parse")
+	}
+}

--- a/verifyio/xattrstore/writer.go
+++ b/verifyio/xattrstore/writer.go
@@ -1,0 +1,198 @@
+package xattrstore
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/thinkparq/beegfs-go/verifyio/block"
+	"github.com/thinkparq/beegfs-go/verifyio/fileops"
+	"go.uber.org/zap"
+)
+
+// Writer prepares verifiable blocks and writes them to a data file,
+// keeping the xattr store in sync. A single WriteBlock call handles
+// block construction, optional range locking, xattr update, and the
+// IO operation.
+//
+// Writer is not safe for concurrent use. The intended pattern is one
+// Writer per worker goroutine, each with its own fileops.File.
+type Writer struct {
+	file      *fileops.File
+	store     *Store
+	nodeName  [16]byte
+	workerID  int32
+	kind      block.Kind
+	blockSize int // total on-disk bytes per block
+	bodyLen   int // body bytes; derived from blockSize via block.BodyLen
+	cycle     atomic.Uint64
+	buf       []byte
+	log       *zap.Logger
+}
+
+// NewWriter creates a Writer. The hostname is detected automatically.
+// blockSize is the total on-disk size per block; bodyLen is derived via
+// block.BodyLen. Not all values are valid — use a power of two (512, 1024,
+// 4096, ...). log is used for per-operation IO traces; pass nil to disable.
+func NewWriter(file *fileops.File, store *Store, workerID int, kind block.Kind, blockSize int, log *zap.Logger) (*Writer, error) {
+	if file == nil {
+		return nil, fmt.Errorf("xattrstore.NewWriter: file is nil")
+	}
+	if store == nil {
+		return nil, fmt.Errorf("xattrstore.NewWriter: store is nil")
+	}
+	bodyLen, err := block.BodyLen(blockSize)
+	if err != nil {
+		return nil, fmt.Errorf("xattrstore.NewWriter: %w", err)
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, fmt.Errorf("xattrstore.NewWriter: hostname: %w", err)
+	}
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return &Writer{
+		file:      file,
+		store:     store,
+		nodeName:  block.NodeNameFromString(hostname),
+		workerID:  int32(workerID),
+		kind:      kind,
+		blockSize: blockSize,
+		bodyLen:   bodyLen,
+		buf:       make([]byte, blockSize),
+		log:       log,
+	}, nil
+}
+
+// WriteBlock writes exactly blockSize bytes at offset using the given IOType.
+// Tag in the header is set to uint32(ioType) so dump tools can see which IO
+// method produced each block.
+//
+// If takeLock is true, an OFD range lock is acquired before writing
+// and released after. ErrLockBusy and ErrSetChanged are returned as
+// non-fatal signals — the caller should skip or move to a different
+// region rather than retrying immediately.
+//
+// The xattr is written before the data (intent-before-data ordering)
+// so a verifier can distinguish a clean write from a crashed one.
+func (w *Writer) WriteBlock(offset int64, ioType fileops.IOType, takeLock bool) error {
+	dataSize := int64(w.blockSize)
+	unlock, err := w.maybeLock(offset, dataSize, takeLock)
+	if err != nil {
+		w.log.Warn("block skipped",
+			zap.Int32("worker", w.workerID),
+			zap.Int64("offset", offset),
+			zap.String("ioType", ioType.String()),
+			zap.Error(err),
+		)
+		return err
+	}
+	defer func() { _ = unlock() }()
+
+	cycle := w.cycle.Add(1) - 1
+	seed := uint64(w.workerID)<<32 | cycle
+
+	h := block.Header{
+		NodeName: w.nodeName,
+		WorkerID: w.workerID,
+		TimeNs:   time.Now().UnixNano(),
+		Cycle:    cycle,
+		Offset:   uint64(offset),
+		Tag:      uint32(ioType),
+	}
+	if err := block.MakeBlock(w.buf, &h, w.kind, seed, w.bodyLen); err != nil {
+		return fmt.Errorf("xattrstore.Writer.WriteBlock: MakeBlock: %w", err)
+	}
+
+	// Marshal the header separately so it can be stored in the xattr.
+	var hdrBuf [block.HeaderSize]byte
+	if err := block.MarshalHeader(hdrBuf[:], &h); err != nil {
+		return fmt.Errorf("xattrstore.Writer.WriteBlock: MarshalHeader: %w", err)
+	}
+	written := hdrBuf[:]
+
+	// Intent-before-data: write the xattr header before the data block, and do
+	// NOT reorder these. If the data Write below fails, the xattr intent is left
+	// on disk with no matching data — this is deliberate. A verifier can flag and
+	// recover from an xattr without data; the inverse (data with no xattr claim)
+	// would be unrecoverable, so we never allow it.
+	if err := w.store.Put(offset, dataSize, written); err != nil {
+		return fmt.Errorf("xattrstore.Writer.WriteBlock: store.Put: %w", err)
+	}
+	if err := w.file.Write(ioType, w.buf, offset); err != nil {
+		return fmt.Errorf("xattrstore.Writer.WriteBlock: file.Write: %w", err)
+	}
+
+	// BeeGFS does not provide cross-node page-cache coherence: a buffered
+	// write stays in this node's page cache until the OS writes it back
+	// asynchronously. Without an explicit flush, a reader on another node
+	// can acquire the lock after we release it and still see stale data from
+	// the storage servers, while the updated xattr is already visible (xattrs
+	// go through the metadata path, not the data-path cache). Syncing while
+	// the lock is still held ensures data reaches the storage servers before
+	// any remote reader can acquire the lock and observe an inconsistency.
+	if takeLock {
+		if err := w.file.Sync(); err != nil {
+			return fmt.Errorf("xattrstore.Writer.WriteBlock: sync: %w", err)
+		}
+		// Data has reached the storage servers. Stamp TagFsynced in the xattr
+		// so a verifier can distinguish a coherence failure from a missing flush.
+		// Re-marshal and re-put while the lock is still held so readers always
+		// see a consistent (fsynced=true ↔ data on storage) state.
+		h.Tag |= block.TagFsynced
+		if err := block.MarshalHeader(hdrBuf[:], &h); err != nil {
+			return fmt.Errorf("xattrstore.Writer.WriteBlock: re-marshal after sync: %w", err)
+		}
+		if err := w.store.Put(offset, dataSize, written); err != nil {
+			return fmt.Errorf("xattrstore.Writer.WriteBlock: xattr update after sync: %w", err)
+		}
+	}
+
+	// While the locks are still held, read back the xattr and verify it
+	// matches what we wrote. A mismatch means another writer modified this
+	// range while we held the lock — the filesystem's distributed locking
+	// did not provide the expected exclusivity.
+	if takeLock {
+		readBack, err := w.store.Get(offset, dataSize)
+		if err != nil {
+			return fmt.Errorf("xattrstore.Writer.WriteBlock: read-back: %w", err)
+		}
+		if !bytes.Equal(readBack, written) {
+			formatHeader := func(label string, raw []byte) string {
+				h, err := block.UnmarshalHeader(raw)
+				if err != nil {
+					return fmt.Sprintf("  %s: <unparseable: %v>", label, err)
+				}
+				return fmt.Sprintf("  %s: %s", label, h)
+			}
+			fmt.Fprintf(os.Stderr, "lock violation at offset=%d dataSize=%d:\n%s\n%s\n",
+				offset, dataSize,
+				formatHeader("wrote   ", written),
+				formatHeader("read back", readBack),
+			)
+			return ErrLockViolation
+		}
+	}
+
+	w.log.Debug("wrote block",
+		zap.Int32("worker", w.workerID),
+		zap.Int64("offset", offset),
+		zap.Uint64("cycle", cycle),
+		zap.String("ioType", ioType.String()),
+		zap.Int("size", w.blockSize),
+	)
+	return nil
+}
+
+// maybeLock acquires a range lock when takeLock is true. Always
+// returns an unlock function that must be called; when takeLock is
+// false the function is a no-op.
+func (w *Writer) maybeLock(offset, length int64, takeLock bool) (func() error, error) {
+	if !takeLock {
+		return func() error { return nil }, nil
+	}
+	return w.lockRegion(offset, length)
+}

--- a/verifyio/xattrstore/writer_lock_linux.go
+++ b/verifyio/xattrstore/writer_lock_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package xattrstore
+
+// lockRegion acquires an OFD range lock over [offset, offset+length)
+// and returns a function that releases it.
+func (w *Writer) lockRegion(offset, length int64) (func() error, error) {
+	lease, err := w.store.TryAcquireExclusive(w.file.LockFd(), offset, length)
+	if err != nil {
+		return func() error { return nil }, err
+	}
+	return lease.Release, nil
+}

--- a/verifyio/xattrstore/writer_lock_other.go
+++ b/verifyio/xattrstore/writer_lock_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package xattrstore
+
+import "errors"
+
+// lockRegion is a stub on non-Linux platforms where OFD locks are not
+// available.
+func (w *Writer) lockRegion(offset, length int64) (func() error, error) {
+	return func() error { return nil }, errors.New("xattrstore: OFD locking not supported on this platform")
+}


### PR DESCRIPTION
### What does this PR do / why do we need it?

Adds `beegfs iotest`, a tool for driving IO workloads built into beegfs.
It has 3 components:

1. `verifyio`, a Go library to drive POSIX IO.
2. Client-side IO testing tools using the verifyio library. These tools
   are relatively simple and more about demonstrating functionality than being final products.
3. A framework to drive multi-node IO using those client-side tools.

The goal of this is to drive IO in a customer-like manner: requests flow
from the client module → network → storage.

The verifyio library is intended to support both benchmark mode (where
we just write the data as quickly as possible) and a verification mode,
where we place xattrs with checksums alongside the file to allow for data
verification. The written data also includes checksums to allow the
detection of bit rot.

For the tooling, there are currently two modes:

- **Standalone probes** (`smoke`, `verify`, `dump`): quick, single-node
  checks: write+verify a sanity check in one shot, verify existing data
  files, or dump a file's block headers for inspection.

- **Framework-managed multi-node workloads** (`bench`, `soak`, `inval`):
  SSH fan-out across nodes, shared-path status files, and a
  start/status/stop/cleanup lifecycle. `bench` measures bandwidth,
  `soak` is a long-running write/re-write stress test that surfaces
  silent corruption and torn writes under sustained load, and `inval`
  measures cross-node metadata cache-invalidation latency.

### Related Issue(s)

This is the beginning of work toward #324

### Where should the reviewer(s) start reviewing this?

Begin with the verifyio library (the first commit). This covers the
block format, xattr store, locking, and the verification code.

Then the various consumers of the library, and finally the interface
into the beegfs CLI.

### What are the next steps after this PR?

There are a lot of improvements planned for all of these features long
term. This is intended to be the initial commit for a lot of additional
work — a starting point, not a finishing point.

The next steps planned for the verifyio library include: mmap support,
various directory stress/verification mechanisms,
non-fcntl inter-node locking, and more programs for cache-coherence testing. 
Then, adding consumer test programs for those features.

### Checklist before merging:

- [x] Documentation:
  - [x] Does developer documentation (code comments, readme, etc.) need
        to be added or updated? — documentation for the CLI is in
        `ctl/internal/cmd/iotest/DESIGN.md`, and for the verifyio library
        in `verifyio/README.md`.
  - [ ] Does the user documentation need to be expanded or updated for
        this change?
- [x] Testing:
  - [x] Does this functionality require changing or adding new unit
        tests? — this includes unit tests for the verifyio library; no
        additional unit tests required for this PR.
  - [x] Does this functionality require changing or adding new
        integration tests? — no.
- [x] Git Hygiene:
  - [x] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [x] Is the commit history squashed down reasonably?
