### PR TITLE
fix(copy): Remove some redundant text in the beegfs copy usage message

### DIFF
--- a/ctl/internal/cmd/copy/copy.go
+++ b/ctl/internal/cmd/copy/copy.go
@@ -193,6 +193,11 @@ destination have different modification times.`,
 	}
 
 	bflagSet = bflag.NewFlagSet(copyFlags, cmd)
+	// "0" suppresses pflag's auto "(default N)" usage suffix (see
+	// Flag.defaultIsZeroValue in spf13/pflag) -- the real default (128/1024)
+	// is already stated in each flag's description text above.
+	cmd.Flags().Lookup("chunksize").DefValue = "0"
+	cmd.Flags().Lookup("partition-threshold").DefValue = "0"
 	cmd.Flags().StringVar(&frontendCfg.stdinDelimiter, "stdin-delimiter", "\\n", `Change the string delimiter used to determine individual paths when read from stdin.
 For example use --stdin-delimiter=\"\\x00\" for NULL.`)
 	cmd.Flags().IntVar(&frontendCfg.batchSize, "stdin-batch", 1024, "At most this many paths will be read from stdin before triggering the parallel copy. Setting to higher values will consume more memory.")


### PR DESCRIPTION
### What does this PR do / why do we need it?
`beegfs copy --help` showed the default value for `--chunksize` and `--partition-threshold` twice: once in the flag's own description text, once via pflag's auto-generated `(default N)` suffix. Suppresses the redundant suffix by setting each flag's `DefValue` to `"0"`, which trips pflag's existing `defaultIsZeroValue()` check (see `spf13/pflag`'s `flag.go`) that skips printing `(default N)` when the default is the type's zero value. The actual bound default (128MB / 1024MB) is unaffected -- `DefValue` is a display-only string, separate from the flag's real value.

Follows the same pattern already used in `ctl/internal/cmd/rst/pushpull.go` for `PriorityFlag`.

Verified: built and ran `beegfs copy --help` -- output now shows only the explicit "Default chunk size: 128 MB." text, no more duplicate `(default 128)`. Confirmed via `gofmt` and `go build`/`go vet` (GOOS=linux) that nothing else broke.

### Related Issue(s)
https://github.com/ThinkParQ/beegfs-go/issues/323

### Where should the reviewer(s) start reviewing this?
Single 5-line change in `ctl/internal/cmd/copy/copy.go`.

### Are there any specific topics we should discuss before merging?
Not required.

### What are the next steps after this PR?
Not required.

### Checklist before merging:
- [x] Documentation: no developer or user documentation changes needed beyond the usage message itself (which this PR fixes).
- [x] Testing: cosmetic help-text change; no new tests needed.
- [x] Git Hygiene: single commit, Conventional Commits format.
