### PR TITLE
fix(build): bump go directive to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thinkparq/beegfs-go
 
-go 1.26.4
+go 1.26.5
 
 tool (
 	github.com/google/go-licenses/v2


### PR DESCRIPTION
govulncheck flags crypto/tls@go1.26.4 as vulnerable under GO-2026-5856 (Encrypted Client Hello privacy leak, fixed in go1.26.5), reachable via several call paths (test-subscriber, filesystem.CopyContentsToFile, xattrstore.Writer.WriteBlock, rst.S3Client.IsWorkRequestReady). Bumping the go directive resolves it with no code changes.

### What does this PR do / why do we need it?
Pushes are failing due to a go vulnerability in 1.26.4



### Checklist before merging:
*Required for all PRs.*

When creating a PR these are items to keep in mind that cannot be checked by GitHub actions:

- [ ] Documentation:
  - [ ] Does developer documentation (code comments, readme, etc.) need to be added or updated?
  - [ ] Does the user documentation need to be expanded or updated for this change?
- [ ] Testing:
  - [ ] Does this functionality require changing or adding new unit tests?
  - [ ] Does this functionality require changing or adding new integration tests?
- [ ] Git Hygiene: 
  - [ ] Do commits adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)?
  - [ ] Is the commit history squashed down reasonably?
